### PR TITLE
Fix clang warnings in the project

### DIFF
--- a/Comments/src/items/VCommentDiagramShape.h
+++ b/Comments/src/items/VCommentDiagramShape.h
@@ -55,7 +55,7 @@ class COMMENTS_API VCommentDiagramShape
 	protected:
 		virtual void determineChildren() override;
 		virtual void updateGeometry(int availableWidth, int availableHeight) override;
-		void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+		void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 	private:
 

--- a/Comments/src/items/VCommentFreeNode.h
+++ b/Comments/src/items/VCommentFreeNode.h
@@ -50,7 +50,7 @@ class COMMENTS_API VCommentFreeNode : public Super<Visualization::ItemWithNode<V
 
 	protected:
 		virtual void determineChildren() override;
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::Item* content_{};

--- a/Comments/src/items/VCommentTable.h
+++ b/Comments/src/items/VCommentTable.h
@@ -52,7 +52,7 @@ class COMMENTS_API VCommentTable : public Super<Visualization::ItemWithNode<VCom
 
 	protected:
 		virtual void determineChildren() override;
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		QVector< QVector<Visualization::Item*> > items_;

--- a/Comments/src/items/VCommentText.h
+++ b/Comments/src/items/VCommentText.h
@@ -46,12 +46,12 @@ class COMMENTS_API VCommentText :
 
 	public:
 		VCommentText(Item* parent, NodeType* node, const StyleType* style = itemStyles().get());
-		virtual bool setText(const QString& newText);
+		virtual bool setText(const QString& newText) override;
 
 		virtual bool moveCursor(CursorMoveDirection dir = MoveDefault, QPoint reference = QPoint()) override;
 
 	protected:
-		virtual QString currentText();
+		virtual QString currentText() override;
 };
 
 }

--- a/ControlFlowVisualization/src/items/ControlFlowItem.h
+++ b/ControlFlowVisualization/src/items/ControlFlowItem.h
@@ -49,7 +49,7 @@ class ControlFlowItem : public Super<Visualization::Item>
 		void setPreferredContinueExit(PreferedExitDirection preference);
 		void setPreferredBreakExit(PreferedExitDirection preference);
 
-		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 	protected:
 

--- a/ControlFlowVisualization/src/items/VBlockCF.h
+++ b/ControlFlowVisualization/src/items/VBlockCF.h
@@ -43,12 +43,12 @@ class CONTROLFLOWVISUALIZATION_API VBlockCF : public Super<Visualization::ItemWi
 		VBlockCF(Item* parent, NodeType* node, const StyleType* style = itemStyles().get());
 		virtual ~VBlockCF();
 
-		virtual bool sizeDependsOnParent() const;
-		virtual bool isEmpty() const;
+		virtual bool sizeDependsOnParent() const override;
+		virtual bool isEmpty() const override;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		VListCF* statements;

--- a/ControlFlowVisualization/src/items/VBreakStatementCF.h
+++ b/ControlFlowVisualization/src/items/VBreakStatementCF.h
@@ -43,8 +43,8 @@ class CONTROLFLOWVISUALIZATION_API VBreakStatementCF
 		virtual ~VBreakStatementCF();
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		OOVisualization::VBreakStatement* vis_;

--- a/ControlFlowVisualization/src/items/VContinueStatementCF.h
+++ b/ControlFlowVisualization/src/items/VContinueStatementCF.h
@@ -44,8 +44,8 @@ class CONTROLFLOWVISUALIZATION_API VContinueStatementCF
 		virtual ~VContinueStatementCF();
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		OOVisualization::VContinueStatement* vis_;

--- a/ControlFlowVisualization/src/items/VIfStatementCF.h
+++ b/ControlFlowVisualization/src/items/VIfStatementCF.h
@@ -43,12 +43,12 @@ class CONTROLFLOWVISUALIZATION_API VIfStatementCF
 		VIfStatementCF(Item* parent, NodeType* node, const StyleType* style = itemStyles().get());
 		virtual ~VIfStatementCF();
 
-		virtual bool sizeDependsOnParent() const;
-		virtual bool isEmpty() const;
+		virtual bool sizeDependsOnParent() const override;
+		virtual bool isEmpty() const override;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::SequentialLayout* conditionBackground;

--- a/ControlFlowVisualization/src/items/VListCF.h
+++ b/ControlFlowVisualization/src/items/VListCF.h
@@ -46,11 +46,11 @@ class CONTROLFLOWVISUALIZATION_API VListCF : public Super<Visualization::ItemWit
 		VListCF(Item* parent, NodeType* node, const StyleType* style = itemStyles().get());
 		virtual ~VListCF();
 
-		virtual bool isEmpty() const;
+		virtual bool isEmpty() const override;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		QVector< Visualization::Item* > items_;

--- a/ControlFlowVisualization/src/items/VLoopStatementCF.h
+++ b/ControlFlowVisualization/src/items/VLoopStatementCF.h
@@ -43,12 +43,12 @@ class CONTROLFLOWVISUALIZATION_API VLoopStatementCF
 		VLoopStatementCF(Item* parent, NodeType* node, const StyleType* style = itemStyles().get());
 		virtual ~VLoopStatementCF();
 
-		virtual bool sizeDependsOnParent() const;
-		virtual bool isEmpty() const;
+		virtual bool sizeDependsOnParent() const override;
+		virtual bool isEmpty() const override;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::SequentialLayout* conditionBackground;

--- a/ControlFlowVisualization/src/items/VReturnStatementCF.h
+++ b/ControlFlowVisualization/src/items/VReturnStatementCF.h
@@ -43,8 +43,8 @@ class CONTROLFLOWVISUALIZATION_API VReturnStatementCF
 		virtual ~VReturnStatementCF();
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		OOVisualization::VReturnStatement* vis_;

--- a/Core/src/reflect/typeIdMacros.h
+++ b/Core/src/reflect/typeIdMacros.h
@@ -27,6 +27,27 @@
 #pragma once
 
 /***********************************************************************************************************************
+ * Same as DECLARE_TYPE_ID below but for base classes that don't need the override keyword for virtual methods.
+ */
+#define DECLARE_TYPE_ID_BASE																														\
+	public:																																				\
+		virtual const QString& typeName() const;																								\
+		virtual int typeId() const;																												\
+																																							\
+		/*  Returns an ordered list of all ids in the type hierarchy of this class. */											\
+		/* The most derived id appears at the front of the list. */																		\
+		virtual QList<int> hierarchyTypeIds() const;																							\
+		virtual bool isSubtypeOf(int type) const;																								\
+		virtual bool isSubtypeOf(const QString& type) const;																				\
+																																							\
+		static const QString& typeNameStatic();																								\
+		static int typeIdStatic() { return typeId_; }																						\
+		static void initType();																														\
+																																							\
+	private:																																				\
+		static int typeId_;																															\
+
+/***********************************************************************************************************************
  * Declares standard methods for querying a classes's type statically or at run-time.
  *
  * This macro declares a static method initType which should be called during the initialization of the a plug-in where
@@ -41,14 +62,14 @@
  */
 #define DECLARE_TYPE_ID																																\
 	public:																																				\
-		virtual const QString& typeName() const;																								\
-		virtual int typeId() const;																												\
+		virtual const QString& typeName() const override;																					\
+		virtual int typeId() const override;																									\
 																																							\
 		/*  Returns an ordered list of all ids in the type hierarchy of this class. */											\
 		/* The most derived id appears at the front of the list. */																		\
-		virtual QList<int> hierarchyTypeIds() const;																							\
-		virtual bool isSubtypeOf(int type) const;																								\
-		virtual bool isSubtypeOf(const QString& type) const;																				\
+		virtual QList<int> hierarchyTypeIds() const override;																				\
+		virtual bool isSubtypeOf(int type) const override;																					\
+		virtual bool isSubtypeOf(const QString& type) const override;																	\
 																																							\
 		static const QString& typeNameStatic();																								\
 		static int typeIdStatic() { return typeId_; }																						\

--- a/Core/src/reflect/typeIdMacros.h
+++ b/Core/src/reflect/typeIdMacros.h
@@ -27,28 +27,9 @@
 #pragma once
 
 /***********************************************************************************************************************
- * Same as DECLARE_TYPE_ID below but for base classes that don't need the override keyword for virtual methods.
- */
-#define DECLARE_TYPE_ID_BASE																														\
-	public:																																				\
-		virtual const QString& typeName() const;																								\
-		virtual int typeId() const;																												\
-																																							\
-		/*  Returns an ordered list of all ids in the type hierarchy of this class. */											\
-		/* The most derived id appears at the front of the list. */																		\
-		virtual QList<int> hierarchyTypeIds() const;																							\
-		virtual bool isSubtypeOf(int type) const;																								\
-		virtual bool isSubtypeOf(const QString& type) const;																				\
-																																							\
-		static const QString& typeNameStatic();																								\
-		static int typeIdStatic() { return typeId_; }																						\
-		static void initType();																														\
-																																							\
-	private:																																				\
-		static int typeId_;																															\
-
-/***********************************************************************************************************************
  * Declares standard methods for querying a classes's type statically or at run-time.
+ *
+ * DO NOT USE DIRECTLY. Use DECLARE_TYPE_ID or DECLARE_TYPE_ID_BASE defined below
  *
  * This macro declares a static method initType which should be called during the initialization of the a plug-in where
  * the class is defined. This will assure that the new class's type is properly initialized.
@@ -60,16 +41,16 @@
  * 	DECLARE_TYPE_ID
  * 	...
  */
-#define DECLARE_TYPE_ID																																\
+#define DECLARE_TYPE_ID_COMMON(OVERRIDE)																										\
 	public:																																				\
