### PR TITLE
Fix compile problems with clang3.5

### DIFF
--- a/CppImport/src/CppImportUtilities.cpp
+++ b/CppImport/src/CppImportUtilities.cpp
@@ -570,9 +570,19 @@ OOModel::Expression* CppImportUtilities::translateTypePtr(const clang::Type* typ
 	{
 		// TODO: include templates. (and more?)
 		OOModel::FunctionTypeExpression* ooFunctionType = new OOModel::FunctionTypeExpression();
+#if ((CLANG_VERSION_MAJOR >= 3) && (CLANG_VERSION_MINOR >= 5))
+		ooFunctionType->results()->append(translateQualifiedType(functionProtoType->getReturnType(), location));
+#else
 		ooFunctionType->results()->append(translateQualifiedType(functionProtoType->getResultType(), location));
+#endif
+
+#if ((CLANG_VERSION_MAJOR >= 3) && (CLANG_VERSION_MINOR >= 5))
+		for (auto argIt = functionProtoType->param_type_begin(); argIt != functionProtoType->param_type_end(); ++argIt)
+		{
+#else
 		for (auto argIt = functionProtoType->arg_type_begin(); argIt != functionProtoType->arg_type_end(); ++argIt)
 		{
+#endif
 			ooFunctionType->arguments()->append(translateQualifiedType(*argIt, location));
 		}
 		translatedType = ooFunctionType;

--- a/CppImport/src/CppImportUtilities.cpp
+++ b/CppImport/src/CppImportUtilities.cpp
@@ -570,19 +570,10 @@ OOModel::Expression* CppImportUtilities::translateTypePtr(const clang::Type* typ
 	{
 		// TODO: include templates. (and more?)
 		OOModel::FunctionTypeExpression* ooFunctionType = new OOModel::FunctionTypeExpression();
-#if ((CLANG_VERSION_MAJOR >= 3) && (CLANG_VERSION_MINOR >= 5))
 		ooFunctionType->results()->append(translateQualifiedType(functionProtoType->getReturnType(), location));
-#else
-		ooFunctionType->results()->append(translateQualifiedType(functionProtoType->getResultType(), location));
-#endif
 
-#if ((CLANG_VERSION_MAJOR >= 3) && (CLANG_VERSION_MINOR >= 5))
 		for (auto argIt = functionProtoType->param_type_begin(); argIt != functionProtoType->param_type_end(); ++argIt)
 		{
-#else
-		for (auto argIt = functionProtoType->arg_type_begin(); argIt != functionProtoType->arg_type_end(); ++argIt)
-		{
-#endif
 			ooFunctionType->arguments()->append(translateQualifiedType(*argIt, location));
 		}
 		translatedType = ooFunctionType;

--- a/CppImport/src/manager/NodeHasher.cpp
+++ b/CppImport/src/manager/NodeHasher.cpp
@@ -37,11 +37,7 @@ void NodeHasher::setSourceManager(const clang::SourceManager* sourceManager)
 const QString NodeHasher::hashFunction(const clang::FunctionDecl* functionDecl)
 {
 	QString hash = QString::fromStdString(functionDecl->getNameAsString());
-#if ((CLANG_VERSION_MAJOR >= 3) && (CLANG_VERSION_MINOR >= 5))
 	hash.prepend(QString::fromStdString(functionDecl->getReturnType().getAsString()).append("_"));
-#else
-	hash.prepend(QString::fromStdString(functionDecl->getResultType().getAsString()).append("_"));
-#endif
 	hash.append("_").append(functionDecl->getNumParams());
 
 	for (unsigned i = 0; i < functionDecl->param_size(); i++)
@@ -54,11 +50,7 @@ const QString NodeHasher::hashFunction(const clang::FunctionDecl* functionDecl)
 const QString NodeHasher::hashMethod(const clang::CXXMethodDecl* methodDecl)
 {
 	QString hash = QString::fromStdString(methodDecl->getNameAsString());
-#if ((CLANG_VERSION_MAJOR >= 3) && (CLANG_VERSION_MINOR >= 5))
 	hash.prepend(QString::fromStdString(methodDecl->getReturnType().getCanonicalType().getAsString()).append("_"));
-#else
-	hash.prepend(QString::fromStdString(methodDecl->getResultType().getCanonicalType().getAsString()).append("_"));
-#endif
 	hash.append("_").append(hashRecord(methodDecl->getParent()));
 	hash.append("_").append(methodDecl->getNumParams());
 

--- a/CppImport/src/manager/NodeHasher.cpp
+++ b/CppImport/src/manager/NodeHasher.cpp
@@ -37,7 +37,11 @@ void NodeHasher::setSourceManager(const clang::SourceManager* sourceManager)
 const QString NodeHasher::hashFunction(const clang::FunctionDecl* functionDecl)
 {
 	QString hash = QString::fromStdString(functionDecl->getNameAsString());
+#if ((CLANG_VERSION_MAJOR >= 3) && (CLANG_VERSION_MINOR >= 5))
+	hash.prepend(QString::fromStdString(functionDecl->getReturnType().getAsString()).append("_"));
+#else
 	hash.prepend(QString::fromStdString(functionDecl->getResultType().getAsString()).append("_"));
+#endif
 	hash.append("_").append(functionDecl->getNumParams());
 
 	for (unsigned i = 0; i < functionDecl->param_size(); i++)
@@ -50,7 +54,11 @@ const QString NodeHasher::hashFunction(const clang::FunctionDecl* functionDecl)
 const QString NodeHasher::hashMethod(const clang::CXXMethodDecl* methodDecl)
 {
 	QString hash = QString::fromStdString(methodDecl->getNameAsString());
+#if ((CLANG_VERSION_MAJOR >= 3) && (CLANG_VERSION_MINOR >= 5))
+	hash.prepend(QString::fromStdString(methodDecl->getReturnType().getCanonicalType().getAsString()).append("_"));
+#else
 	hash.prepend(QString::fromStdString(methodDecl->getResultType().getCanonicalType().getAsString()).append("_"));
+#endif
 	hash.append("_").append(hashRecord(methodDecl->getParent()));
 	hash.append("_").append(methodDecl->getNumParams());
 

--- a/CppImport/src/manager/TranslateManager.cpp
+++ b/CppImport/src/manager/TranslateManager.cpp
@@ -287,11 +287,7 @@ OOModel::Method* TranslateManager::addNewMethod(clang::CXXMethodDecl* mDecl, OOM
 	if (!llvm::isa<clang::CXXConstructorDecl>(mDecl) && !llvm::isa<clang::CXXDestructorDecl>(mDecl))
 	{
 		// process result type
-#if ((CLANG_VERSION_MAJOR >= 3) && (CLANG_VERSION_MINOR >= 5))
 		OOModel::Expression* restype = utils_->translateQualifiedType(mDecl->getReturnType(), mDecl->getLocStart());
-#else
-		OOModel::Expression* restype = utils_->translateQualifiedType(mDecl->getResultType(), mDecl->getLocStart());
-#endif
 		if (restype)
 		{
 			OOModel::FormalResult* methodResult = new OOModel::FormalResult();
@@ -329,14 +325,8 @@ OOModel::Method* TranslateManager::addNewFunction(clang::FunctionDecl* functionD
 	OOModel::Method* ooFunction= new OOModel::Method();
 	ooFunction->setName(QString::fromStdString(functionDecl->getNameAsString()));
 	// process result type
-
-#if ((CLANG_VERSION_MAJOR >= 3) && (CLANG_VERSION_MINOR >= 5))
 	OOModel::Expression* restype = utils_->translateQualifiedType(functionDecl->getReturnType(),
 																					  functionDecl->getLocStart());
-#else
-	OOModel::Expression* restype = utils_->translateQualifiedType(functionDecl->getResultType(),
-																					  functionDecl->getLocStart());
-#endif
 	if (restype)
 	{
 		OOModel::FormalResult* methodResult = new OOModel::FormalResult();

--- a/CppImport/src/manager/TranslateManager.cpp
+++ b/CppImport/src/manager/TranslateManager.cpp
@@ -287,7 +287,11 @@ OOModel::Method* TranslateManager::addNewMethod(clang::CXXMethodDecl* mDecl, OOM
 	if (!llvm::isa<clang::CXXConstructorDecl>(mDecl) && !llvm::isa<clang::CXXDestructorDecl>(mDecl))
 	{
 		// process result type
+#if ((CLANG_VERSION_MAJOR >= 3) && (CLANG_VERSION_MINOR >= 5))
+		OOModel::Expression* restype = utils_->translateQualifiedType(mDecl->getReturnType(), mDecl->getLocStart());
+#else
 		OOModel::Expression* restype = utils_->translateQualifiedType(mDecl->getResultType(), mDecl->getLocStart());
+#endif
 		if (restype)
 		{
 			OOModel::FormalResult* methodResult = new OOModel::FormalResult();
@@ -325,8 +329,14 @@ OOModel::Method* TranslateManager::addNewFunction(clang::FunctionDecl* functionD
 	OOModel::Method* ooFunction= new OOModel::Method();
 	ooFunction->setName(QString::fromStdString(functionDecl->getNameAsString()));
 	// process result type
+
+#if ((CLANG_VERSION_MAJOR >= 3) && (CLANG_VERSION_MINOR >= 5))
+	OOModel::Expression* restype = utils_->translateQualifiedType(functionDecl->getReturnType(),
+																					  functionDecl->getLocStart());
+#else
 	OOModel::Expression* restype = utils_->translateQualifiedType(functionDecl->getResultType(),
 																					  functionDecl->getLocStart());
+#endif
 	if (restype)
 	{
 		OOModel::FormalResult* methodResult = new OOModel::FormalResult();

--- a/CppImport/src/precompiled.h
+++ b/CppImport/src/precompiled.h
@@ -87,6 +87,7 @@
 #include <clang/Basic/LangOptions.h>
 #include <clang/Basic/IdentifierTable.h>
 #include <clang/Basic/Builtins.h>
+#include <clang/Basic/Version.h>
 
 #include <clang/Lex/Preprocessor.h>
 #include <clang/Lex/HeaderSearch.h>

--- a/CppImport/src/precompiled.h
+++ b/CppImport/src/precompiled.h
@@ -87,7 +87,6 @@
 #include <clang/Basic/LangOptions.h>
 #include <clang/Basic/IdentifierTable.h>
 #include <clang/Basic/Builtins.h>
-#include <clang/Basic/Version.h>
 
 #include <clang/Lex/Preprocessor.h>
 #include <clang/Lex/HeaderSearch.h>


### PR DESCRIPTION
Apparently getResultType is now called getReturnType, and param is used
more consistently.
