### PR TITLE
Fix adapt_classpath.sh

### DIFF
--- a/JavaImportTool/adapt_classpath.sh
+++ b/JavaImportTool/adapt_classpath.sh
@@ -3,7 +3,7 @@
 # Tries to adapt the .classpath file matching to your system.
 
 # Standard plug-in path can be overriden by argument
-PREFERRED_PLUGIN_PATHS=("/opt/eclipse/plugins" "/usr/share/eclipse/plugins")
+PREFERRED_PLUGIN_PATHS=("/opt/eclipse/plugins" "/usr/share/eclipse/plugins" "/usr/lib/eclipse/plugins")
 
 if [ ! -f .classpath ]
 then
@@ -11,7 +11,7 @@ then
 	exit 1
 fi
 
-PLUGIN_PATH=${ARRAY[0]}
+PLUGIN_PATH=${PREFERRED_PLUGIN_PATHS[0]}
 if [ $# == 1 ]
 then
 	PLUGIN_PATH=$1


### PR DESCRIPTION
Previously it wouldn't warn if no directory was found as PLUGIN_PATH was
initialized to empty. This lead to confusing error messages from the
basename command.

This commit properly initializes PLUGIN_PATH to the first entry of the
search paths. Additionally it add another path to search which is used
in newer version of ArchLinux/Eclipse.