-		virtual const QString& typeName() const override;																					\
-		virtual int typeId() const override;																									\
+		virtual const QString& typeName() const OVERRIDE;																					\
+		virtual int typeId() const OVERRIDE;																									\
 																																							\
 		/*  Returns an ordered list of all ids in the type hierarchy of this class. */											\
 		/* The most derived id appears at the front of the list. */																		\
-		virtual QList<int> hierarchyTypeIds() const override;																				\
-		virtual bool isSubtypeOf(int type) const override;																					\
-		virtual bool isSubtypeOf(const QString& type) const override;																	\
+		virtual QList<int> hierarchyTypeIds() const OVERRIDE;																				\
+		virtual bool isSubtypeOf(int type) const OVERRIDE;																					\
+		virtual bool isSubtypeOf(const QString& type) const OVERRIDE;																	\
 																																							\
 		static const QString& typeNameStatic();																								\
 		static int typeIdStatic() { return typeId_; }																						\
@@ -78,6 +59,34 @@
 	private:																																				\
 		static int typeId_;																															\
 
+/**********************************************************************************************************************/
+
+/***********************************************************************************************************************
+ * A specialized version of DECLARE_TYPE_ID_COMMON that should be used with classes which inherit from a TYPE_ID enabled
+ * class.
+ *
+ * This macro should appear as the first line after the class declaration e.g. :
+ *
+ * class MyNewNode : public ...
+ * {
+ * 	DECLARE_TYPE_ID
+ * 	...
+ */
+#define DECLARE_TYPE_ID DECLARE_TYPE_ID_COMMON(override)
+/**********************************************************************************************************************/
+
+/***********************************************************************************************************************
+ * A specialized version of DECLARE_TYPE_ID_COMMON that should be used with classes that are at the top of the
+ * hierarchy.
+ *
+ * This macro should appear as the first line after the class declaration e.g. :
+ *
+ * class MyNewNode : public ...
+ * {
+ * 	DECLARE_TYPE_ID_BASE
+ * 	...
+ */
+#define DECLARE_TYPE_ID_BASE DECLARE_TYPE_ID_COMMON()
 /**********************************************************************************************************************/
 
 /***********************************************************************************************************************

--- a/CppImport/src/CppImportUtilities.cpp
+++ b/CppImport/src/CppImportUtilities.cpp
@@ -194,7 +194,7 @@ OOModel::Expression* CppImportUtilities::translateNestedNameSpecifier
 			break;
 		default:
 			// In version 3.6 this is only NestedNameSpecifier::Super, which is a Microsoft specific extension (_super).
-			throw new CppImportException("Unsupported nested name specifier kind: " + nestedName->getKind());
+			throw new CppImportException(QString("Unsupported nested name specifier kind: %1").arg(nestedName->getKind()));
 			break;
 	}
 	if (auto prefix = nestedName->getPrefix())

--- a/CppImport/src/manager/NodeHasher.cpp
+++ b/CppImport/src/manager/NodeHasher.cpp
@@ -252,7 +252,7 @@ const QString NodeHasher::hashNestedNameSpecifier(const clang::NestedNameSpecifi
 			break;
 		default:
 			// In version 3.6 this is only NestedNameSpecifier::Super, which is a Microsoft specific extension (_super).
-			throw new CppImportException("Unsupported nested name specifier kind: " + nestedName->getKind());
+			throw new CppImportException(QString("Unsupported nested name specifier kind: %1").arg(nestedName->getKind()));
 			break;
 	}
 	if (auto p = nestedName->getPrefix())

--- a/CustomMethodCall/src/items/EmptyMethodVis.h
+++ b/CustomMethodCall/src/items/EmptyMethodVis.h
@@ -51,7 +51,7 @@ class CUSTOMMETHODCALL_API EmptyMethodVis
 		virtual ~EmptyMethodVis();
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::Static* icon_;

--- a/CustomMethodCall/src/items/FindMethodVis.h
+++ b/CustomMethodCall/src/items/FindMethodVis.h
@@ -53,7 +53,7 @@ class CUSTOMMETHODCALL_API FindMethodVis
 		virtual ~FindMethodVis();
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::Text* name_;

--- a/CustomMethodCall/src/items/InsertMethodVis.h
+++ b/CustomMethodCall/src/items/InsertMethodVis.h
@@ -52,7 +52,7 @@ class CUSTOMMETHODCALL_API InsertMethodVis
 		virtual ~InsertMethodVis();
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::Static* icon_;

--- a/CustomMethodCall/src/items/SumMethodVis.h
+++ b/CustomMethodCall/src/items/SumMethodVis.h
@@ -51,7 +51,7 @@ class CUSTOMMETHODCALL_API SumMethodVis
 		virtual ~SumMethodVis();
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::Static* name_;

--- a/FilePersistence/src/simple/GenericTree.h
+++ b/FilePersistence/src/simple/GenericTree.h
@@ -33,7 +33,7 @@ namespace FilePersistence {
 
 class GenericNode;
 class PiecewiseLoader;
-class NodeData;
+struct NodeData;
 
 class FILEPERSISTENCE_API GenericTree {
 	public:

--- a/InteractionBase/src/handlers/HRootItem.h
+++ b/InteractionBase/src/handlers/HRootItem.h
@@ -35,7 +35,7 @@ namespace Interaction {
 class INTERACTIONBASE_API HRootItem : public GenericHandler
 {
 	public:
-		virtual void keyPressEvent(Visualization::Item *target, QKeyEvent *event);
+		virtual void keyPressEvent(Visualization::Item *target, QKeyEvent *event) override;
 
 		// Mouse events for moving items around the scene
 		virtual void mousePressEvent(Visualization::Item *target, QGraphicsSceneMouseEvent *event) override;

--- a/InteractionBase/src/vis/CommandPrompt.h
+++ b/InteractionBase/src/vis/CommandPrompt.h
@@ -69,8 +69,8 @@ class INTERACTIONBASE_API CommandPrompt : public Super<Visualization::Item>
 		bool wasCancelled() const;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::Item* commandReceiver_{};

--- a/InteractionBase/src/vis/TextAndDescription.h
+++ b/InteractionBase/src/vis/TextAndDescription.h
@@ -44,12 +44,12 @@ class INTERACTIONBASE_API TextAndDescription : public Super<Visualization::Layou
 		TextAndDescription(const QString& text, const QString& description, const StyleType* style = itemStyles().get());
 		virtual ~TextAndDescription();
 
-		virtual bool sizeDependsOnParent() const;
+		virtual bool sizeDependsOnParent() const override;
 
 		void setContents(const QString& text, const QString& description);
 
 	protected:
-		virtual void determineChildren();
+		virtual void determineChildren() override;
 
 	private:
 		Visualization::Text* textVis_;

--- a/InteractionBase/src/vis/ViewSwitcherMenu.h
+++ b/InteractionBase/src/vis/ViewSwitcherMenu.h
@@ -41,9 +41,9 @@ class INTERACTIONBASE_API ViewSwitcherMenu : public Super<Menu>
 		static void show(Visualization::Item* target);
 
 	protected:
-		virtual bool executeEntry(Visualization::Item* item);
-		virtual void startFocusMode(Visualization::Item* target);
-		virtual void endFocusMode(Visualization::Item* target);
+		virtual bool executeEntry(Visualization::Item* item) override;
+		virtual void startFocusMode(Visualization::Item* target) override;
+		virtual void endFocusMode(Visualization::Item* target) override;
 
 	private:
 		static void showNow(Visualization::Item* target);

--- a/ModelBase/src/nodes/Boolean.h
+++ b/ModelBase/src/nodes/Boolean.h
@@ -45,8 +45,8 @@ class MODELBASE_API Boolean: public Super<Node>
 		bool get() const;
 		void set(const bool& newval);
 
-		virtual void save(PersistentStore &store) const;
-		virtual void load(PersistentStore &store);
+		virtual void save(PersistentStore &store) const override;
+		virtual void load(PersistentStore &store) override;
 };
 
 inline bool Boolean::get() const { return value; }

--- a/ModelBase/src/nodes/Character.h
+++ b/ModelBase/src/nodes/Character.h
@@ -45,8 +45,8 @@ class MODELBASE_API Character: public Super<Node>
 		QChar get() const;
 		void set(const QChar& newval);
 
-		virtual void save(PersistentStore &store) const;
-		virtual void load(PersistentStore &store);
+		virtual void save(PersistentStore &store) const override;
+		virtual void load(PersistentStore &store) override;
 };
 
 inline QChar Character::get() const { return value; }

--- a/ModelBase/src/nodes/Float.h
+++ b/ModelBase/src/nodes/Float.h
@@ -45,8 +45,8 @@ class MODELBASE_API Float: public Super<Node>
 		double  get() const;
 		void set(const double& newval);
 
-		virtual void save(PersistentStore &store) const;
-		virtual void load(PersistentStore &store);
+		virtual void save(PersistentStore &store) const override;
+		virtual void load(PersistentStore &store) override;
 };
 
 inline double Float::get() const { return value; }

--- a/ModelBase/src/nodes/Integer.h
+++ b/ModelBase/src/nodes/Integer.h
@@ -45,8 +45,8 @@ class MODELBASE_API Integer: public Super<Node>
 		int  get() const;
 		void set(const int& newval);
 
-		virtual void save(PersistentStore &store) const;
-		virtual void load(PersistentStore &store);
+		virtual void save(PersistentStore &store) const override;
+		virtual void load(PersistentStore &store) override;
 };
 
 inline int Integer::get() const { return integer; }

--- a/ModelBase/src/nodes/List.h
+++ b/ModelBase/src/nodes/List.h
@@ -44,8 +44,8 @@ class MODELBASE_API List: public Super<Node>
 	public:
 		virtual ~List();
 
-		virtual void save(PersistentStore &store) const;
-		virtual void load(PersistentStore &store);
+		virtual void save(PersistentStore &store) const override;
+		virtual void load(PersistentStore &store) override;
 
 		virtual QList<Node*> children() const override;
 
@@ -90,7 +90,7 @@ class MODELBASE_API List: public Super<Node>
 		virtual bool findSymbols(QSet<Node*>& result, const SymbolMatcher& matcher, const Node* source,
 				FindSymbolDirection direction, SymbolTypes symbolTypes, bool exhaustAllScopes) const override;
 
-		virtual bool replaceChild(Node* child, Node* replacement);
+		virtual bool replaceChild(Node* child, Node* replacement) override;
 
 		/**
 		 * Creates a new Node that is suitable for inserting in the list. The newly created node is not directly inserted

--- a/ModelBase/src/nodes/Node.h
+++ b/ModelBase/src/nodes/Node.h
@@ -71,7 +71,7 @@ class UsedLibrary;
  */
 class MODELBASE_API Node
 {
-	DECLARE_TYPE_ID
+	DECLARE_TYPE_ID_BASE
 	public:
 
 		/**

--- a/ModelBase/src/nodes/Reference.h
+++ b/ModelBase/src/nodes/Reference.h
@@ -47,8 +47,8 @@ class MODELBASE_API Reference: public Super<Node>
 
 		Node* target();
 
-		virtual void save(PersistentStore &store) const;
-		virtual void load(PersistentStore &store);
+		virtual void save(PersistentStore &store) const override;
+		virtual void load(PersistentStore &store) override;
 
 		bool resolve();
 		bool isResolved() const;

--- a/ModelBase/src/nodes/Text.h
+++ b/ModelBase/src/nodes/Text.h
@@ -47,8 +47,8 @@ class MODELBASE_API Text: public Super<Node>
 
 		void set(const QString &newText);
 
-		virtual void save(PersistentStore &store) const;
-		virtual void load(PersistentStore &store);
+		virtual void save(PersistentStore &store) const override;
+		virtual void load(PersistentStore &store) override;
 
 	private:
 		QString text_;

--- a/ModelBase/src/nodes/TypedList.h
+++ b/ModelBase/src/nodes/TypedList.h
@@ -40,7 +40,7 @@ class TypedList: public Super<List>
 		T* last() const;
 		T* at(int i) const;
 
-		virtual bool replaceChild(Node* child, Node* replacement);
+		virtual bool replaceChild(Node* child, Node* replacement) override;
 
 		virtual Node* createDefaultElement() override;
 

--- a/ModelBase/src/nodes/composite/CompositeNode.h
+++ b/ModelBase/src/nodes/composite/CompositeNode.h
@@ -85,7 +85,7 @@ class MODELBASE_API CompositeNode: public Super<Node>
 		CompositeIndex indexOf(const QString& nodeName) const;
 
 		virtual QList<Node*> children() const override;
-		virtual bool replaceChild(Node* child, Node* replacement);
+		virtual bool replaceChild(Node* child, Node* replacement) override;
 
 		void set(const CompositeIndex &attributeIndex, Node* node);
 
@@ -119,8 +119,8 @@ class MODELBASE_API CompositeNode: public Super<Node>
 		 */
 		Node* setDefault(QString nodeName);
 
-		virtual void save(PersistentStore &store) const;
-		virtual void load(PersistentStore &store);
+		virtual void save(PersistentStore &store) const override;
+		virtual void load(PersistentStore &store) override;
 
 		bool hasAttribute(const QString& attributeName);
 

--- a/ModelBase/src/nodes/nodeMacros.h
+++ b/ModelBase/src/nodes/nodeMacros.h
@@ -94,7 +94,7 @@
 		}																																					\
 																																							\
 	protected:																																			\
