### PR TITLE
Make it possible to enter quoted arguments in commands

### DIFF
--- a/InteractionBase/src/commands/CommandExecutionEngine.cpp
+++ b/InteractionBase/src/commands/CommandExecutionEngine.cpp
@@ -251,6 +251,7 @@ QStringList CommandExecutionEngine::tokenize(const QString& string, const QStrin
 				quote = QChar();
 				str = QString();
 			}
+			else str.append(string[i]);
 		}
 	}
 


### PR DESCRIPTION
I think this should be allowed and might be helpful for scripting.

Or is there a particular reason why quoted strings were just ignored?
