### PR TITLE
Ignore all .directory files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 /*/Makefile
 /*/Makefile.Release
 /*/Makefile.Debug
+
+*.directory


### PR DESCRIPTION
I don't think we ever need them in Envision.

When adding a new project such a File might accidentally slip in a commit (happened to me),
annoying especially if recognized late.