-		virtual ::Model::AttributeChain& topLevelMeta();																					\
+		virtual ::Model::AttributeChain& topLevelMeta() override;																		\
 																																							\
 	private:																																				\
 		static QList<QPair< ::Model::CompositeIndex&, ::Model::Attribute> >& attributesToRegisterAtInitialization_();	\

--- a/ModelBase/src/test_nodes/BinaryNodeAccessUnit.h
+++ b/ModelBase/src/test_nodes/BinaryNodeAccessUnit.h
@@ -43,7 +43,7 @@ class MODELBASE_API BinaryNodeAccessUnit: public Super<BinaryNode>
 		Model::NodeReadWriteLock accessLock_;
 
 	public:
-		virtual Model::NodeReadWriteLock* accessLock() const;
+		virtual Model::NodeReadWriteLock* accessLock() const override;
 };
 
 }

--- a/ModelBase/src/test_nodes/BinaryNodePersistenceUnit.h
+++ b/ModelBase/src/test_nodes/BinaryNodePersistenceUnit.h
@@ -39,7 +39,7 @@ class MODELBASE_API BinaryNodePersistenceUnit: public Super<BinaryNode>
 	COMPOSITENODE_DECLARE_STANDARD_METHODS(BinaryNodePersistenceUnit)
 
 	public:
-		virtual bool isNewPersistenceUnit() const;
+		virtual bool isNewPersistenceUnit() const override;
 };
 
 }

