### PR TITLE
Add -Wimplicit-fallthrough for clang compilation

### DIFF
--- a/Core/common.pri
+++ b/Core/common.pri
@@ -6,6 +6,7 @@ CONFIG(debug, debug|release):DEFINES += DEBUG
 QMAKE_CXXFLAGS += -std=c++1y -pedantic-errors -Werror -Wextra -O2 -g -fno-omit-frame-pointer -Woverloaded-virtual
 
 clang:QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-private-field
+clang:QMAKE_CXXFLAGS += -Wimplicit-fallthrough
 
 QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN\''          # Used so that the main executable can link link to core
 QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN/qt\''       # Used so that the main executable can link to custom built Qt


### PR DESCRIPTION
The compiler should warn us about fall throughs in switch statement, as
that is usually not what we want.

gcc unfortunately does not have this warning.

See also: http://stackoverflow.com/a/27965827
