### PR TITLE
Remove unneeded libs and defines from cppimport

### DIFF
--- a/CppImport/CppImport.pro
+++ b/CppImport/CppImport.pro
@@ -14,7 +14,7 @@ win32:LIBS += -llogger \
 QMAKE_CXXFLAGS += -isystem ""$(shell llvm-config --includedir)"" # Use this instead of the line below to avoid warnings
 #INCLUDEPATH +=  /usr/lib/llvm/include
 
-DEFINES += _GNU_SOURCE __STDC_CONSTANT_MACROS __STDC_FORMAT_MACROS __STDC_LIMIT_MACROS
+DEFINES += __STDC_LIMIT_MACROS __STDC_CONSTANT_MACROS
 
 
 LIBS += -lclangTooling\
@@ -22,15 +22,9 @@ LIBS += -lclangTooling\
 				-lclangFrontend\
 				-lclangDriver\
 				-lclangSerialization\
-				-lclangCodeGen\
 				-lclangParse\
 				-lclangSema\
-				-lclangStaticAnalyzerFrontend\
-				-lclangStaticAnalyzerCheckers\
-				-lclangStaticAnalyzerCore\
-				-lclangAnalysis\
-				-lclangARCMigrate\
-				-lclangRewriteFrontend\
+				-lclangAnalysis \
 				-lclangEdit\
 				-lclangAST\
 				-lclangLex\


### PR DESCRIPTION
This hopefully improves compile/link time

NOTE: Only tested against clang3.5, hopefully works in 3.4 as well