--- a/OODebug/src/debugger/DebugUtils.h
+++ b/OODebug/src/debugger/DebugUtils.h
@@ -49,9 +49,9 @@ namespace OOModel {
 namespace OODebug {
 
 class DebugConnector;
-class Location;
-class Value;
-class VariableDetails;
+struct Location;
+struct Value;
+struct VariableDetails;
 
 class OODEBUG_API DebugUtils
 {

--- a/OODebug/src/debugger/JavaDebugger.h
+++ b/OODebug/src/debugger/JavaDebugger.h
@@ -51,8 +51,8 @@ namespace Interaction {
 
 namespace OODebug {
 
-class BreakpointEvent;
-class SingleStepEvent;
+struct BreakpointEvent;
+struct SingleStepEvent;
 struct VariableObserver;
 
 class OODEBUG_API JavaDebugger

--- a/OODebug/src/debugger/jdwp/DebugConnector.h
+++ b/OODebug/src/debugger/jdwp/DebugConnector.h
@@ -34,16 +34,16 @@ namespace OODebug {
 
 class Command;
 
-class Event;
+struct Event;
 
-class VersionInfo;
-class Location;
-class LineTable;
-class Frames;
-class VariableTable;
-class Values;
-class StackVariable;
-class ArrayValues;
+struct VersionInfo;
+struct Location;
+struct LineTable;
+struct Frames;
+struct VariableTable;
+struct Values;
+struct StackVariable;
+struct ArrayValues;
 
 /**
  * A Connector to a Java VM via the JDWP protocol.

--- a/OOModel/src/elements/Modifier.h
+++ b/OOModel/src/elements/Modifier.h
@@ -67,8 +67,8 @@ class OOMODEL_API Modifier :  public Super<Model::Node>
 		void set(Modifiers modifiers, bool enable = true);
 		void clear();
 
-		virtual void save(Model::PersistentStore &store) const;
-		virtual void load(Model::PersistentStore &store);
+		virtual void save(Model::PersistentStore &store) const override;
+		virtual void load(Model::PersistentStore &store) override;
 
 	private:
 		Modifiers modifiers_{0};

--- a/OOModel/src/elements/OOReference.h
+++ b/OOModel/src/elements/OOReference.h
@@ -49,7 +49,7 @@ class OOMODEL_API OOReference : public Super<Model::Reference>
 
 	private:
 
-		virtual void targetChanged(Node* oldTarget);
+		virtual void targetChanged(Node* oldTarget) override;
 
 		enum class ReferenceTargetKind {Unknown, Container, Type, Callable, Assignable, Variable};
 		ReferenceTargetKind referenceTargetKind() const;

--- a/OOModel/src/expressions/ArrayInitializer.h
+++ b/OOModel/src/expressions/ArrayInitializer.h
@@ -39,7 +39,7 @@ class OOMODEL_API ArrayInitializer: public Super<Expression>
 	ATTRIBUTE(Model::TypedList<Expression>, values, setValues)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/AssignmentExpression.h
+++ b/OOModel/src/expressions/AssignmentExpression.h
@@ -52,7 +52,7 @@ class OOMODEL_API AssignmentExpression: public Super<Expression>
 		AssignmentTypes op() const;
 		void setOp(const AssignmentTypes& oper);
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 inline AssignmentExpression::AssignmentTypes AssignmentExpression::op() const

--- a/OOModel/src/expressions/BinaryOperation.h
+++ b/OOModel/src/expressions/BinaryOperation.h
@@ -52,7 +52,7 @@ class OOMODEL_API BinaryOperation: public Super<Expression>
 
 		BinaryOperation(OperatorTypes op, Expression* left = nullptr, Expression* right = nullptr);
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 inline BinaryOperation::OperatorTypes BinaryOperation::op() const { return static_cast<OperatorTypes> (opr()); }

--- a/OOModel/src/expressions/BooleanLiteral.h
+++ b/OOModel/src/expressions/BooleanLiteral.h
@@ -43,7 +43,7 @@ class OOMODEL_API BooleanLiteral: public Super<Expression>
 	public:
 		BooleanLiteral(bool value);
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 

--- a/OOModel/src/expressions/CastExpression.h
+++ b/OOModel/src/expressions/CastExpression.h
@@ -42,7 +42,7 @@ class OOMODEL_API CastExpression: public Super<Expression>
 	PRIVATE_ATTRIBUTE_VALUE(Model::Integer, cKind, setCKind, int)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 
 		enum class CastKind : int
 		{Default, ConstCast, DynamicCast, ReinterpretCast, StaticCast, FunctionalCast};

--- a/OOModel/src/expressions/CharacterLiteral.h
+++ b/OOModel/src/expressions/CharacterLiteral.h
@@ -43,7 +43,7 @@ class OOMODEL_API CharacterLiteral: public Super<Expression>
 	public:
 		CharacterLiteral(const QChar& value);
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 

--- a/OOModel/src/expressions/CommaExpression.h
+++ b/OOModel/src/expressions/CommaExpression.h
@@ -50,7 +50,7 @@ class OOMODEL_API CommaExpression: public Super<Expression>
 		 */
 		QList<Expression*> allSubOperands(bool detachOperands);
 
-		virtual Type* type();
+		virtual Type* type() override;
 		virtual bool findSymbols(QSet<Node*>& result, const Model::SymbolMatcher& matcher, const Node* source,
 				FindSymbolDirection direction, SymbolTypes symbolTypes, bool exhaustAllScopes) const override;
 

--- a/OOModel/src/expressions/ConditionalExpression.h
+++ b/OOModel/src/expressions/ConditionalExpression.h
@@ -41,7 +41,7 @@ class OOMODEL_API ConditionalExpression: public Super<Expression>
 	ATTRIBUTE(Expression, falseExpression, setFalseExpression)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 } /* namespace OOModel */

--- a/OOModel/src/expressions/EmptyExpression.h
+++ b/OOModel/src/expressions/EmptyExpression.h
@@ -37,7 +37,7 @@ class OOMODEL_API EmptyExpression : public Super<Expression>
 	COMPOSITENODE_DECLARE_STANDARD_METHODS(EmptyExpression)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 } /* namespace InteractionBase */

--- a/OOModel/src/expressions/ErrorExpression.h
+++ b/OOModel/src/expressions/ErrorExpression.h
@@ -43,7 +43,7 @@ class OOMODEL_API ErrorExpression : public Super<Expression> {
 	ATTRIBUTE_VALUE_CUSTOM_RETURN(::Model::Text, postfix, setPostfix, QString, const QString&)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 } /* namespace OOModel */

--- a/OOModel/src/expressions/FloatLiteral.h
+++ b/OOModel/src/expressions/FloatLiteral.h
@@ -43,7 +43,7 @@ class OOMODEL_API FloatLiteral: public Super<Expression>
 	public:
 		FloatLiteral(double value);
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/GlobalScopeExpression.h
+++ b/OOModel/src/expressions/GlobalScopeExpression.h
@@ -37,7 +37,7 @@ class OOMODEL_API GlobalScopeExpression : public Super<Expression>
 	COMPOSITENODE_DECLARE_STANDARD_METHODS(GlobalScopeExpression)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 } /* namespace OOModel */

--- a/OOModel/src/expressions/InstanceOfExpression.h
+++ b/OOModel/src/expressions/InstanceOfExpression.h
@@ -40,7 +40,7 @@ class OOMODEL_API InstanceOfExpression: public Super<Expression>
 	ATTRIBUTE(Expression, typeExpression, setTypeExpression)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 
 };
 

--- a/OOModel/src/expressions/IntegerLiteral.h
+++ b/OOModel/src/expressions/IntegerLiteral.h
@@ -43,7 +43,7 @@ class OOMODEL_API IntegerLiteral: public Super<Expression>
 	public:
 		IntegerLiteral(int value);
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/LambdaExpression.h
+++ b/OOModel/src/expressions/LambdaExpression.h
@@ -45,7 +45,7 @@ class OOMODEL_API LambdaExpression: public Super<Expression>
 	ATTRIBUTE(StatementItemList, body, setBody)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 } /* namespace OOModel */

--- a/OOModel/src/expressions/MethodCallExpression.h
+++ b/OOModel/src/expressions/MethodCallExpression.h
@@ -52,7 +52,7 @@ class OOMODEL_API MethodCallExpression: public Super<Expression>
 		 */
 		Method* methodDefinition();
 
-		virtual Type* type();
+		virtual Type* type() override;
 
 	private:
 		Method* methodDefinition(Type*& calleeType);

--- a/OOModel/src/expressions/NewExpression.h
+++ b/OOModel/src/expressions/NewExpression.h
@@ -44,7 +44,7 @@ class OOMODEL_API NewExpression: public Super<Expression>
 
 		NewExpression(Expression* type, Expression* firstDimension = nullptr);
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/NullLiteral.h
+++ b/OOModel/src/expressions/NullLiteral.h
@@ -37,7 +37,7 @@ class OOMODEL_API NullLiteral: public Super<Expression>
 	COMPOSITENODE_DECLARE_STANDARD_METHODS(NullLiteral)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/ReferenceExpression.h
+++ b/OOModel/src/expressions/ReferenceExpression.h
@@ -47,7 +47,7 @@ class OOMODEL_API ReferenceExpression: public Super<Expression>
 		ReferenceExpression(const QString& name, Expression* prefix = nullptr);
 
 		Model::Node* target();
-		virtual Type* type();
+		virtual Type* type() override;
 
 		void setName(const QString& name);
 		const QString& name();

--- a/OOModel/src/expressions/StringLiteral.h
+++ b/OOModel/src/expressions/StringLiteral.h
@@ -42,7 +42,7 @@ class OOMODEL_API StringLiteral: public Super<Expression>
 
 	public:
 		StringLiteral(const QString& value);
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/SuperExpression.h
+++ b/OOModel/src/expressions/SuperExpression.h
@@ -37,7 +37,7 @@ class OOMODEL_API SuperExpression: public Super<Expression>
 	COMPOSITENODE_DECLARE_STANDARD_METHODS(SuperExpression)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 } /* namespace OOModel */

--- a/OOModel/src/expressions/ThisExpression.h
+++ b/OOModel/src/expressions/ThisExpression.h
@@ -37,7 +37,7 @@ class OOMODEL_API ThisExpression: public Super<Expression>
 	COMPOSITENODE_DECLARE_STANDARD_METHODS(ThisExpression)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/TypeTraitExpression.h
+++ b/OOModel/src/expressions/TypeTraitExpression.h
@@ -49,7 +49,7 @@ class OOMODEL_API TypeTraitExpression : public Super<Expression>
 		TypeTraitKind typeTraitKind() const;
 		void setTypeTraitKind(const TypeTraitKind& kind);
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 inline TypeTraitExpression::TypeTraitKind TypeTraitExpression::typeTraitKind() const

--- a/OOModel/src/expressions/UnaryOperation.h
+++ b/OOModel/src/expressions/UnaryOperation.h
@@ -50,7 +50,7 @@ class OOMODEL_API UnaryOperation: public Super<Expression>
 		OperatorTypes op() const;
 		void setOp(const OperatorTypes& oper);
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 inline UnaryOperation::OperatorTypes UnaryOperation::op() const { return static_cast<OperatorTypes> (opr()); }

--- a/OOModel/src/expressions/UnfinishedOperator.h
+++ b/OOModel/src/expressions/UnfinishedOperator.h
@@ -42,7 +42,7 @@ class OOMODEL_API UnfinishedOperator : public Super<Expression>
 	ATTRIBUTE(Model::TypedList<Expression>, operands, setOperands)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 
 };
 

--- a/OOModel/src/expressions/VariableDeclarationExpression.h
+++ b/OOModel/src/expressions/VariableDeclarationExpression.h
@@ -53,7 +53,7 @@ class OOMODEL_API VariableDeclarationExpression: public Super<Expression>
 		virtual const QString& symbolName() const override;
 		virtual SymbolTypes symbolType() const override;
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/types/ArrayTypeExpression.h
+++ b/OOModel/src/expressions/types/ArrayTypeExpression.h
@@ -40,7 +40,7 @@ class OOMODEL_API ArrayTypeExpression : public Super<TypeExpression>
 	ATTRIBUTE(Expression, fixedSize, setFixedSize)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/types/AutoTypeExpression.h
+++ b/OOModel/src/expressions/types/AutoTypeExpression.h
@@ -37,7 +37,7 @@ class OOMODEL_API AutoTypeExpression : public Super<TypeExpression>
 	COMPOSITENODE_DECLARE_STANDARD_METHODS(AutoTypeExpression)
 
 	public:
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/types/ClassTypeExpression.h
+++ b/OOModel/src/expressions/types/ClassTypeExpression.h
@@ -42,7 +42,7 @@ class OOMODEL_API ClassTypeExpression : public Super<TypeExpression>
 
 	public:
 		ClassTypeExpression(ReferenceExpression* ref);
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/types/FunctionTypeExpression.h
+++ b/OOModel/src/expressions/types/FunctionTypeExpression.h
@@ -42,7 +42,7 @@ class OOMODEL_API FunctionTypeExpression : public Super<TypeExpression>
 	public:
 		FunctionTypeExpression(const QList<Expression*>& arguments, const QList<Expression*>& results = {});
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/types/PointerTypeExpression.h
+++ b/OOModel/src/expressions/types/PointerTypeExpression.h
@@ -40,7 +40,7 @@ class OOMODEL_API PointerTypeExpression : public Super<TypeExpression>
 
 	public:
 		PointerTypeExpression(Expression* expr);
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/types/PrimitiveTypeExpression.h
+++ b/OOModel/src/expressions/types/PrimitiveTypeExpression.h
@@ -47,7 +47,7 @@ class OOMODEL_API PrimitiveTypeExpression : public Super<TypeExpression>
 		PrimitiveTypes typeValue() const;
 		void setTypeValue(const PrimitiveTypes& type);
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 inline PrimitiveTypeExpression::PrimitiveTypes PrimitiveTypeExpression::typeValue()

--- a/OOModel/src/expressions/types/ReferenceTypeExpression.h
+++ b/OOModel/src/expressions/types/ReferenceTypeExpression.h
@@ -42,7 +42,7 @@ class OOMODEL_API ReferenceTypeExpression : public Super<TypeExpression>
 
 		ReferenceTypeExpression(Expression* ref);
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 }

