### PR TITLE
Task views

### DIFF
--- a/InteractionBase/InteractionBase.pro
+++ b/InteractionBase/InteractionBase.pro
@@ -86,7 +86,8 @@ HEADERS += src/commands/CommandWithFlags.h \
     src/commands/AddReferencedToViewCommand.h \
     src/commands/CSaveView.h \
     src/commands/CAddNodeToViewByName.h \
-    src/commands/CAddNodeToView.h
+    src/commands/CAddNodeToView.h \
+    src/handlers/HViewItem.h
 SOURCES += src/commands/CommandWithFlags.cpp \
     src/expression_editor/tree_builder/AddSubExpression.cpp \
     src/commands/CSceneHandlerSave.cpp \
@@ -165,4 +166,5 @@ SOURCES += src/commands/CommandWithFlags.cpp \
     src/vis/ViewSwitcherMenu.cpp \
     src/commands/CSaveView.cpp \
     src/commands/CAddNodeToViewByName.cpp \
-    src/commands/CAddNodeToView.cpp
+    src/commands/CAddNodeToView.cpp \
+    src/handlers/HViewItem.cpp

--- a/InteractionBase/src/InteractionBasePlugin.cpp
+++ b/InteractionBase/src/InteractionBasePlugin.cpp
@@ -36,6 +36,7 @@
 #include "handlers/HPositionLayout.h"
 #include "handlers/HRootItem.h"
 #include "handlers/HInfoNode.h"
+#include "handlers/HViewItem.h"
 
 #include "vis/CommandPrompt.h"
 #include "vis/TextAndDescription.h"
@@ -65,6 +66,7 @@
 #include "VisualizationBase/src/layouts/SequentialLayout.h"
 #include "VisualizationBase/src/layouts/PositionLayout.h"
 #include "VisualizationBase/src/VisualizationManager.h"
+#include "VisualizationBase/src/items/ViewItem.h"
 
 #include "SelfTest/src/SelfTestSuite.h"
 
@@ -90,6 +92,7 @@ bool InteractionBasePlugin::initialize(Core::EnvisionManager& envisionManager)
 	Visualization::RootItem::setDefaultClassHandler(HRootItem::instance());
 	Visualization::PositionLayout::setDefaultClassHandler(HPositionLayout::instance());
 	Visualization::VInfoNode::setDefaultClassHandler(HInfoNode::instance());
+	Visualization::ViewItem::setDefaultClassHandler(HViewItem::instance());
 	CommandPrompt::setDefaultClassHandler(HCommandPrompt::instance());
 	ActionPrompt::setDefaultClassHandler(HActionPrompt::instance());
 

--- a/InteractionBase/src/commands/CAddNodeToViewByName.cpp
+++ b/InteractionBase/src/commands/CAddNodeToViewByName.cpp
@@ -29,6 +29,8 @@
 #include "VisualizationBase/src/items/ViewItem.h"
 #include "ModelBase/src/model/TreeManager.h"
 #include "VisualizationBase/src/items/VViewItemNode.h"
