### PR TITLE
Fix link problems with clang3.5

### DIFF
--- a/CppImport/CppImport.pro
+++ b/CppImport/CppImport.pro
@@ -31,7 +31,6 @@ LIBS += -lclangTooling\
 				-lclangAnalysis\
 				-lclangARCMigrate\
 				-lclangRewriteFrontend\
-				-lclangRewriteCore\
 				-lclangEdit\
 				-lclangAST\
 				-lclangLex\


### PR DESCRIPTION
clangRewriteCore is no longer around thus linking fails with clang3.5.

Could you please test clang3.4 compatibility with this change?
I don't think this was ever needed thus shouldn't trigger problems.
