### PR TITLE
Fix CppImport to work with relative directories

### DIFF
--- a/CppImport/src/CppImportManager.cpp
+++ b/CppImport/src/CppImportManager.cpp
@@ -109,7 +109,7 @@ void CppImportManager::setupTest()
 		else if (testDir.startsWith("path:"))
 		{
 			testDir.replace(0, 5, "");
-			return setImportPath(QCoreApplication::applicationDirPath() + "/test" + testDir);
+			return setImportPath(QDir(QCoreApplication::applicationDirPath() + "/test" + testDir).absolutePath());
 		}
 		else if (testDir.startsWith("spath:"))
 		{


### PR DESCRIPTION
Extension to the commit:
https://github.com/lukedirtwalker/Envision/commit/b7dca227f62e626eec21a5a65e547797fd392dc4

Fix CppImport to work with relative directories in the 'path' case as well. 