+#include "VisualizationBase/src/declarative/GridLayoutFormElement.h"
+#include "VisualizationBase/src/cursor/LayoutCursor.h"
 
 
 namespace Interaction {
@@ -41,7 +43,7 @@ bool CAddNodeToViewByName::canInterpret(Visualization::Item*, Visualization::Ite
 	return commandTokens.size() >= 1 && commandTokens.first() == name();
 }
 
-CommandResult* CAddNodeToViewByName::execute(Visualization::Item* source, Visualization::Item* target,
+CommandResult* CAddNodeToViewByName::execute(Visualization::Item*, Visualization::Item* target,
 		const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& cursor)
 {
 	if (commandTokens.size() < 2)
@@ -49,26 +51,16 @@ CommandResult* CAddNodeToViewByName::execute(Visualization::Item* source, Visual
 
 	auto currentView = target->scene()->currentViewItem();
 	QPoint posToInsert;
-	if (source == currentView && isHorizontal(cursor->region()))
+	auto layoutCursor = dynamic_cast<Visualization::LayoutCursor*>(cursor.get());
+	if (cursor->owner() == currentView && cursor->type() == Visualization::Cursor::HorizontalCursor && layoutCursor)
 	{
-		auto below =  findItemBelow(currentView, cursor->region());
-		if (below)
-		{
-			auto pos = currentView->positionOfItem(below);
-			posToInsert.setX(pos.x());
-			posToInsert.setY(pos.y());
-		}
+		posToInsert.setX(layoutCursor->x());
+		posToInsert.setY(layoutCursor->y());
 	}
-	else if (source == currentView && !isHorizontal(cursor->region()))
+	else if (cursor->owner() == currentView && cursor->type() == Visualization::Cursor::VerticalCursor && layoutCursor)
 	{
-		auto left = findItemLeft(currentView, cursor->region());
-		if (left)
-		{
-			auto pos = currentView->positionOfItem(left);
-			currentView->insertColumn(pos.x() + 1);
-			posToInsert.setX(pos.x() + 1);
-		}
-		else currentView->insertColumn(0);
+		currentView->insertColumn(layoutCursor->x());
+		posToInsert.setX(layoutCursor->x());
 	}
 
 	auto tokens = commandTokens.mid(1);
@@ -76,7 +68,7 @@ CommandResult* CAddNodeToViewByName::execute(Visualization::Item* source, Visual
 	for (auto manager : Model::AllTreeManagers::instance().loadedManagers())
 		if (auto node = findNode(tokens, manager->root()))
 		{
-			target->scene()->currentViewItem()->insertNode(node, posToInsert.x(), posToInsert.y());
+			currentView->insertNode(node, posToInsert.x(), posToInsert.y());
 			return new CommandResult();
 		}
 	return new CommandResult(new CommandError("Could not find node with name " + commandTokens[1]));
@@ -166,38 +158,6 @@ Model::Node* CAddNodeToViewByName::findNode(QStringList fullyQualifiedName, Mode
 bool CAddNodeToViewByName::isSuggestable(Model::Node::SymbolTypes symbolType)
 {
 	return symbolType == Model::Node::METHOD || symbolType == Model::Node::CONTAINER;
-}
-
-bool CAddNodeToViewByName::isHorizontal(QRect region)
-{
-	return region.width() > region.height();
-}
-
-Visualization::Item* CAddNodeToViewByName::findItemBelow(Visualization::ViewItem *view, QRect region)
-{
-	Visualization::Item* result{};
-	for (auto node : view->allNodes())
-		if (auto vis = view->findVisualizationOf(node))
-			//If it is in the same column, continue
-			if ((vis->scenePos().x() <= region.left() && region.left() <= vis->scenePos().x() + vis->widthInScene())
-				|| (region.left() <= vis->scenePos().x() && vis->scenePos().x() <= region.right()))
-				//If it is below the region, and we don't have a closer one yet
-				if (vis->scenePos().y() >= region.bottom()
-						&& (!result || result->scenePos().y() > vis->scenePos().y()))
-					result = vis;
-	return result;
-}
-
-Visualization::Item* CAddNodeToViewByName::findItemLeft(Visualization::ViewItem *view, QRect region)
-{
-	Visualization::Item* result{};
-	for (auto node : view->allNodes())
-		if (auto vis = view->findVisualizationOf(node))
-			//If it is in a column to the left, and closer than the current
-			if (vis->scenePos().x() < region.left()
-					&& (!result || result->scenePos().x() < vis->scenePos().x()))
-				result = vis;
-	return result;
 }
 
 }

--- a/InteractionBase/src/commands/CAddNodeToViewByName.h
+++ b/InteractionBase/src/commands/CAddNodeToViewByName.h
@@ -49,6 +49,10 @@ class INTERACTIONBASE_API CAddNodeToViewByName : public Command
 		QStringList findNames(QStringList nameParts, Model::Node* root);
 		Model::Node* findNode(QStringList fullyQualifiedName, Model::Node* root);
 		bool isSuggestable(Model::Node::SymbolTypes symbolType);
+
+		bool isHorizontal(QRect region);
+		Visualization::Item* findItemBelow(Visualization::ViewItem* view, QRect region);
+		Visualization::Item* findItemLeft(Visualization::ViewItem* view, QRect region);
 };
 
 }

--- a/InteractionBase/src/commands/CAddNodeToViewByName.h
+++ b/InteractionBase/src/commands/CAddNodeToViewByName.h
@@ -49,10 +49,6 @@ class INTERACTIONBASE_API CAddNodeToViewByName : public Command
 		QStringList findNames(QStringList nameParts, Model::Node* root);
 		Model::Node* findNode(QStringList fullyQualifiedName, Model::Node* root);
 		bool isSuggestable(Model::Node::SymbolTypes symbolType);
-
-		bool isHorizontal(QRect region);
-		Visualization::Item* findItemBelow(Visualization::ViewItem* view, QRect region);
-		Visualization::Item* findItemLeft(Visualization::ViewItem* view, QRect region);
 };
 
 }

--- a/InteractionBase/src/commands/CommandWithDefaultArguments.cpp
+++ b/InteractionBase/src/commands/CommandWithDefaultArguments.cpp
@@ -51,8 +51,11 @@ QList<CommandSuggestion*> CommandWithDefaultArguments::suggest(Visualization::It
 
 	if (textSoFar.trimmed().startsWith(this->name() + " ") || this->name().startsWith(textSoFar.trimmed()))
 	{
-		result.append(new CommandSuggestion(this->name(),
-			this->description(source, target, getParameters(textSoFar.split(" ")), cursor)));
+		auto parameters = getParameters(textSoFar.split(" "));
+		parameters.prepend(name());
+		if (canInterpret(source, target, parameters, cursor))
+			result.append(new CommandSuggestion(this->name(),
+				this->description(source, target, getParameters(textSoFar.split(" ")), cursor)));
 	}
 
 	return result;

--- a/InteractionBase/src/handlers/HViewItem.cpp
+++ b/InteractionBase/src/handlers/HViewItem.cpp
@@ -1,0 +1,52 @@
+/***********************************************************************************************************************
+ **
+ ** Copyright (c) 2015 ETH Zurich
+ ** All rights reserved.
+ **
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ ** following conditions are met:
+ **
+ **    * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ **      following disclaimer.
+ **    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ **      following disclaimer in the documentation and/or other materials provided with the distribution.
+ **    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+ **      derived from this software without specific prior written permission.
+ **
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ ** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ ** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ ** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ ** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **
+ **********************************************************************************************************************/
+
+#include "HViewItem.h"
+
+namespace Interaction {
+
+HViewItem::HViewItem()
+{
+}
+
+HViewItem* HViewItem::instance()
+{
+	static HViewItem h;
+	return &h;
+}
+
+void HViewItem::keyPressEvent(Visualization::Item *target, QKeyEvent *event)
+{
+	if (event->modifiers() == Qt::NoModifier && event->key() == Qt::Key_Return)
+	{
+		qDebug() << "Hello";
+		event->accept();
+		GenericHandler::showCommandPrompt(target, "add ");
+	}
+	else GenericHandler::keyPressEvent(target, event);
+}
+
+} /* namespace Interaction */

--- a/InteractionBase/src/handlers/HViewItem.cpp
+++ b/InteractionBase/src/handlers/HViewItem.cpp
@@ -41,11 +41,7 @@ HViewItem* HViewItem::instance()
 void HViewItem::keyPressEvent(Visualization::Item *target, QKeyEvent *event)
 {
 	if (event->modifiers() == Qt::NoModifier && event->key() == Qt::Key_Return)
-	{
-		qDebug() << "Hello";
-		event->accept();
 		GenericHandler::showCommandPrompt(target, "add ");
-	}
 	else GenericHandler::keyPressEvent(target, event);
 }
 

--- a/InteractionBase/src/handlers/HViewItem.h
+++ b/InteractionBase/src/handlers/HViewItem.h
@@ -1,0 +1,46 @@
+/***********************************************************************************************************************
+ **
+ ** Copyright (c) 2015 ETH Zurich
+ ** All rights reserved.
+ **
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ ** following conditions are met:
+ **
+ **    * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ **      following disclaimer.
+ **    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ **      following disclaimer in the documentation and/or other materials provided with the distribution.
+ **    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+ **      derived from this software without specific prior written permission.
+ **
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ ** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ ** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ ** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ ** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **
+ **********************************************************************************************************************/
+
+#pragma once
+
+#include "../interactionbase_api.h"
+
+#include "GenericHandler.h"
+
+namespace Interaction {
+
+class INTERACTIONBASE_API HViewItem : public GenericHandler
+{
+	public:
+		virtual void keyPressEvent(Visualization::Item *target, QKeyEvent *event) override;
+
+		static HViewItem* instance();
+
+	protected:
+		HViewItem();
+};
+
+} /* namespace Interaction */

--- a/VisualizationBase/src/ViewItemManager.cpp
+++ b/VisualizationBase/src/ViewItemManager.cpp
@@ -36,6 +36,8 @@ ViewItemManager::ViewItemManager(Scene* scene)
 	: scene_(scene)
 {
 	viewItems_.resize(VIEW_ITEM_COLUMNS);
+	currentViewItem_ = newViewItem("ProjectView");
+	currentViewItem_->show();
 }
 
 ViewItemManager::~ViewItemManager()


### PR DESCRIPTION
I added an improvement to the CAddNodeToViewByName command, where if one currently has the ViewItem itself selected, the new item is added at the current cursor's position (either inserting an item into a column, or inserting a column and a new item into it). Furthermore, I added a handler for the ViewItem, which on "Enter" opens a new command prompt with "add " already written to it.