--- a/OOModel/src/expressions/types/TypeQualifierExpression.h
+++ b/OOModel/src/expressions/types/TypeQualifierExpression.h
@@ -50,7 +50,7 @@ class OOMODEL_API TypeQualifierExpression : public Super<TypeExpression>
 		Qualifier qualifier() const;
 		void setQualifier(Qualifier q);
 
-		virtual Type* type();
+		virtual Type* type() override;
 };
 
 inline TypeQualifierExpression::Qualifier TypeQualifierExpression::qualifier()

--- a/OOModel/src/types/PointerType.h
+++ b/OOModel/src/types/PointerType.h
@@ -37,7 +37,7 @@ class OOMODEL_API PointerType : public Type {
 		PointerType(const PointerType& other);
 		virtual ~PointerType();
 
-		virtual bool equals(const Type* other) const;
+		virtual bool equals(const Type* other) const override;
 		virtual PointerType* clone() const override;
 
 		const Type* baseType() const;

--- a/OOModel/src/types/ReferenceType.h
+++ b/OOModel/src/types/ReferenceType.h
@@ -37,7 +37,7 @@ class OOMODEL_API ReferenceType : public Type {
 		ReferenceType(const ReferenceType& other);
 		virtual ~ReferenceType();
 
-		virtual bool equals(const Type* other) const;
+		virtual bool equals(const Type* other) const override;
 		virtual ReferenceType* clone() const override;
 
 		const Type* baseType() const;

--- a/OOVisualization/src/alternative/VKeywordMethodCall.h
+++ b/OOVisualization/src/alternative/VKeywordMethodCall.h
@@ -55,7 +55,7 @@ class OOVISUALIZATION_API VKeywordMethodCall
 		Visualization::VList* arguments() const;
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::Static* keyword_;

--- a/OOVisualization/src/elements/VCommentStatementItem.h
+++ b/OOVisualization/src/elements/VCommentStatementItem.h
@@ -44,8 +44,8 @@ class OOVISUALIZATION_API VCommentStatementItem
 		virtual ~VCommentStatementItem();
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::Item* comment_;

--- a/OOVisualization/src/elements/VEnumerator.h
+++ b/OOVisualization/src/elements/VEnumerator.h
@@ -55,7 +55,7 @@ class OOVISUALIZATION_API VEnumerator : public Super<Visualization::ItemWithNode
 		Visualization::Item* value() const;
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::VText* name_{};

--- a/OOVisualization/src/elements/VFormalResult.h
+++ b/OOVisualization/src/elements/VFormalResult.h
@@ -50,7 +50,7 @@ class OOVISUALIZATION_API VFormalResult
 		virtual ~VFormalResult();
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::VText* name_;

--- a/OOVisualization/src/expressions/VArrayInitializer.h
+++ b/OOVisualization/src/expressions/VArrayInitializer.h
@@ -59,7 +59,7 @@ class OOVISUALIZATION_API VArrayInitializer
 		Visualization::GridLayout* grid() const;
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::VList* list_{};

--- a/OOVisualization/src/expressions/VBinaryOperation.h
+++ b/OOVisualization/src/expressions/VBinaryOperation.h
@@ -49,7 +49,7 @@ class OOVISUALIZATION_API VBinaryOperation
 		virtual ~VBinaryOperation();
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::Static* pre_;

--- a/OOVisualization/src/expressions/VCastExpression.h
+++ b/OOVisualization/src/expressions/VCastExpression.h
@@ -46,7 +46,7 @@ class OOVISUALIZATION_API VCastExpression : public Super<VExpression<VCastExpres
 		virtual ~VCastExpression();
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::NodeWrapper* castType_{};

--- a/OOVisualization/src/expressions/VEmptyExpression.h
+++ b/OOVisualization/src/expressions/VEmptyExpression.h
@@ -45,8 +45,8 @@ OOModel::EmptyExpression>>
 		virtual ~VEmptyExpression();
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::Static* vis_;

--- a/OOVisualization/src/expressions/VErrorExpression.h
+++ b/OOVisualization/src/expressions/VErrorExpression.h
@@ -50,7 +50,7 @@ class OOVISUALIZATION_API VErrorExpression : public Super<VExpression<VErrorExpr
 		virtual ~VErrorExpression();
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::VText* prefix_;

--- a/OOVisualization/src/expressions/VLambdaExpression.h
+++ b/OOVisualization/src/expressions/VLambdaExpression.h
@@ -56,7 +56,7 @@ class OOVISUALIZATION_API VLambdaExpression : public Super<VExpression<VLambdaEx
 		VStatementItemList* body() const;
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::VList* arguments_{};

--- a/OOVisualization/src/expressions/VMethodCallExpression.h
+++ b/OOVisualization/src/expressions/VMethodCallExpression.h
@@ -53,7 +53,7 @@ class OOVISUALIZATION_API VMethodCallExpression : public Super<VExpression<VMeth
 		Visualization::VList* arguments() const;
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Item* callee_{};

--- a/OOVisualization/src/expressions/VNewExpression.h
+++ b/OOVisualization/src/expressions/VNewExpression.h
@@ -54,7 +54,7 @@ Visualization::LayoutProvider<>,	OOModel::NewExpression>>
 		Visualization::VList* dimensions() const;
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 

--- a/OOVisualization/src/expressions/VReferenceExpression.h
+++ b/OOVisualization/src/expressions/VReferenceExpression.h
@@ -57,7 +57,7 @@ class OOVISUALIZATION_API VReferenceExpression : public Super<VExpression<VRefer
 		Visualization::VList* typeArguments() const;
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		VOOReference* name_;

--- a/OOVisualization/src/expressions/VSuperExpression.h
+++ b/OOVisualization/src/expressions/VSuperExpression.h
@@ -46,8 +46,8 @@ OOModel::SuperExpression>>
 		Visualization::Static* item() const;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::Static* vis_;

--- a/OOVisualization/src/expressions/VThisExpression.h
+++ b/OOVisualization/src/expressions/VThisExpression.h
@@ -46,8 +46,8 @@ OOModel::ThisExpression>>
 		Visualization::Static* item() const;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::Static* vis_;

--- a/OOVisualization/src/expressions/VUnfinishedOperator.h
+++ b/OOVisualization/src/expressions/VUnfinishedOperator.h
@@ -49,7 +49,7 @@ class OOVISUALIZATION_API VUnfinishedOperator : public Super<VExpression<VUnfini
 		virtual ~VUnfinishedOperator();
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		QVector<Visualization::VText*> delimiters_;

--- a/OOVisualization/src/expressions/VVariableDeclarationExpression.h
+++ b/OOVisualization/src/expressions/VVariableDeclarationExpression.h
@@ -55,7 +55,7 @@ class OOVISUALIZATION_API VVariableDeclarationExpression : public Super<VExpress
 		Visualization::Item* initialValue() const;
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 		Visualization::VText* name_;

--- a/OOVisualization/src/expressions/literals/VBooleanLiteral.h
+++ b/OOVisualization/src/expressions/literals/VBooleanLiteral.h
@@ -48,8 +48,8 @@ OOModel::BooleanLiteral>>
 		Visualization::VBoolean* item() const;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::VBoolean* vis_;

--- a/OOVisualization/src/expressions/literals/VCharacterLiteral.h
+++ b/OOVisualization/src/expressions/literals/VCharacterLiteral.h
@@ -53,7 +53,7 @@ class OOVISUALIZATION_API VCharacterLiteral
 		virtual ~VCharacterLiteral();
 
 	protected:
-		virtual void determineChildren();
+		virtual void determineChildren() override;
 
 	private:
 		Visualization::Static* pre_{};

--- a/OOVisualization/src/expressions/literals/VFloatLiteral.h
+++ b/OOVisualization/src/expressions/literals/VFloatLiteral.h
@@ -46,8 +46,8 @@ class OOVISUALIZATION_API VFloatLiteral
 		virtual ~VFloatLiteral();
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::VFloat* vis_;

--- a/OOVisualization/src/expressions/literals/VIntegerLiteral.h
+++ b/OOVisualization/src/expressions/literals/VIntegerLiteral.h
@@ -48,8 +48,8 @@ class OOVISUALIZATION_API VIntegerLiteral
 		Visualization::VInteger* item() const;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::VInteger* vis_;

--- a/OOVisualization/src/expressions/literals/VNullLiteral.h
+++ b/OOVisualization/src/expressions/literals/VNullLiteral.h
@@ -46,8 +46,8 @@ class OOVISUALIZATION_API VNullLiteral
 		Visualization::Static* item() const;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::Static* vis_;

--- a/OOVisualization/src/expressions/literals/VStringLiteral.h
+++ b/OOVisualization/src/expressions/literals/VStringLiteral.h
@@ -53,7 +53,7 @@ class OOVISUALIZATION_API VStringLiteral
 		virtual ~VStringLiteral();
 
 	protected:
-		virtual void determineChildren();
+		virtual void determineChildren() override;
 
 	private:
 		Visualization::Static* pre_{};

--- a/OOVisualization/src/expressions/types/VAutoType.h
+++ b/OOVisualization/src/expressions/types/VAutoType.h
@@ -46,8 +46,8 @@ OOModel::AutoTypeExpression>>
 		Visualization::Static* item() const;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::Static* vis_;

--- a/OOVisualization/src/expressions/types/VClassType.h
+++ b/OOVisualization/src/expressions/types/VClassType.h
@@ -45,8 +45,8 @@ class OOVISUALIZATION_API VClassType
 		VReferenceExpression* reference() const;
 
 	protected:
-		void determineChildren();
-		void updateGeometry(int availableWidth, int availableHeight);
+		void determineChildren() override;
+		void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		VReferenceExpression* vis_;

--- a/OOVisualization/src/expressions/types/VFunctionType.h
+++ b/OOVisualization/src/expressions/types/VFunctionType.h
@@ -56,7 +56,7 @@ class OOVISUALIZATION_API VFunctionType : public Super<VExpression<VFunctionType
 		Visualization::VList* results() const;
 
 	protected:
-		void determineChildren();
+		void determineChildren() override;
 
 	private:
 

--- a/OOVisualization/src/expressions/types/VPrimitiveType.h
+++ b/OOVisualization/src/expressions/types/VPrimitiveType.h
@@ -52,8 +52,8 @@ class OOVISUALIZATION_API VPrimitiveType
 		Visualization::Static* item() const;
 
 	protected:
-		void determineChildren();
-		void updateGeometry(int availableWidth, int availableHeight);
+		void determineChildren() override;
+		void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::Static* vis_;

--- a/OOVisualization/src/statements/VBlock.h
+++ b/OOVisualization/src/statements/VBlock.h
@@ -47,8 +47,8 @@ class OOVISUALIZATION_API VBlock : public Super<VStatementItem<VBlock, Visualiza
 		virtual ~VBlock();
 
 	protected:
-		void determineChildren();
-		void updateGeometry(int availableWidth, int availableHeight);
+		void determineChildren() override;
+		void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		VStatementItemList* items_;

--- a/OOVisualization/src/statements/VBreakStatement.h
+++ b/OOVisualization/src/statements/VBreakStatement.h
@@ -44,8 +44,8 @@ class OOVISUALIZATION_API VBreakStatement
 		virtual ~VBreakStatement();
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::Static* vis_;

--- a/OOVisualization/src/statements/VDeclarationStatement.h
+++ b/OOVisualization/src/statements/VDeclarationStatement.h
@@ -44,8 +44,8 @@ class OOVISUALIZATION_API VDeclarationStatement
 		virtual ~VDeclarationStatement();
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::Item* decl_;

--- a/OOVisualization/src/statements/VExpressionStatement.h
+++ b/OOVisualization/src/statements/VExpressionStatement.h
@@ -44,8 +44,8 @@ class OOVISUALIZATION_API VExpressionStatement
 		virtual ~VExpressionStatement();
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Visualization::Item* expr_;

--- a/VisualizationBase/src/Scene.h
+++ b/VisualizationBase/src/Scene.h
@@ -84,7 +84,7 @@ class VISUALIZATIONBASE_API Scene : public QGraphicsScene
 		Cursor* mainCursor();
 		void setMainCursor(Cursor* cursor);
 
-		virtual void customEvent(QEvent *event);
+		virtual void customEvent(QEvent *event) override;
 
 		virtual SceneHandlerItem* sceneHandlerItem();
 

--- a/VisualizationBase/src/cursor/CursorShapeItem.h
+++ b/VisualizationBase/src/cursor/CursorShapeItem.h
@@ -53,8 +53,8 @@ class VISUALIZATIONBASE_API CursorShapeItem: public Super<Item>
 		bool useCenter() const;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Cursor* cursor_;

--- a/VisualizationBase/src/cursor/LayoutCursor.h
+++ b/VisualizationBase/src/cursor/LayoutCursor.h
@@ -55,8 +55,8 @@ class VISUALIZATIONBASE_API LayoutCursor : public Cursor {
 
 		void setIsAtBoundary(bool isAtBoundary);
 
-		virtual bool isSame(Cursor* c);
-		virtual bool isAtBoundary() const;
+		virtual bool isSame(Cursor* c) override;
+		virtual bool isAtBoundary() const override;
 
 	private:
 		int x_;

--- a/VisualizationBase/src/cursor/TextCursor.h
+++ b/VisualizationBase/src/cursor/TextCursor.h
@@ -61,14 +61,14 @@ class VISUALIZATIONBASE_API TextCursor : public Cursor {
 
 		int cursorAtX(int x) const;
 
-		TextRenderer* owner() const;
+		TextRenderer* owner() const override;
 
 		bool isCursorBeforeSelection();
 
 		void update(const QFontMetrics& qfm);
 
-		virtual bool isSame(Cursor* c);
-		virtual bool isAtBoundary() const;
+		virtual bool isSame(Cursor* c) override;
+		virtual bool isAtBoundary() const override;
 
 	private:
 		/**

--- a/VisualizationBase/src/declarative/DeclarativeItem.h
+++ b/VisualizationBase/src/declarative/DeclarativeItem.h
@@ -96,11 +96,11 @@ class DeclarativeItem : public DeclarativeItemBase
 			static VisualizationItemWrapperFormElement<VisualizationType, ChildItemVisualizationType, true>*
 			item(ChildItemVisualizationType* VisualizationType::* item);
 		template <class ChildItemVisualizationType>
-			static VisualizationItemWrapperFormElement<VisualizationType, ChildItemVisualizationType>*
+			static VisualizationItemWrapperFormElement<VisualizationType, ChildItemVisualizationType, false>*
 			item(ChildItemVisualizationType* VisualizationType::* item,
 					std::function<const typename ChildItemVisualizationType::StyleType* (VisualizationType* v)> styleGetter);
 		template <class ChildItemVisualizationType, class ParentStyleType>
-			static VisualizationItemWrapperFormElement<VisualizationType, ChildItemVisualizationType>*
+			static VisualizationItemWrapperFormElement<VisualizationType, ChildItemVisualizationType, false>*
 			item(ChildItemVisualizationType* VisualizationType::* item,
 					 Style::Property<typename ChildItemVisualizationType::StyleType> ParentStyleType::* stylePointer);
 

--- a/VisualizationBase/src/declarative/DeclarativeItemDef.h
+++ b/VisualizationBase/src/declarative/DeclarativeItemDef.h
@@ -111,18 +111,18 @@ template <class ChildItemVisualizationType>
 
 template <class VisualizationType>
 template <class ChildItemVisualizationType>
-	VisualizationItemWrapperFormElement<VisualizationType, ChildItemVisualizationType>*
+	VisualizationItemWrapperFormElement<VisualizationType, ChildItemVisualizationType, false>*
 	DeclarativeItem<VisualizationType>::item(ChildItemVisualizationType* VisualizationType::* itemStorage,
 										std::function<const
 											typename ChildItemVisualizationType::StyleType* (VisualizationType* v)> styleGetter)
 {
-	return new VisualizationItemWrapperFormElement<VisualizationType, ChildItemVisualizationType>(itemStorage,
+	return new VisualizationItemWrapperFormElement<VisualizationType, ChildItemVisualizationType, false>(itemStorage,
 																																 styleGetter);
 }
 
 template <class VisualizationType>
 template <class ChildItemVisualizationType, class ParentStyleType>
-	VisualizationItemWrapperFormElement<VisualizationType, ChildItemVisualizationType>*
+	VisualizationItemWrapperFormElement<VisualizationType, ChildItemVisualizationType, false>*
 	DeclarativeItem<VisualizationType>::item(ChildItemVisualizationType* VisualizationType::* itemStorage,
 			Style::Property<typename ChildItemVisualizationType::StyleType> ParentStyleType::* stylePointer)
 {

--- a/VisualizationBase/src/icons/Icon.h
+++ b/VisualizationBase/src/icons/Icon.h
@@ -41,7 +41,7 @@ class VISUALIZATIONBASE_API Icon: public Super<Item>
 		Icon(Item* parent, const IconStyle* style);
 
 	protected:
-		virtual void determineChildren();
+		virtual void determineChildren() override;
 
 		int xOffset() const;
 		int yOffset() const;

--- a/VisualizationBase/src/icons/SVGIcon.h
+++ b/VisualizationBase/src/icons/SVGIcon.h
@@ -39,8 +39,8 @@ class VISUALIZATIONBASE_API SVGIcon : public Super<Icon>
 		SVGIcon(Item* parent, const SVGIconStyle *style = itemStyles().get());
 		SVGIcon(Item* parent, const QString& iconStyleName);
 
-		virtual void updateGeometry(int availableWidth, int availableHeight);
-		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
+		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 };
 
 }

--- a/VisualizationBase/src/icons/SVGIconStyle.h
+++ b/VisualizationBase/src/icons/SVGIconStyle.h
@@ -37,7 +37,7 @@ class VISUALIZATIONBASE_API SVGIconStyle : public Super<IconStyle>
 {
 	public:
 		virtual ~SVGIconStyle() override;
-		virtual void load(StyleLoader& sl);
+		virtual void load(StyleLoader& sl) override;
 
 		void paint(QPainter* painter, int x, int y) const;
 

--- a/VisualizationBase/src/items/Item.h
+++ b/VisualizationBase/src/items/Item.h
@@ -48,7 +48,7 @@ class OverlayAccessor;
 
 class VISUALIZATIONBASE_API Item : public QGraphicsItem
 {
-	DECLARE_TYPE_ID
+	DECLARE_TYPE_ID_BASE
 
 	public:
 		typedef ItemStyle StyleType;
@@ -499,7 +499,7 @@ class VISUALIZATIONBASE_API Item : public QGraphicsItem
 		friend class DynamicGridFormElement;
 		template <class ParentType> friend class NodeItemWrapperFormElement;
 		template <class ParentType, class VisualizationType> friend class NodeWithVisualizationItemWrapperFormElement;
-		template <class ParentType, class VisualizationType, bool externalSynchronization = false>
+		template <class ParentType, class VisualizationType, bool externalSynchronization>
 			friend class VisualizationItemWrapperFormElement;
 		template <class ChildItem, class Style, bool use>
 			friend struct VisualizationItemWrapperFormElementSyncMethod;

--- a/VisualizationBase/src/items/ItemMacros.h
+++ b/VisualizationBase/src/items/ItemMacros.h
@@ -43,14 +43,14 @@ public:																																					\
 	typedef StyleTypeName StyleType;																												\
 																																							\
 	const StyleType* style() const { return static_cast<const StyleType*> (Item::style()); }									\
-	virtual void setStyle(const Visualization::ItemStyle* style);																		\
+	virtual void setStyle(const Visualization::ItemStyle* style) override;															\
 	static Visualization::StyleSet<ItemClass>& itemStyles();																				\
 																																							\
-	virtual Visualization::InteractionHandler* handler() const;																			\
+	virtual Visualization::InteractionHandler* handler() const override;																\
 	static void setDefaultClassHandler(Visualization::InteractionHandler* handler) {defaultClassHandler_ = handler;}	\
 	static Visualization::InteractionHandler* defaultClassHandler() {return defaultClassHandler_;}							\
 																																							\
-	virtual QList<Visualization::VisualizationAddOn*> addOns();																			\
+	virtual QList<Visualization::VisualizationAddOn*> addOns() override;																\
 	static void addAddOn(Visualization::VisualizationAddOn* addOn);																	\
 	static bool removeAddOn(Visualization::VisualizationAddOn* addOn);																\
 private:																																					\

--- a/VisualizationBase/src/items/ItemStyle.h
+++ b/VisualizationBase/src/items/ItemStyle.h
@@ -46,7 +46,7 @@ class VISUALIZATIONBASE_API ItemStyle : public Super<Style>
 		Shape* createShape(Item* parent) const;
 		bool hasShape() const;
 
-		virtual void load(StyleLoader& sl);
+		virtual void load(StyleLoader& sl) override;
 
 		Property<bool> drawsOnlyShape{this, "drawsOnlyShape"};
 		Property<bool> drawShapeWhenEmpty{this, "drawShapeWhenEmpty"};

--- a/VisualizationBase/src/items/LayoutProviderBase.h
+++ b/VisualizationBase/src/items/LayoutProviderBase.h
@@ -42,8 +42,8 @@ class VISUALIZATIONBASE_API LayoutProviderBase : public Super<Item>
 		LayoutProviderBase(Item* parent, const StyleType *style, Layout* layout);
 		virtual ~LayoutProviderBase();
 
-		virtual bool sizeDependsOnParent() const;
-		virtual bool isEmpty() const;
+		virtual bool sizeDependsOnParent() const override;
+		virtual bool isEmpty() const override;
 
 		Layout* layout() const;
 
@@ -51,7 +51,7 @@ class VISUALIZATIONBASE_API LayoutProviderBase : public Super<Item>
 			const override;
 
 	protected:
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Layout* layout_;

--- a/VisualizationBase/src/items/SceneHandlerItem.h
+++ b/VisualizationBase/src/items/SceneHandlerItem.h
@@ -42,8 +42,8 @@ class VISUALIZATIONBASE_API SceneHandlerItem : public Super<Item>
 		SceneHandlerItem(Scene* scene);
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 };
 
 }

--- a/VisualizationBase/src/items/Static.h
+++ b/VisualizationBase/src/items/Static.h
@@ -43,16 +43,16 @@ class VISUALIZATIONBASE_API Static : public Super<Item>
 		Static(Item* parent, const StyleType *style = itemStyles().get());
 		virtual ~Static();
 
-		virtual bool isEmpty() const;
-		virtual bool sizeDependsOnParent() const;
+		virtual bool isEmpty() const override;
+		virtual bool sizeDependsOnParent() const override;
 
 		template<class T> static void registerStaticItem();
 
 		Item* item();
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Item* item_;

--- a/VisualizationBase/src/items/Symbol.h
+++ b/VisualizationBase/src/items/Symbol.h
@@ -39,11 +39,11 @@ class VISUALIZATIONBASE_API Symbol : public Super<TextRenderer>
 
 	public:
 		Symbol(Item* parent, const StyleType *style = itemStyles().get());
-		virtual bool setText(const QString& newText);
-		virtual bool isEmpty() const;
+		virtual bool setText(const QString& newText) override;
+		virtual bool isEmpty() const override;
 
 	protected:
-		virtual QString currentText();
+		virtual QString currentText() override;
 };
 
 }

--- a/VisualizationBase/src/items/Text.h
+++ b/VisualizationBase/src/items/Text.h
@@ -41,7 +41,7 @@ class VISUALIZATIONBASE_API Text : public Super<TextRenderer>
 		Text(Item* parent, const StyleType *style, const QString& text = QString());
 
 	protected:
-		virtual QString currentText();
+		virtual QString currentText() override;
 };
 
 }

--- a/VisualizationBase/src/items/TextRenderer.h
+++ b/VisualizationBase/src/items/TextRenderer.h
@@ -63,7 +63,7 @@ class VISUALIZATIONBASE_API TextRenderer : public Super<Item>
 		bool isEditable();
 		void setEditable(bool editable);
 
-		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 		virtual bool moveCursor(CursorMoveDirection dir = MoveDefault, QPoint reference = QPoint()) override;
 
@@ -75,8 +75,8 @@ class VISUALIZATIONBASE_API TextRenderer : public Super<Item>
 		bool isHtml() const;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 		/**
 		 * Returns the text of that is represented by the current item.

--- a/VisualizationBase/src/items/TextStyle.h
+++ b/VisualizationBase/src/items/TextStyle.h
@@ -36,7 +36,7 @@ class VISUALIZATIONBASE_API TextStyle : public Super<ItemStyle>
 {
 	public:
 		virtual ~TextStyle() override;
-		void load(StyleLoader& sl);
+		void load(StyleLoader& sl) override;
 
 		Property<QPen> pen{this, "pen"};
 		Property<QFont> font{this, "font"};

--- a/VisualizationBase/src/items/VBoolean.h
+++ b/VisualizationBase/src/items/VBoolean.h
@@ -41,10 +41,10 @@ class VISUALIZATIONBASE_API VBoolean : public Super<ItemWithNode<VBoolean, TextR
 
 	public:
 		VBoolean(Item* parent, NodeType *node, const StyleType *style = itemStyles().get());
-		virtual bool setText(const QString& newText);
+		virtual bool setText(const QString& newText) override;
 
 	protected:
-		virtual QString currentText();
+		virtual QString currentText() override;
 };
 
 }

--- a/VisualizationBase/src/items/VCharacter.h
+++ b/VisualizationBase/src/items/VCharacter.h
@@ -41,10 +41,10 @@ class VISUALIZATIONBASE_API VCharacter : public Super<ItemWithNode<VCharacter, T
 
 	public:
 		VCharacter(Item* parent, NodeType *node, const StyleType *style = itemStyles().get());
-		virtual bool setText(const QString& newText);
+		virtual bool setText(const QString& newText) override;
 
 	protected:
-		virtual QString currentText();
+		virtual QString currentText() override;
 };
 
 }

--- a/VisualizationBase/src/items/VFloat.h
+++ b/VisualizationBase/src/items/VFloat.h
@@ -41,10 +41,10 @@ class VISUALIZATIONBASE_API VFloat : public Super<ItemWithNode<VFloat, TextRende
 
 	public:
 		VFloat(Item* parent, NodeType *node, const StyleType *style = itemStyles().get());
-		virtual bool setText(const QString& newText);
+		virtual bool setText(const QString& newText) override;
 
 	protected:
-		virtual QString currentText();
+		virtual QString currentText() override;
 };
 
 }

--- a/VisualizationBase/src/items/VInteger.h
+++ b/VisualizationBase/src/items/VInteger.h
@@ -41,10 +41,10 @@ class VISUALIZATIONBASE_API VInteger : public Super<ItemWithNode<VInteger, TextR
 
 	public:
 		VInteger(Item* parent, NodeType *node, const StyleType *style = itemStyles().get());
-		virtual bool setText(const QString& newText);
+		virtual bool setText(const QString& newText) override;
 
 	protected:
-		virtual QString currentText();
+		virtual QString currentText() override;
 };
 
 }

--- a/VisualizationBase/src/items/VList.h
+++ b/VisualizationBase/src/items/VList.h
@@ -61,7 +61,7 @@ class VISUALIZATIONBASE_API VList: public Super<ItemWithNode<VList, DeclarativeI
 		bool isShowingEmptyTip();
 
 		static void initializeForms();
-		virtual int determineForm();
+		virtual int determineForm() override;
 
 		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 		virtual bool moveCursor(CursorMoveDirection dir = MoveDefault, QPoint reference = QPoint()) override;

--- a/VisualizationBase/src/items/VReference.h
+++ b/VisualizationBase/src/items/VReference.h
@@ -41,10 +41,10 @@ class VISUALIZATIONBASE_API VReference : public Super<ItemWithNode<VReference, T
 
 	public:
 		VReference(Item* parent, NodeType *node, const StyleType *style = itemStyles().get());
-		virtual bool setText(const QString& newText);
+		virtual bool setText(const QString& newText) override;
 
 	protected:
-		virtual QString currentText();
+		virtual QString currentText() override;
 };
 
 }

--- a/VisualizationBase/src/items/VText.h
+++ b/VisualizationBase/src/items/VText.h
@@ -41,12 +41,12 @@ class VISUALIZATIONBASE_API VText : public Super<ItemWithNode<VText, TextRendere
 
 	public:
 		VText(Item* parent, NodeType* node, const StyleType* style = itemStyles().get());
-		virtual bool setText(const QString& newText);
+		virtual bool setText(const QString& newText) override;
 
 		virtual bool moveCursor(CursorMoveDirection dir = MoveDefault, QPoint reference = QPoint()) override;
 
 	protected:
-		virtual QString currentText();
+		virtual QString currentText() override;
 };
 
 }

--- a/VisualizationBase/src/layouts/GridLayout.h
+++ b/VisualizationBase/src/layouts/GridLayout.h
@@ -45,9 +45,9 @@ class VISUALIZATIONBASE_API GridLayout: public Super<Layout>
 		GridLayout(Item* parent, const StyleType* style = itemStyles().get());
 		~GridLayout();
 
-		virtual bool isEmpty() const;
+		virtual bool isEmpty() const override;
 
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 		QPoint focusedElementIndex() const;

--- a/VisualizationBase/src/layouts/Layout.h
+++ b/VisualizationBase/src/layouts/Layout.h
@@ -43,7 +43,7 @@ class VISUALIZATIONBASE_API Layout: public Super<Item>
 
 		void setInnerSize(int width, int height);
 
-		virtual void determineChildren();
+		virtual void determineChildren() override;
 
 	protected:
 		int xOffset() const;

--- a/VisualizationBase/src/layouts/PositionLayout.h
+++ b/VisualizationBase/src/layouts/PositionLayout.h
@@ -69,7 +69,7 @@ class VISUALIZATIONBASE_API PositionLayout : public Super<Layout>
 
 		void synchronizeWithNodes(const QList<Model::Node*>& nodes);
 
-		virtual bool isEmpty() const;
+		virtual bool isEmpty() const override;
 		virtual bool isSensitiveToScale() const override;
 
 		int focusedElementIndex() const;

--- a/VisualizationBase/src/layouts/SequentialLayout.h
+++ b/VisualizationBase/src/layouts/SequentialLayout.h
@@ -45,14 +45,14 @@ class VISUALIZATIONBASE_API SequentialLayout: public Super<Layout>
 		SequentialLayout(Item* parent, const StyleType* style = itemStyles().get());
 		~SequentialLayout();
 
-		virtual bool isEmpty() const;
+		virtual bool isEmpty() const override;
 
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 		virtual bool sizeDependsOnParent() const override;
 
 		int focusedElementIndex() const;
 
-		virtual QList<ItemRegion> regions();
+		virtual QList<ItemRegion> regions() override;
 
 		bool isHorizontal() const;
 		bool isForward() const;

--- a/VisualizationBase/src/nodes/InfoNode.h
+++ b/VisualizationBase/src/nodes/InfoNode.h
@@ -64,8 +64,8 @@ class VISUALIZATIONBASE_API InfoNode : public Super<Model::Node>
 		void setEnabled(const QString name, bool isEnabled);
 		bool isEnabled(const QString name) const;
 
-		virtual void save(Model::PersistentStore& store) const;
-		virtual void load(Model::PersistentStore& store);
+		virtual void save(Model::PersistentStore& store) const override;
+		virtual void load(Model::PersistentStore& store) override;
 
 		/**
 		 * Registers a new method to get information.

--- a/VisualizationBase/src/nodes/UINode.h
+++ b/VisualizationBase/src/nodes/UINode.h
@@ -42,8 +42,8 @@ class VISUALIZATIONBASE_API UINode : public Super<Model::Node>
 	public:
 		UINode();
 
-		virtual void save(Model::PersistentStore& store) const;
-		virtual void load(Model::PersistentStore& store);
+		virtual void save(Model::PersistentStore& store) const override;
+		virtual void load(Model::PersistentStore& store) override;
 };
 
 }

--- a/VisualizationBase/src/overlays/ArrowOverlay.h
+++ b/VisualizationBase/src/overlays/ArrowOverlay.h
@@ -44,8 +44,8 @@ class VISUALIZATIONBASE_API ArrowOverlay: public Super<Overlay<Item>>
 		virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		QPoint lineFrom_{};

--- a/VisualizationBase/src/overlays/IconOverlay.h
+++ b/VisualizationBase/src/overlays/IconOverlay.h
@@ -42,8 +42,8 @@ class VISUALIZATIONBASE_API IconOverlay : public Super<Overlay<Item>>
 		IconOverlay(Item* associatedItem, const StyleType* style = itemStyles().get());
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		Static* icon_{};

--- a/VisualizationBase/src/overlays/SelectionOverlay.h
+++ b/VisualizationBase/src/overlays/SelectionOverlay.h
@@ -40,8 +40,8 @@ class VISUALIZATIONBASE_API SelectionOverlay: public Super<Overlay<Item>>
 		SelectionOverlay(Item* selectedItem, const StyleType* style = itemStyles().get());
 
 	protected:
-		virtual void determineChildren();
-		virtual void updateGeometry(int availableWidth, int availableHeight);
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 };
 
 }

--- a/VisualizationBase/src/shapes/Box.h
+++ b/VisualizationBase/src/shapes/Box.h
@@ -40,15 +40,15 @@ class VISUALIZATIONBASE_API Box: public Super<Shape>
 	public:
 		Box(Item *parent, StyleType *style = itemStyles().get());
 
-		virtual void update();
-		virtual int contentLeft();
-		virtual int contentTop();
+		virtual void update() override;
+		virtual int contentLeft() override;
+		virtual int contentTop() override;
 		virtual QRect contentRect() override;
 
-		virtual QSize innerSize(QSize outterSize) const;
-		virtual QSize outterSize(QSize innerSize) const;
+		virtual QSize innerSize(QSize outterSize) const override;
+		virtual QSize outterSize(QSize innerSize) const override;
 
-		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 	protected:
 		int outerWidth_{};

--- a/VisualizationBase/src/shapes/Braces.h
+++ b/VisualizationBase/src/shapes/Braces.h
@@ -40,15 +40,15 @@ class VISUALIZATIONBASE_API Braces: public Super<Shape>
 	public:
 		Braces(Item *parent, StyleType *style = itemStyles().get());
 
-		virtual void update();
-		virtual int contentLeft();
-		virtual int contentTop();
+		virtual void update() override;
+		virtual int contentLeft() override;
+		virtual int contentTop() override;
 		virtual QRect contentRect() override;
 
-		virtual QSize innerSize(QSize outterSize) const;
-		virtual QSize outterSize(QSize innerSize) const;
+		virtual QSize innerSize(QSize outterSize) const override;
+		virtual QSize outterSize(QSize innerSize) const override;
 
-		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 	protected:
 		qreal contentTop_;

--- a/VisualizationBase/src/shapes/Diamond.h
+++ b/VisualizationBase/src/shapes/Diamond.h
@@ -48,15 +48,15 @@ class VISUALIZATIONBASE_API Diamond: public Super<Shape>
 	public:
 		Diamond(Item *parent, StyleType *style = itemStyles().get());
 
-		virtual void update();
-		virtual int contentLeft();
-		virtual int contentTop();
+		virtual void update() override;
+		virtual int contentLeft() override;
+		virtual int contentTop() override;
 		virtual QRect contentRect() override;
 
-		virtual QSize innerSize(QSize outterSize) const;
-		virtual QSize outterSize(QSize innerSize) const;
+		virtual QSize innerSize(QSize outterSize) const override;
+		virtual QSize outterSize(QSize innerSize) const override;
 
-		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 };
 
 }

--- a/VisualizationBase/src/shapes/Shape.h
+++ b/VisualizationBase/src/shapes/Shape.h
@@ -38,7 +38,7 @@ namespace Visualization {
 
 class VISUALIZATIONBASE_API Shape
 {
-	DECLARE_TYPE_ID
+	DECLARE_TYPE_ID_BASE
 
 	public:
 		typedef ShapeStyle StyleType;

--- a/VisualizationBase/src/shapes/SvgShape.h
+++ b/VisualizationBase/src/shapes/SvgShape.h
@@ -40,15 +40,15 @@ class VISUALIZATIONBASE_API SvgShape : public Super<Shape>
 	public:
 		SvgShape(Item *parent, StyleType *style = itemStyles().get());
 
-		virtual void update();
-		virtual int contentLeft();
-		virtual int contentTop();
+		virtual void update() override;
+		virtual int contentLeft() override;
+		virtual int contentTop() override;
 		virtual QRect contentRect() override;
 
-		virtual QSize innerSize(QSize outterSize) const;
-		virtual QSize outterSize(QSize innerSize) const;
+		virtual QSize innerSize(QSize outterSize) const override;
+		virtual QSize outterSize(QSize innerSize) const override;
 
-		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget);
+		virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
 	private:
 		qreal svgWidth;

--- a/VisualizationBase/src/shapes/SvgShapeStyle.h
+++ b/VisualizationBase/src/shapes/SvgShapeStyle.h
@@ -36,7 +36,7 @@ class VISUALIZATIONBASE_API SvgShapeStyle : public Super<ShapeStyle>
 {
 	public:
 		virtual ~SvgShapeStyle() override;
-		virtual void load(StyleLoader& sl);
+		virtual void load(StyleLoader& sl) override;
 		void paint(QPainter* painter, int x, int y, int width, int height) const;
 
 		Property<QString> filename{this, "filename"};

--- a/VisualizationBase/src/shapes/shapeMacros.h
+++ b/VisualizationBase/src/shapes/shapeMacros.h
@@ -43,7 +43,7 @@ public:																																					\
 	typedef StyleTypeName StyleType;																												\
 																																							\
 	const StyleType* style() const { return static_cast<const StyleType*> (Shape::style()); }									\
-	virtual void setStyle(const Visualization::ShapeStyle* style);																		\
+	virtual void setStyle(const Visualization::ShapeStyle* style) override;															\
 	static StyleSet<ShapeClass>& itemStyles();																								\
 																																							\
 private:

--- a/VisualizationBase/test/BoxTest.h
+++ b/VisualizationBase/test/BoxTest.h
@@ -40,8 +40,8 @@ class BoxTest : public Super<Item>
 	public:
 		BoxTest(Item* parent, int sub);
 
-		void determineChildren();
-		void updateGeometry(int availableWidth, int availableHeight);
+		void determineChildren() override;
+		void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		SequentialLayout items;


### PR DESCRIPTION
-Mostly this is just missing the override keyword (Special attention to
typeIdMacros.h)
-Template friend classes can have no default template arguments (Item.h)
-Some forward declarations which used class instead of struct

ATTENTION: This touches more or less the whole codebase so there might be some conflict with other branches?
