### PR TITLE
Graph api

### DIFF
--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -43,7 +43,9 @@ HEADERS += src/precompiled.h \
     src/queries/QueryExecutor.h \
     src/visualization/DefaultVisualizer.h \
     src/visitors/AllNodesOfType.h \
-    src/queries/CompositeQuery.h
+    src/queries/CompositeQuery.h \
+    src/queries/GenericFilter.h \
+    src/queries/AstNameFilter.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -60,7 +62,9 @@ SOURCES += src/InformationScriptingException.cpp \
     src/queries/AstQuery.cpp \
     src/queries/QueryExecutor.cpp \
     src/visualization/DefaultVisualizer.cpp \
-    src/queries/CompositeQuery.cpp
+    src/queries/CompositeQuery.cpp \
+    src/queries/GenericFilter.cpp \
+    src/queries/AstNameFilter.cpp
 
 
 # HACK to only include the AstApi_Generated file if it exists.

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -41,7 +41,8 @@ HEADERS += src/precompiled.h \
     src/queries/Query.h \
     src/queries/AstQuery.h \
     src/queries/QueryExecutor.h \
-    src/visualization/DefaultVisualizer.h
+    src/visualization/DefaultVisualizer.h \
+    src/visitors/AllNodesOfType.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -46,7 +46,7 @@ HEADERS += src/precompiled.h \
     src/queries/CompositeQuery.h \
     src/queries/GenericFilter.h \
     src/queries/AstNameFilter.h \
-    src/queries/ComplementOperator.h
+    src/queries/SubstractNodesOperator.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -66,7 +66,7 @@ SOURCES += src/InformationScriptingException.cpp \
     src/queries/CompositeQuery.cpp \
     src/queries/GenericFilter.cpp \
     src/queries/AstNameFilter.cpp \
-    src/queries/ComplementOperator.cpp
+    src/queries/SubstractNodesOperator.cpp
 
 
 # HACK to only include the AstApi_Generated file if it exists.

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -40,7 +40,8 @@ HEADERS += src/precompiled.h \
     src/sources/AstSource.h \
     src/queries/Query.h \
     src/queries/AstQuery.h \
-    src/queries/QueryExecutor.h
+    src/queries/QueryExecutor.h \
+    src/visualization/DefaultVisualizer.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -55,7 +56,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/graph/InformationEdge.cpp \
     src/sources/AstSource.cpp \
     src/queries/AstQuery.cpp \
-    src/queries/QueryExecutor.cpp
+    src/queries/QueryExecutor.cpp \
+    src/visualization/DefaultVisualizer.cpp
 
 
 # HACK to only include the AstApi_Generated file if it exists.

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -42,7 +42,8 @@ HEADERS += src/precompiled.h \
     src/queries/AstQuery.h \
     src/queries/QueryExecutor.h \
     src/visualization/DefaultVisualizer.h \
-    src/visitors/AllNodesOfType.h
+    src/visitors/AllNodesOfType.h \
+    src/queries/CompositeQuery.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -58,7 +59,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/sources/AstSource.cpp \
     src/queries/AstQuery.cpp \
     src/queries/QueryExecutor.cpp \
-    src/visualization/DefaultVisualizer.cpp
+    src/visualization/DefaultVisualizer.cpp \
+    src/queries/CompositeQuery.cpp
 
 
 # HACK to only include the AstApi_Generated file if it exists.

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -45,7 +45,8 @@ HEADERS += src/precompiled.h \
     src/visitors/AllNodesOfType.h \
     src/queries/CompositeQuery.h \
     src/queries/GenericFilter.h \
-    src/queries/AstNameFilter.h
+    src/queries/AstNameFilter.h \
+    src/queries/ComplementOperator.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -64,7 +65,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/visualization/DefaultVisualizer.cpp \
     src/queries/CompositeQuery.cpp \
     src/queries/GenericFilter.cpp \
-    src/queries/AstNameFilter.cpp
+    src/queries/AstNameFilter.cpp \
+    src/queries/ComplementOperator.cpp
 
 
 # HACK to only include the AstApi_Generated file if it exists.

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -36,7 +36,8 @@ HEADERS += src/precompiled.h \
     src/wrappers/NodeApi.h \
     src/graph/PropertyMap.h \
     src/graph/Graph.h \
-    src/graph/InformationEdge.h
+    src/graph/InformationEdge.h \
+    src/sources/AstSource.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -48,7 +49,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/graph/PropertyMap.cpp \
     src/graph/Property.cpp \
     src/graph/Graph.cpp \
-    src/graph/InformationEdge.cpp
+    src/graph/InformationEdge.cpp \
+    src/sources/AstSource.cpp
 
 
 # HACK to only include the AstApi_Generated file if it exists.

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -37,7 +37,10 @@ HEADERS += src/precompiled.h \
     src/graph/PropertyMap.h \
     src/graph/Graph.h \
     src/graph/InformationEdge.h \
-    src/sources/AstSource.h
+    src/sources/AstSource.h \
+    src/queries/Query.h \
+    src/queries/AstQuery.h \
+    src/queries/QueryExecutor.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -50,7 +53,9 @@ SOURCES += src/InformationScriptingException.cpp \
     src/graph/Property.cpp \
     src/graph/Graph.cpp \
     src/graph/InformationEdge.cpp \
-    src/sources/AstSource.cpp
+    src/sources/AstSource.cpp \
+    src/queries/AstQuery.cpp \
+    src/queries/QueryExecutor.cpp
 
 
 # HACK to only include the AstApi_Generated file if it exists.

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -34,8 +34,9 @@ HEADERS += src/precompiled.h \
     src/graph/InformationNode.h \
     src/graph/Property.h \
     src/wrappers/NodeApi.h \
-    src/graph/PropertyMap.h
-
+    src/graph/PropertyMap.h \
+    src/graph/Graph.h \
+    src/graph/InformationEdge.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -45,7 +46,9 @@ SOURCES += src/InformationScriptingException.cpp \
     src/graph/InformationNode.cpp \
     src/wrappers/NodeApi.cpp \
     src/graph/PropertyMap.cpp \
-    src/graph/Property.cpp
+    src/graph/Property.cpp \
+    src/graph/Graph.cpp \
+    src/graph/InformationEdge.cpp
 
 
 # HACK to only include the AstApi_Generated file if it exists.

--- a/InformationScripting/src/InformationScriptingPlugin.cpp
+++ b/InformationScripting/src/InformationScriptingPlugin.cpp
@@ -32,6 +32,7 @@
 
 #include "commands/CScript.h"
 #include "helpers/BoostPythonHelpers.h"
+#include "sources/AstSource.h"
 
 #include "visitors/AllNodesOfType.h"
 
@@ -40,6 +41,7 @@ namespace InformationScripting {
 bool InformationScriptingPlugin::initialize(Core::EnvisionManager&)
 {
 	BoostPythonHelpers::initializeQStringConverters();
+	AstSource::init();
 	AllNodesOfType<OOModel::Method>::init();
 	OOInteraction::HStatementItemList::instance()->addCommand(new CScript());
 	return true;

--- a/InformationScripting/src/InformationScriptingPlugin.cpp
+++ b/InformationScripting/src/InformationScriptingPlugin.cpp
@@ -28,15 +28,19 @@
 #include "SelfTest/src/SelfTestSuite.h"
 
 #include "OOInteraction/src/handlers/HStatementItemList.h"
+#include "OOModel/src/declarations/Method.h"
 
 #include "commands/CScript.h"
 #include "helpers/BoostPythonHelpers.h"
+
+#include "visitors/AllNodesOfType.h"
 
 namespace InformationScripting {
 
 bool InformationScriptingPlugin::initialize(Core::EnvisionManager&)
 {
 	BoostPythonHelpers::initializeQStringConverters();
+	AllNodesOfType<OOModel::Method>::init();
 	OOInteraction::HStatementItemList::instance()->addCommand(new CScript());
 	return true;
 }

--- a/InformationScripting/src/InformationScriptingPlugin.cpp
+++ b/InformationScripting/src/InformationScriptingPlugin.cpp
@@ -29,6 +29,7 @@
 
 #include "OOInteraction/src/handlers/HStatementItemList.h"
 #include "OOModel/src/declarations/Method.h"
+#include "OOModel/src/declarations/Class.h"
 
 #include "commands/CScript.h"
 #include "helpers/BoostPythonHelpers.h"
@@ -43,6 +44,7 @@ bool InformationScriptingPlugin::initialize(Core::EnvisionManager&)
 	BoostPythonHelpers::initializeQStringConverters();
 	AstSource::init();
 	AllNodesOfType<OOModel::Method>::init();
+	AllNodesOfType<OOModel::Class>::init();
 	OOInteraction::HStatementItemList::instance()->addCommand(new CScript());
 	return true;
 }

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -37,7 +37,7 @@
 #include "../queries/QueryExecutor.h"
 #include "../queries/CompositeQuery.h"
 #include "../queries/AstNameFilter.h"
-#include "../queries/ComplementOperator.h"
+#include "../queries/SubstractNodesOperator.h"
 #include "../sources/AstSource.h"
 
 namespace InformationScripting {
@@ -153,7 +153,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 		// Find all methods that are not called transitively from the TARGET method.
 		auto allMethodsQuery = AstSource::instance().createMethodQuery(node, {"g"});
 		auto callGraphQuery = AstSource::instance().createCallgraphQuery(node, args);
-		auto complement = new ComplementOperator();
+		auto complement = new SubstractNodesOperator();
 		auto compositeQuery = new CompositeQuery();
 		compositeQuery->connectQuery(allMethodsQuery, complement);
 		compositeQuery->connectQuery(callGraphQuery, 0, complement, 1);

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -27,6 +27,8 @@
 #include "CScript.h"
 
 #include "ModelBase/src/nodes/Node.h"
+#include "ModelBase/src/SymbolMatcher.h"
+
 #include "OOModel/src/declarations/Class.h"
 #include "OOModel/src/declarations/Method.h"
 
@@ -125,9 +127,9 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 		// Find all classes for which the name contains X and which have a method named Y
 		// 5 queries seems like a lot for this :S
 		auto classesQuery = new AstQuery(AstQuery::QueryType::Classes, node, {"g"});
-		auto filterQuery = new AstNameFilter("Matcher");
+		auto filterQuery = new AstNameFilter(Model::SymbolMatcher(new QRegExp("\\w*Matcher\\w*")));
 		auto methodsOfQuery = new AstQuery(AstQuery::QueryType::Methods, node, {"of"});
-		auto methodsFilter = new AstNameFilter("matches", true);
+		auto methodsFilter = new AstNameFilter(Model::SymbolMatcher("matches"));
 		auto toBaseQuery = new AstQuery(AstQuery::QueryType::ToClass, node, args);
 		auto compositeQuery = new CompositeQuery();
 		compositeQuery->connectQuery(classesQuery, filterQuery);

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -124,12 +124,18 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 	else if (command == "query21")
 	{
 		// Find all classes for which the name contains X and which have a method named Y
-		// TODO currently we only have the classes with name part
+		// 5 queries seems like a lot for this :S
 		auto classesQuery = AstSource::instance().createClassesQuery(node, {"g"});
 		auto filterQuery = new AstNameFilter("Matcher");
+		auto methodsOfQuery = AstSource::instance().createMethodQuery(node, {"of"});
+		auto methodsFilter = new AstNameFilter("matches", true);
+		auto toBaseQuery = AstSource::instance().createToClassNodeQuery(node, args);
 		auto compositeQuery = new CompositeQuery();
 		compositeQuery->connectQuery(classesQuery, filterQuery);
-		compositeQuery->connectToOutput(filterQuery);
+		compositeQuery->connectQuery(filterQuery, methodsOfQuery);
+		compositeQuery->connectQuery(methodsOfQuery, methodsFilter);
+		compositeQuery->connectQuery(methodsFilter, toBaseQuery);
+		compositeQuery->connectToOutput(toBaseQuery);
 		QueryExecutor queryExecutor(compositeQuery);
 		queryExecutor.execute();
 	}

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -35,6 +35,7 @@
 #include "../helpers/BoostPythonHelpers.h"
 #include "../graph/InformationNode.h"
 #include "../queries/QueryExecutor.h"
+#include "../queries/CompositeQuery.h"
 #include "../sources/AstSource.h"
 
 namespace InformationScripting {
@@ -98,7 +99,9 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 	else if (command == "methods")
 	{
 		auto query = AstSource::instance().createMethodQuery(node, args);
-		QueryExecutor queryExecutor(query);
+		auto compositeQuery = new CompositeQuery();
+		compositeQuery->connectToOutput(query);
+		QueryExecutor queryExecutor(compositeQuery);
 		queryExecutor.execute();
 	}
 	else if (command == "bases")

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -37,6 +37,7 @@
 #include "../queries/QueryExecutor.h"
 #include "../queries/CompositeQuery.h"
 #include "../queries/AstNameFilter.h"
+#include "../queries/ComplementOperator.h"
 #include "../sources/AstSource.h"
 
 namespace InformationScripting {
@@ -144,6 +145,19 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 		auto query = AstSource::instance().createCallgraphQuery(node, args);
 		auto compositeQuery = new CompositeQuery();
 		compositeQuery->connectToOutput(query);
+		QueryExecutor queryExecutor(compositeQuery);
+		queryExecutor.execute();
+	}
+	else if (command == "query19")
+	{
+		// Find all methods that are not called transitively from the TARGET method.
+		auto allMethodsQuery = AstSource::instance().createMethodQuery(node, {"g"});
+		auto callGraphQuery = AstSource::instance().createCallgraphQuery(node, args);
+		auto complement = new ComplementOperator();
+		auto compositeQuery = new CompositeQuery();
+		compositeQuery->connectQuery(allMethodsQuery, complement);
+		compositeQuery->connectQuery(callGraphQuery, 0, complement, 1);
+		compositeQuery->connectToOutput(complement);
 		QueryExecutor queryExecutor(compositeQuery);
 		queryExecutor.execute();
 	}

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -77,8 +77,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 			for (auto method : *parentClass->methods())
 			{
 				// TODO: this leaks currently
-				auto infoNode = new InformationNode();
-				infoNode->insert("ast", method);
+				auto infoNode = new InformationNode({{"ast", method}});
 				methods.append(python::ptr(infoNode));
 			}
 

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -56,7 +56,12 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 	Q_ASSERT(node);
 
 	QStringList args = commandTokens.mid(1);
-	if (args[0] == "script")
+	if (!args.size()) new Interaction::CommandResult();
+
+	QString command = args[0];
+	args = args.mid(1);
+
+	if (command == "script")
 	{
 
 		auto parentClass = node->firstAncestorOfType<OOModel::Class>();
@@ -90,15 +95,15 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 			qDebug() << "Error in Python: " << BoostPythonHelpers::parsePythonException();
 		}
 	}
-	else if (args[0] == "methods")
+	else if (command == "methods")
 	{
-		auto query = AstSource::instance().createMethodQuery(node);
+		auto query = AstSource::instance().createMethodQuery(node, args);
 		QueryExecutor queryExecutor(query);
 		queryExecutor.execute();
 	}
-	else if (args[0] == "bases")
+	else if (command == "bases")
 	{
-		auto query = AstSource::instance().createBaseClassesQuery(node);
+		auto query = AstSource::instance().createBaseClassesQuery(node, args);
 		QueryExecutor queryExecutor(query);
 		queryExecutor.execute();
 	}

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -34,6 +34,8 @@
 #include "../wrappers/NodeApi.h"
 #include "../helpers/BoostPythonHelpers.h"
 #include "../graph/InformationNode.h"
+#include "../queries/QueryExecutor.h"
+#include "../sources/AstSource.h"
 
 namespace InformationScripting {
 
@@ -50,11 +52,12 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 {
 	using namespace boost;
 
+	auto node = target->node();
+	Q_ASSERT(node);
+
 	QStringList args = commandTokens.mid(1);
-	if (args[0] == "methods")
+	if (args[0] == "script")
 	{
-		auto node = target->node();
-		Q_ASSERT(node);
 
 		auto parentClass = node->firstAncestorOfType<OOModel::Class>();
 
@@ -87,6 +90,12 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 		} catch (python::error_already_set ) {
 			qDebug() << "Error in Python: " << BoostPythonHelpers::parsePythonException();
 		}
+	}
+	else if (args[0] == "methods")
+	{
+		auto query = AstSource::instance().createMethodQuery(node);
+		QueryExecutor queryExecutor(query);
+		queryExecutor.execute();
 	}
 	return new Interaction::CommandResult();
 }

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -139,6 +139,14 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 		QueryExecutor queryExecutor(compositeQuery);
 		queryExecutor.execute();
 	}
+	else if (command == "callgraph")
+	{
+		auto query = AstSource::instance().createCallgraphQuery(node, args);
+		auto compositeQuery = new CompositeQuery();
+		compositeQuery->connectToOutput(query);
+		QueryExecutor queryExecutor(compositeQuery);
+		queryExecutor.execute();
+	}
 	return new Interaction::CommandResult();
 }
 

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -38,7 +38,7 @@
 #include "../queries/CompositeQuery.h"
 #include "../queries/AstNameFilter.h"
 #include "../queries/SubstractNodesOperator.h"
-#include "../sources/AstSource.h"
+#include "../queries/AstQuery.h"
 
 namespace InformationScripting {
 
@@ -100,20 +100,20 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 	}
 	else if (command == "methods")
 	{
-		auto query = AstSource::instance().createMethodQuery(node, args);
+		auto query = new AstQuery(AstQuery::QueryType::Methods, node, args);
 		QueryExecutor queryExecutor(query);
 		queryExecutor.execute();
 	}
 	else if (command == "bases")
 	{
-		auto query = AstSource::instance().createBaseClassesQuery(node, args);
+		auto query = new AstQuery(AstQuery::QueryType::BaseClasses, node, args);
 		QueryExecutor queryExecutor(query);
 		queryExecutor.execute();
 	}
 	else if (command == "pipe")
 	{
-		auto methodQuery = AstSource::instance().createMethodQuery(node, args);
-		auto toBaseQuery = AstSource::instance().createToClassNodeQuery(node, args);
+		auto methodQuery = new AstQuery(AstQuery::QueryType::Methods, node, args);
+		auto toBaseQuery = new AstQuery(AstQuery::QueryType::ToClass, node, args);
 		auto compositeQuery = new CompositeQuery();
 		compositeQuery->connectQuery(methodQuery, toBaseQuery);
 		compositeQuery->connectToOutput(toBaseQuery);
@@ -124,11 +124,11 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 	{
 		// Find all classes for which the name contains X and which have a method named Y
 		// 5 queries seems like a lot for this :S
-		auto classesQuery = AstSource::instance().createClassesQuery(node, {"g"});
+		auto classesQuery = new AstQuery(AstQuery::QueryType::Classes, node, {"g"});
 		auto filterQuery = new AstNameFilter("Matcher");
-		auto methodsOfQuery = AstSource::instance().createMethodQuery(node, {"of"});
+		auto methodsOfQuery = new AstQuery(AstQuery::QueryType::Methods, node, {"of"});
 		auto methodsFilter = new AstNameFilter("matches", true);
-		auto toBaseQuery = AstSource::instance().createToClassNodeQuery(node, args);
+		auto toBaseQuery = new AstQuery(AstQuery::QueryType::ToClass, node, args);
 		auto compositeQuery = new CompositeQuery();
 		compositeQuery->connectQuery(classesQuery, filterQuery);
 		compositeQuery->connectQuery(filterQuery, methodsOfQuery);
@@ -140,7 +140,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 	}
 	else if (command == "callgraph")
 	{
-		auto query = AstSource::instance().createCallgraphQuery(node, args);
+		auto query = new AstQuery(AstQuery::QueryType::CallGraph, node, args);
 		auto compositeQuery = new CompositeQuery();
 		compositeQuery->connectToOutput(query);
 		QueryExecutor queryExecutor(compositeQuery);
@@ -149,8 +149,8 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 	else if (command == "query19")
 	{
 		// Find all methods that are not called transitively from the TARGET method.
-		auto allMethodsQuery = AstSource::instance().createMethodQuery(node, {"g"});
-		auto callGraphQuery = AstSource::instance().createCallgraphQuery(node, args);
+		auto allMethodsQuery = new AstQuery(AstQuery::QueryType::Methods, node, {"g"});
+		auto callGraphQuery = new AstQuery(AstQuery::QueryType::CallGraph, node, args);
 		auto complement = new SubstractNodesOperator();
 		auto compositeQuery = new CompositeQuery();
 		compositeQuery->connectQuery(allMethodsQuery, complement);

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -101,9 +101,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 	else if (command == "methods")
 	{
 		auto query = AstSource::instance().createMethodQuery(node, args);
-		auto compositeQuery = new CompositeQuery();
-		compositeQuery->connectToOutput(query);
-		QueryExecutor queryExecutor(compositeQuery);
+		QueryExecutor queryExecutor(query);
 		queryExecutor.execute();
 	}
 	else if (command == "bases")

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -36,6 +36,7 @@
 #include "../graph/InformationNode.h"
 #include "../queries/QueryExecutor.h"
 #include "../queries/CompositeQuery.h"
+#include "../queries/AstNameFilter.h"
 #include "../sources/AstSource.h"
 
 namespace InformationScripting {
@@ -117,6 +118,18 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 		auto compositeQuery = new CompositeQuery();
 		compositeQuery->connectQuery(methodQuery, toBaseQuery);
 		compositeQuery->connectToOutput(toBaseQuery);
+		QueryExecutor queryExecutor(compositeQuery);
+		queryExecutor.execute();
+	}
+	else if (command == "query21")
+	{
+		// Find all classes for which the name contains X and which have a method named Y
+		// TODO currently we only have the classes with name part
+		auto classesQuery = AstSource::instance().createClassesQuery(node, {"g"});
+		auto filterQuery = new AstNameFilter("Matcher");
+		auto compositeQuery = new CompositeQuery();
+		compositeQuery->connectQuery(classesQuery, filterQuery);
+		compositeQuery->connectToOutput(filterQuery);
 		QueryExecutor queryExecutor(compositeQuery);
 		queryExecutor.execute();
 	}

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -97,6 +97,12 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 		QueryExecutor queryExecutor(query);
 		queryExecutor.execute();
 	}
+	else if (args[0] == "bases")
+	{
+		auto query = AstSource::instance().createBaseClassesQuery(node);
+		QueryExecutor queryExecutor(query);
+		queryExecutor.execute();
+	}
 	return new Interaction::CommandResult();
 }
 

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -110,6 +110,16 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 		QueryExecutor queryExecutor(query);
 		queryExecutor.execute();
 	}
+	else if (command == "pipe")
+	{
+		auto methodQuery = AstSource::instance().createMethodQuery(node, args);
+		auto toBaseQuery = AstSource::instance().createToClassNodeQuery(node, args);
+		auto compositeQuery = new CompositeQuery();
+		compositeQuery->connectQuery(methodQuery, toBaseQuery);
+		compositeQuery->connectToOutput(toBaseQuery);
+		QueryExecutor queryExecutor(compositeQuery);
+		queryExecutor.execute();
+	}
 	return new Interaction::CommandResult();
 }
 

--- a/InformationScripting/src/graph/Graph.cpp
+++ b/InformationScripting/src/graph/Graph.cpp
@@ -106,10 +106,15 @@ void Graph::remove(InformationNode* node)
 	// If the node isn't in the graph we don't have to do anything:
 	if (nodeIt == nodes_.end()) return;
 
+	// It could be that node points to a different node with the same hash.
+	// TODO in this case we might also want to merge the infos?
+	auto ownedNode = node;
+	if (ownedNode != *nodeIt) ownedNode = *nodeIt;
+
 	for (auto edgeIt = edges_.begin(); edgeIt != edges_.end();)
 	{
 		auto edge = *edgeIt;
-		if (edge->from() == node || edge->to() == node)
+		if (edge->from() == ownedNode || edge->to() == ownedNode)
 		{
 			SAFE_DELETE(edge);
 			edgeIt = edges_.erase(edgeIt);
@@ -120,7 +125,7 @@ void Graph::remove(InformationNode* node)
 		}
 	}
 
-	SAFE_DELETE(node);
+	SAFE_DELETE(ownedNode);
 	nodes_.erase(nodeIt);
 }
 

--- a/InformationScripting/src/graph/Graph.cpp
+++ b/InformationScripting/src/graph/Graph.cpp
@@ -62,10 +62,22 @@ InformationNode* Graph::add(InformationNode* node)
 	return node;
 }
 
-InformationEdge* Graph::addDirectedEdge(InformationNode*, InformationNode*, const QString&)
+InformationEdge* Graph::addDirectedEdge(InformationNode* from, InformationNode* to, const QString& name)
 {
-	// TODO
-	return nullptr;
+	// TODO what if from/to is not yet in the graph?
+	for (auto edge : edges_)
+	{
+		if (edge->from() == from && edge->to() == to && edge->name() == name)
+		{
+			auto existingEdge = edge;
+			Q_ASSERT(existingEdge->isDirected());
+			existingEdge->incrementCount();
+			return existingEdge;
+		}
+	}
+	auto edge = new InformationEdge(from, to, name);
+	edges_.push_back(edge);
+	return edge;
 }
 
 InformationEdge* Graph::addEdge(InformationNode*, InformationNode*, const QString&)
@@ -93,10 +105,11 @@ QList<InformationNode*> Graph::nodesForWhich(Graph::NodeCondition holds) const
 	return result;
 }
 
-QList<InformationNode*> Graph::edgesFowWhich(Graph::EdgeCondition) const
+QList<InformationEdge*> Graph::edgesFowWhich(Graph::EdgeCondition holds) const
 {
-	// TODO
-	return {};
+	QList<InformationEdge*> result;
+	for (auto edge : edges_) if (holds(edge)) result.push_back(edge);
+	return result;
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/Graph.cpp
+++ b/InformationScripting/src/graph/Graph.cpp
@@ -52,7 +52,7 @@ InformationNode* Graph::add(InformationNode* node)
 	}
 	else
 	{
-		nodes_[hashValueOf(node)] = node;
+		nodes_[hashOf(node)] = node;
 		existingNode = node;
 	}
 	return existingNode;
@@ -101,7 +101,7 @@ InformationEdge* Graph::addEdge(InformationNode* a, InformationNode* b, const QS
 void Graph::remove(InformationNode* node)
 {
 	Q_ASSERT(node);
-	auto hash = hashValueOf(node);
+	auto hash = hashOf(node);
 	auto nodeIt = nodes_.find(hash);
 	// If the node isn't in the graph we don't have to do anything:
 	if (nodeIt == nodes_.end()) return;
@@ -120,9 +120,7 @@ void Graph::remove(InformationNode* node)
 			edgeIt = edges_.erase(edgeIt);
 		}
 		else
-		{
 			++edgeIt;
-		}
 	}
 
 	SAFE_DELETE(ownedNode);
@@ -134,30 +132,25 @@ void Graph::remove(QList<InformationNode*> nodes)
 	for (auto node : nodes) remove(node);
 }
 
-QList<InformationNode*> Graph::nodes() const
+QList<InformationNode*> Graph::nodes(Graph::NodeCondition holds) const
 {
-	return nodes_.values();
-}
-
-QList<InformationNode*> Graph::nodesForWhich(Graph::NodeCondition holds) const
-{
-	Q_ASSERT(holds);
+	if (!holds) return nodes_.values();
 
 	QList<InformationNode*> result;
 	for (auto node : nodes_) if (holds(node)) result.push_back(node);
 	return result;
 }
 
-QList<InformationEdge*> Graph::edgesFowWhich(Graph::EdgeCondition holds) const
+QList<InformationEdge*> Graph::edges(Graph::EdgeCondition holds) const
 {
-	Q_ASSERT(holds);
+	if (!holds) return edges_;
 
 	QList<InformationEdge*> result;
 	for (auto edge : edges_) if (holds(edge)) result.push_back(edge);
 	return result;
 }
 
-std::size_t Graph::hashValueOf(const InformationNode* n) const
+std::size_t Graph::hashOf(const InformationNode* n) const
 {
 	for (auto hashFunction : nodeHashFunctions_)
 	{
@@ -170,7 +163,7 @@ std::size_t Graph::hashValueOf(const InformationNode* n) const
 
 InformationNode*Graph::findNode(const InformationNode* n) const
 {
-	auto hash = hashValueOf(n);
+	auto hash = hashOf(n);
 	auto it = nodes_.find(hash);
 	if (it != nodes_.end()) return it.value();
 	return nullptr;

--- a/InformationScripting/src/graph/Graph.cpp
+++ b/InformationScripting/src/graph/Graph.cpp
@@ -100,22 +100,38 @@ InformationEdge* Graph::addEdge(InformationNode* a, InformationNode* b, const QS
 
 void Graph::remove(InformationNode* node)
 {
+	Q_ASSERT(node);
+	auto hash = hashValueOf(node);
+	auto nodeIt = nodes_.find(hash);
+	// If the node isn't in the graph we don't have to do anything:
+	if (nodeIt == nodes_.end()) return;
+
 	for (auto edgeIt = edges_.begin(); edgeIt != edges_.end();)
 	{
 		auto edge = *edgeIt;
 		if (edge->from() == node || edge->to() == node)
+		{
+			SAFE_DELETE(edge);
 			edgeIt = edges_.erase(edgeIt);
+		}
 		else
+		{
 			++edgeIt;
+		}
 	}
 
-	auto nodeIt = std::find(nodes_.begin(), nodes_.end(), node);
+	SAFE_DELETE(node);
 	nodes_.erase(nodeIt);
 }
 
 void Graph::remove(QList<InformationNode*> nodes)
 {
 	for (auto node : nodes) remove(node);
+}
+
+QList<InformationNode*> Graph::nodes() const
+{
+	return nodes_.values();
 }
 
 QList<InformationNode*> Graph::nodesForWhich(Graph::NodeCondition holds) const

--- a/InformationScripting/src/graph/Graph.cpp
+++ b/InformationScripting/src/graph/Graph.cpp
@@ -27,7 +27,6 @@
 #include "Graph.h"
 
 #include "InformationNode.h"
-#include "InformationEdge.h"
 
 namespace InformationScripting {
 
@@ -58,42 +57,28 @@ InformationNode* Graph::add(InformationNode* node)
 	return existingNode;
 }
 
-InformationEdge* Graph::addDirectedEdge(InformationNode* from, InformationNode* to, const QString& name)
+InformationEdge* Graph::addEdge(InformationNode* from, InformationNode* to, const QString& name,
+										  InformationEdge::Orientation orientation)
 {
 	// We only allow existing nodes:
 	Q_ASSERT(from == findNode(from));
 	Q_ASSERT(to == findNode(to));
+	// TODO this might be a possible performance hit if we have many edges.
 	for (auto edge : edges_)
 	{
-		if (edge->from() == from && edge->to() == to && edge->name() == name)
+		// TODO if directed only this condition
+		bool directedMatch = edge->from() == from && edge->to() == to;
+		bool undirectedMatch = edge->from() == to && edge->to() == from;
+		if (edge->name() == name && ((orientation == InformationEdge::Orientation::Directed && directedMatch)
+							|| (orientation == InformationEdge::Orientation::Directed && (directedMatch || undirectedMatch))))
 		{
 			auto existingEdge = edge;
-			Q_ASSERT(existingEdge->isDirected());
+			Q_ASSERT(existingEdge->orientation() == orientation);
 			existingEdge->incrementCount();
 			return existingEdge;
 		}
 	}
-	auto edge = new InformationEdge(from, to, name);
-	edges_.push_back(edge);
-	return edge;
-}
-
-InformationEdge* Graph::addEdge(InformationNode* a, InformationNode* b, const QString& name)
-{
-	// We only allow existing nodes:
-	Q_ASSERT(a == findNode(a));
-	Q_ASSERT(b == findNode(b));
-	for (auto edge : edges_)
-	{
-		if ((edge->from() == a || edge->from() == b) && (edge->to() == b || edge->to() == a) && edge->name() == name)
-		{
-			auto existingEdge = edge;
-			Q_ASSERT(!existingEdge->isDirected());
-			existingEdge->incrementCount();
-			return existingEdge;
-		}
-	}
-	auto edge = new InformationEdge(a, b, name, InformationEdge::Orientation::Undirected);
+	auto edge = new InformationEdge(from, to, name, orientation);
 	edges_.push_back(edge);
 	return edge;
 }

--- a/InformationScripting/src/graph/Graph.cpp
+++ b/InformationScripting/src/graph/Graph.cpp
@@ -31,12 +31,14 @@
 
 namespace InformationScripting {
 
-void Graph::add(InformationNode*& node)
+QList<Graph::IsEqual> Graph::equalityChecks_;
+
+InformationNode* Graph::add(InformationNode* node)
 {
 	InformationNode* existingNode = nullptr;
 	for (auto graphNode : nodes_)
 	{
-		for (auto checker : sameCheckers_)
+		for (auto checker : equalityChecks_)
 		{
 			if (checker(graphNode, node))
 			{
@@ -46,8 +48,18 @@ void Graph::add(InformationNode*& node)
 		}
 		if (existingNode) break;
 	}
-	if (existingNode) node = existingNode;
-	else nodes_.push_back(node);
+	if (existingNode)
+	{
+		// TODO merge
+		// TODO delete argument node
+		node = existingNode;
+		Q_ASSERT(false);
+	}
+	else
+	{
+		nodes_.push_back(node);
+	}
+	return node;
 }
 
 InformationEdge* Graph::addDirectedEdge(InformationNode*, InformationNode*, const QString&)

--- a/InformationScripting/src/graph/Graph.cpp
+++ b/InformationScripting/src/graph/Graph.cpp
@@ -24,24 +24,67 @@
 **
 ***********************************************************************************************************************/
 
-#pragma once
+#include "Graph.h"
 
-#include "../informationscripting_api.h"
-
-#include "Property.h"
-#include "PropertyMap.h"
+#include "InformationNode.h"
+#include "InformationEdge.h"
 
 namespace InformationScripting {
 
-class InformationEdge;
-class Graph;
-
-class INFORMATIONSCRIPTING_API InformationNode : public PropertyMap
+void Graph::add(InformationNode*& node)
 {
-	private:
-		friend class Graph;
+	InformationNode* existingNode = nullptr;
+	for (auto graphNode : nodes_)
+	{
+		for (auto checker : sameCheckers_)
+		{
+			if (checker(graphNode, node))
+			{
+				existingNode = graphNode;
+				break;
+			}
+		}
+		if (existingNode) break;
+	}
+	if (existingNode) node = existingNode;
+	else nodes_.push_back(node);
+}
 
-		QList<QPair<QString, InformationEdge*>> incidentEdges_;
-};
+InformationEdge* Graph::addDirectedEdge(InformationNode*, InformationNode*, const QString&)
+{
+	// TODO
+	return nullptr;
+}
+
+InformationEdge* Graph::addEdge(InformationNode*, InformationNode*, const QString&)
+{
+	// TODO
+	return nullptr;
+}
+
+void Graph::remove(InformationNode*)
+{
+	// TODO
+}
+
+void Graph::remove(QList<InformationNode*> nodes)
+{
+	for (auto node : nodes) remove(node);
+}
+
+QList<InformationNode*> Graph::nodesForWhich(Graph::NodeCondition holds) const
+{
+	Q_ASSERT(holds);
+
+	QList<InformationNode*> result;
+	for (auto node : nodes_) if (holds(node)) result.push_back(node);
+	return result;
+}
+
+QList<InformationNode*> Graph::edgesFowWhich(Graph::EdgeCondition) const
+{
+	// TODO
+	return {};
+}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/Graph.h
+++ b/InformationScripting/src/graph/Graph.h
@@ -28,9 +28,10 @@
 
 #include "../informationscripting_api.h"
 
+#include "InformationEdge.h"
+
 namespace InformationScripting {
 
-class InformationEdge;
 class InformationNode;
 
 class Graph
@@ -59,29 +60,17 @@ class Graph
 		InformationNode* add(InformationNode* node);
 
 		/**
-		 * Creates a directed Edge from \a from to \a to with the name \a name.
+		 * Creates an Edge from \a from to \a to with the name \a name.
 		 *
-		 * Returns the directed connection between \a from and \a to.
+		 * Returns the Edge with orientation \a orientation between \a from and \a to.
 		 *
-		 * If there is already a directed edge with the same \a name between \a from and \a to,
+		 * If there is already an edge with the same \a name and \a orientation between \a from and \a to,
 		 * the existing edge is returned with the count property increased.
 		 *
 		 * Note: The graph owns the returned edge.
 		 */
-		InformationEdge* addDirectedEdge(InformationNode* from, InformationNode* to, const QString& name);
-
-		/**
-		 * Connects \a a to \a b with an indirected edge with the name \a name.
-		 *
-		 * Returns the undirected connection between \a a and \a b.
-		 *
-		 * If there is already a undirected edge with the same \a name between \a a and \a b,
-		 * the existing edge is returned with the count property increased.
-		 *
-		 * Note: The graph owns the returned edge.
-		 */
-		InformationEdge* addEdge(InformationNode* a, InformationNode* b, const QString& name);
-
+		InformationEdge* addEdge(InformationNode* from, InformationNode* to, const QString& name,
+													InformationEdge::Orientation orientation = InformationEdge::Orientation::Directed);
 
 		/**
 		 * Removes the \a node and all edges to it.

--- a/InformationScripting/src/graph/Graph.h
+++ b/InformationScripting/src/graph/Graph.h
@@ -111,6 +111,15 @@ class Graph
 		QList<InformationEdge*> edges_;
 
 		std::size_t hashValueOf(const InformationNode* n) const;
+		/**
+		 * Checks if there is a node in the graph with the same hash value as \a n,
+		 * if there is the pointer to this node is returned, otherwise a null pointer is returned.
+		 */
+		InformationNode* findNode(const InformationNode* n) const;
+		/**
+		 * Merges the information of 2 nodes into the node \a into.
+		 */
+		void mergeNodes(InformationNode* into, InformationNode* from);
 
 };
 

--- a/InformationScripting/src/graph/Graph.h
+++ b/InformationScripting/src/graph/Graph.h
@@ -1,0 +1,120 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../informationscripting_api.h"
+
+namespace InformationScripting {
+
+class InformationEdge;
+class InformationNode;
+
+class Graph
+{
+	public:
+		/**
+		 * SameCheck takes 2 nodes and returns if they are the same for some data source.
+		 */
+		using SameCheck = std::function<bool(const InformationNode*, const InformationNode*)>;
+		using NodeCondition = std::function<bool(const InformationNode*)>;
+		using EdgeCondition = std::function<bool(const InformationEdge*)>;
+
+
+		/**
+		 * Registers the SameCheck \a check.
+		 */
+		inline void addSameCheck(SameCheck check);
+
+		/**
+		 * Adds the \a node to the graph. If the graph already contains the same node (checked by unique checkers),
+		 * the node reference is overwritten with the existing node.
+		 *
+		 * Note: Takes ownership on \a node.
+		 */
+		void add(InformationNode*& node);
+
+		/**
+		 * Creates a directed Edge from \a from to \a to with the name \a name.
+		 *
+		 * Returns the directed connection between \a from and \a to.
+		 *
+		 * If there is already a directed edge with the same \a name between \a from and \a to,
+		 * the existing edge is returned with the count property increased.
+		 * If there is already a undirected edge with the same \a name between \a from and \a to,
+		 * an exception is thrown.
+		 *
+		 * Note: The graph owns the returned edge.
+		 */
+		InformationEdge* addDirectedEdge(InformationNode* from, InformationNode* to, const QString& name);
+
+		/**
+		 * Connects \a a to \a b with an indirected edge with the name \a name.
+		 *
+		 * Returns the undirected connection between \a a and \a b.
+		 *
+		 * If there is already a undirected edge with the same \a name between \a a and \a b,
+		 * the existing edge is returned with the count property increased.
+		 * If there is already a directed edge with the same \a name from \a a to \a b, or from \a b to \a a,
+		 * the existing edge is returned.
+		 *
+		 * Note: The graph owns the returned edge.
+		 *
+		 * >NOTE: It is nicer to just return a single edge rather than 2 edges, as it is an implementation detail
+		 * an exception is thrown.
+		 */
+		InformationEdge* addEdge(InformationNode* a, InformationNode* b, const QString& name);
+
+
+		/**
+		 * Removes the \a node and all connections to it.
+		 */
+		void remove(InformationNode* node);
+
+		/**
+		 * Removes all nodes in the list \a nodes and all conntections to the nodes.
+		 */
+		void remove(QList<InformationNode*> nodes);
+
+
+		/**
+		 * Returns all nodes for which the NodeCondition \a holds holds.
+		 */
+		QList<InformationNode*> nodesForWhich(NodeCondition holds) const;
+
+		/**
+		 * Returns all edges for which the EdgeCondition \a holds holds.
+		 */
+		QList<InformationNode*> edgesFowWhich(EdgeCondition holds) const;
+
+	private:
+		QList<SameCheck> sameCheckers_;
+		QList<InformationNode*> nodes_;
+};
+
+void Graph::addSameCheck(Graph::SameCheck check) { sameCheckers_ << check; }
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/graph/Graph.h
+++ b/InformationScripting/src/graph/Graph.h
@@ -93,17 +93,17 @@ class Graph
 		 */
 		void remove(QList<InformationNode*> nodes);
 
-		QList<InformationNode*> nodes() const;
+		/**
+		 * Returns all nodes,
+		 * if \a holds is passed then it returns only the nodes for which the NodeCondition \a holds holds.
+		 */
+		QList<InformationNode*> nodes(NodeCondition holds = {}) const;
 
 		/**
-		 * Returns all nodes for which the NodeCondition \a holds holds.
+		 * Returns all edges,
+		 * if \a holds is passed then it returns only the edges for which the EdgeCondition \a holds holds.
 		 */
-		QList<InformationNode*> nodesForWhich(NodeCondition holds) const;
-
-		/**
-		 * Returns all edges for which the EdgeCondition \a holds holds.
-		 */
-		QList<InformationEdge*> edgesFowWhich(EdgeCondition holds) const;
+		QList<InformationEdge*> edges(EdgeCondition holds = {}) const;
 
 	private:
 		static QList<NodeHash> nodeHashFunctions_;
@@ -111,7 +111,7 @@ class Graph
 		QHash<std::size_t, InformationNode*> nodes_;
 		QList<InformationEdge*> edges_;
 
-		std::size_t hashValueOf(const InformationNode* n) const;
+		std::size_t hashOf(const InformationNode* n) const;
 		/**
 		 * Checks if there is a node in the graph with the same hash value as \a n,
 		 * if there is the pointer to this node is returned, otherwise a null pointer is returned.

--- a/InformationScripting/src/graph/Graph.h
+++ b/InformationScripting/src/graph/Graph.h
@@ -93,6 +93,7 @@ class Graph
 		 */
 		void remove(QList<InformationNode*> nodes);
 
+		QList<InformationNode*> nodes() const;
 
 		/**
 		 * Returns all nodes for which the NodeCondition \a holds holds.

--- a/InformationScripting/src/graph/Graph.h
+++ b/InformationScripting/src/graph/Graph.h
@@ -48,7 +48,7 @@ class Graph
 		using NodeCondition = std::function<bool(const InformationNode*)>;
 		using EdgeCondition = std::function<bool(const InformationEdge*)>;
 
-		static inline void registerNodeHash(NodeHash check);
+		static void registerNodeHash(NodeHash check);
 
 		/**
 		 * Adds the \a node to the graph. Only the returned node should be used after this method is called.
@@ -124,6 +124,6 @@ class Graph
 
 };
 
-void Graph::registerNodeHash(Graph::NodeHash check) { nodeHashFunctions_ << check; }
+inline void Graph::registerNodeHash(Graph::NodeHash check) { nodeHashFunctions_ << check; }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/Graph.h
+++ b/InformationScripting/src/graph/Graph.h
@@ -101,7 +101,7 @@ class Graph
 		/**
 		 * Returns all edges for which the EdgeCondition \a holds holds.
 		 */
-		QList<InformationNode*> edgesFowWhich(EdgeCondition holds) const;
+		QList<InformationEdge*> edgesFowWhich(EdgeCondition holds) const;
 
 	private:
 		static QList<IsEqual> equalityChecks_;

--- a/InformationScripting/src/graph/Graph.h
+++ b/InformationScripting/src/graph/Graph.h
@@ -36,6 +36,7 @@ class InformationNode;
 class Graph
 {
 	public:
+		~Graph();
 		// TODO instead of IsEqual we should use hashing in the future, see github discussion.
 		/**
 		 * IsEqual takes 2 nodes and returns if they are the same for some data source.

--- a/InformationScripting/src/graph/Graph.h
+++ b/InformationScripting/src/graph/Graph.h
@@ -37,18 +37,18 @@ class Graph
 {
 	public:
 		~Graph();
-		// TODO instead of IsEqual we should use hashing in the future, see github discussion.
 		/**
-		 * IsEqual takes 2 nodes and returns if they are the same for some data source.
+		 * Each information source can register 1 NodeHash function. The function takes a node as input,
+		 * and should return a pair of the hash value and a bool if the function could succesfully hash the value.
+		 *
+		 * The second parameter is useful as, e.g. a node from the tag information source can not be hashed by the
+		 * ast information source.
 		 */
-		using IsEqual = std::function<bool(const InformationNode*, const InformationNode*)>;
+		using NodeHash = std::function<QPair<std::size_t, bool>(const InformationNode*)>;
 		using NodeCondition = std::function<bool(const InformationNode*)>;
 		using EdgeCondition = std::function<bool(const InformationEdge*)>;
 
-		/**
-		 * Registers the IsEqual \a check.
-		 */
-		static inline void addEqualityCheck(IsEqual check);
+		static inline void registerNodeHash(NodeHash check);
 
 		/**
 		 * Adds the \a node to the graph. Only the returned node should be used after this method is called.
@@ -105,13 +105,15 @@ class Graph
 		QList<InformationEdge*> edgesFowWhich(EdgeCondition holds) const;
 
 	private:
-		static QList<IsEqual> equalityChecks_;
+		static QList<NodeHash> nodeHashFunctions_;
 
-		QList<InformationNode*> nodes_;
+		QHash<std::size_t, InformationNode*> nodes_;
 		QList<InformationEdge*> edges_;
+
+		std::size_t hashValueOf(const InformationNode* n) const;
 
 };
 
-void Graph::addEqualityCheck(Graph::IsEqual check) { equalityChecks_ << check; }
+void Graph::registerNodeHash(Graph::NodeHash check) { nodeHashFunctions_ << check; }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/InformationEdge.cpp
+++ b/InformationScripting/src/graph/InformationEdge.cpp
@@ -37,7 +37,7 @@ InformationEdge::InformationEdge()
 
 int InformationEdge::count() const
 {
-	return operator[](COUNT_PROPERTY_);
+	return (*this)[COUNT_PROPERTY_];
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/InformationEdge.cpp
+++ b/InformationScripting/src/graph/InformationEdge.cpp
@@ -33,11 +33,8 @@ const QString InformationEdge::NAME_PROPERTY_{"name"};
 
 InformationEdge::InformationEdge(InformationNode* from, InformationNode* to, const QString& name,
 											Orientation orientation)
-	: from_{from}, to_{to}, orientation_{orientation}
-{
-	insert(COUNT_PROPERTY_, 1);
-	insert(NAME_PROPERTY_, name);
-}
+	: PropertyMap{{{COUNT_PROPERTY_, 1}, {NAME_PROPERTY_, name}}}, from_{from}, to_{to}, orientation_{orientation}
+{}
 
 int InformationEdge::count() const
 {

--- a/InformationScripting/src/graph/InformationEdge.cpp
+++ b/InformationScripting/src/graph/InformationEdge.cpp
@@ -29,15 +29,30 @@
 namespace InformationScripting {
 
 const QString InformationEdge::COUNT_PROPERTY_{"count"};
+const QString InformationEdge::NAME_PROPERTY_{"name"};
 
-InformationEdge::InformationEdge()
+InformationEdge::InformationEdge(InformationNode* from, InformationNode* to, const QString& name,
+											Orientation orientation)
+	: from_{from}, to_{to}, orientation_{orientation}
 {
 	insert(COUNT_PROPERTY_, 1);
+	insert(NAME_PROPERTY_, name);
 }
 
 int InformationEdge::count() const
 {
 	return (*this)[COUNT_PROPERTY_];
+}
+
+void InformationEdge::incrementCount()
+{
+	Property& count = (*this)[COUNT_PROPERTY_];
+	count = static_cast<int>(count) + 1;
+}
+
+QString InformationEdge::name() const
+{
+	return (*this)[NAME_PROPERTY_];
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/InformationEdge.cpp
+++ b/InformationScripting/src/graph/InformationEdge.cpp
@@ -36,20 +36,10 @@ InformationEdge::InformationEdge(InformationNode* from, InformationNode* to, con
 	: PropertyMap{{{COUNT_PROPERTY_, 1}, {NAME_PROPERTY_, name}}}, from_{from}, to_{to}, orientation_{orientation}
 {}
 
-int InformationEdge::count() const
-{
-	return (*this)[COUNT_PROPERTY_];
-}
-
 void InformationEdge::incrementCount()
 {
 	Property& count = (*this)[COUNT_PROPERTY_];
 	count = static_cast<int>(count) + 1;
-}
-
-QString InformationEdge::name() const
-{
-	return (*this)[NAME_PROPERTY_];
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/InformationEdge.cpp
+++ b/InformationScripting/src/graph/InformationEdge.cpp
@@ -24,24 +24,20 @@
 **
 ***********************************************************************************************************************/
 
-#pragma once
-
-#include "../informationscripting_api.h"
-
-#include "Property.h"
-#include "PropertyMap.h"
+#include "InformationEdge.h"
 
 namespace InformationScripting {
 
-class InformationEdge;
-class Graph;
+const QString InformationEdge::COUNT_PROPERTY_{"count"};
 
-class INFORMATIONSCRIPTING_API InformationNode : public PropertyMap
+InformationEdge::InformationEdge()
 {
-	private:
-		friend class Graph;
+	insert(COUNT_PROPERTY_, 1);
+}
 
-		QList<QPair<QString, InformationEdge*>> incidentEdges_;
-};
+int InformationEdge::count() const
+{
+	return operator[](COUNT_PROPERTY_);
+}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/InformationEdge.h
+++ b/InformationScripting/src/graph/InformationEdge.h
@@ -45,10 +45,10 @@ class InformationEdge : public PropertyMap
 		void incrementCount();
 		QString name() const;
 
-		inline InformationNode* from() const;
-		inline InformationNode* to() const;
+		InformationNode* from() const;
+		InformationNode* to() const;
 
-		inline bool isDirected() const;
+		bool isDirected() const;
 
 	private:
 		static const QString COUNT_PROPERTY_;
@@ -60,8 +60,10 @@ class InformationEdge : public PropertyMap
 		Orientation orientation_{};
 };
 
-InformationNode* InformationEdge::from() const { return from_; }
-InformationNode* InformationEdge::to() const { return to_; }
-bool InformationEdge::isDirected() const { return orientation_ == Orientation::Directed; }
+inline int InformationEdge::count() const { return (*this)[COUNT_PROPERTY_]; }
+inline QString InformationEdge::name() const { return (*this)[NAME_PROPERTY_]; }
+inline InformationNode* InformationEdge::from() const { return from_; }
+inline InformationNode* InformationEdge::to() const { return to_; }
+inline bool InformationEdge::isDirected() const { return orientation_ == Orientation::Directed; }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/InformationEdge.h
+++ b/InformationScripting/src/graph/InformationEdge.h
@@ -33,14 +33,35 @@
 
 namespace InformationScripting {
 
+class InformationNode;
+
 class InformationEdge : public PropertyMap
 {
 	public:
-		InformationEdge();
+		enum class Orientation : int {Directed, Undirected};
+		InformationEdge(InformationNode* from, InformationNode* to, const QString& name,
+							 Orientation orientation = Orientation::Directed);
 		int count() const;
+		void incrementCount();
+		QString name() const;
+
+		inline InformationNode* from() const;
+		inline InformationNode* to() const;
+
+		inline bool isDirected() const;
 
 	private:
 		static const QString COUNT_PROPERTY_;
+		static const QString NAME_PROPERTY_;
+
+		InformationNode* from_{};
+		InformationNode* to_{};
+
+		Orientation orientation_{};
 };
+
+InformationNode* InformationEdge::from() const { return from_; }
+InformationNode* InformationEdge::to() const { return to_; }
+bool InformationEdge::isDirected() const { return orientation_ == Orientation::Directed; }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/InformationEdge.h
+++ b/InformationScripting/src/graph/InformationEdge.h
@@ -61,8 +61,9 @@ class InformationEdge : public PropertyMap
 		Orientation orientation_{};
 };
 
-inline int InformationEdge::count() const { return (*this)[COUNT_PROPERTY_]; }
-inline QString InformationEdge::name() const { return (*this)[NAME_PROPERTY_]; }
+inline int InformationEdge::count() const { auto it = find(COUNT_PROPERTY_); Q_ASSERT(it != end()); return it->second; }
+inline QString InformationEdge::name() const
+	{ auto it = find(NAME_PROPERTY_); Q_ASSERT(it != end()); return it->second; }
 inline InformationNode* InformationEdge::from() const { return from_; }
 inline InformationNode* InformationEdge::to() const { return to_; }
 inline bool InformationEdge::isDirected() const { return orientation_ == Orientation::Directed; }

--- a/InformationScripting/src/graph/InformationEdge.h
+++ b/InformationScripting/src/graph/InformationEdge.h
@@ -33,15 +33,14 @@
 
 namespace InformationScripting {
 
-class InformationEdge;
-class Graph;
-
-class INFORMATIONSCRIPTING_API InformationNode : public PropertyMap
+class InformationEdge : public PropertyMap
 {
-	private:
-		friend class Graph;
+	public:
+		InformationEdge();
+		int count() const;
 
-		QList<QPair<QString, InformationEdge*>> incidentEdges_;
+	private:
+		static const QString COUNT_PROPERTY_;
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/InformationEdge.h
+++ b/InformationScripting/src/graph/InformationEdge.h
@@ -49,6 +49,7 @@ class InformationEdge : public PropertyMap
 		InformationNode* to() const;
 
 		bool isDirected() const;
+		Orientation orientation() const;
 
 	private:
 		static const QString COUNT_PROPERTY_;
@@ -65,5 +66,6 @@ inline QString InformationEdge::name() const { return (*this)[NAME_PROPERTY_]; }
 inline InformationNode* InformationEdge::from() const { return from_; }
 inline InformationNode* InformationEdge::to() const { return to_; }
 inline bool InformationEdge::isDirected() const { return orientation_ == Orientation::Directed; }
+inline InformationEdge::Orientation InformationEdge::orientation() const { return orientation_; }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/InformationNode.cpp
+++ b/InformationScripting/src/graph/InformationNode.cpp
@@ -28,4 +28,8 @@
 
 namespace InformationScripting {
 
+InformationNode::InformationNode(QList<QPair<QString, Property> > initialValues)
+	: PropertyMap{initialValues}
+{}
+
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/InformationNode.h
+++ b/InformationScripting/src/graph/InformationNode.h
@@ -33,15 +33,8 @@
 
 namespace InformationScripting {
 
-class InformationEdge;
-class Graph;
-
 class INFORMATIONSCRIPTING_API InformationNode : public PropertyMap
 {
-	private:
-		friend class Graph;
-
-		QList<QPair<QString, InformationEdge*>> incidentEdges_;
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/InformationNode.h
+++ b/InformationScripting/src/graph/InformationNode.h
@@ -35,6 +35,8 @@ namespace InformationScripting {
 
 class INFORMATIONSCRIPTING_API InformationNode : public PropertyMap
 {
+	public:
+		InformationNode(QList<QPair<QString, Property>> initialValues);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/Property.cpp
+++ b/InformationScripting/src/graph/Property.cpp
@@ -33,5 +33,10 @@ boost::python::object pythonObject(const Property& p)
 	return p.data_->pythonObject();
 }
 
+bool Property::operator==(const Property& other) const
+{
+	return data_->equals(other.data_);
+}
+
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/Property.h
+++ b/InformationScripting/src/graph/Property.h
@@ -42,8 +42,8 @@ class INFORMATIONSCRIPTING_API Property {
 
 		friend boost::python::object pythonObject(const Property& p);
 
-		template <class ConvertTo> inline operator ConvertTo() const;
-		inline operator Model::Node*() const;
+		template <class ConvertTo> operator ConvertTo() const;
+		operator Model::Node*() const;
 
 		bool operator==(const Property& other) const;
 
@@ -117,13 +117,14 @@ class INFORMATIONSCRIPTING_API Property {
 template <class DataType> Property::Property(DataType propertyData)
 	: data_{std::make_shared<PropertyData<DataType>>(std::move(propertyData))} {}
 
-template <class ConvertTo> Property::operator ConvertTo() const
+template <class ConvertTo>
+inline Property::operator ConvertTo() const
 {
 	if (auto propertyData = std::dynamic_pointer_cast<PropertyData<ConvertTo>>(data_))
 		return propertyData->data_;
 	throw new std::bad_cast;
 }
 
-InformationScripting::Property::operator Model::Node*() const { return data_->node(); }
+inline InformationScripting::Property::operator Model::Node*() const { return data_->node(); }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/Property.h
+++ b/InformationScripting/src/graph/Property.h
@@ -52,7 +52,7 @@ class INFORMATIONSCRIPTING_API Property {
 				virtual ~PropertyDataConcept() = default;
 				virtual boost::python::object pythonObject() const = 0;
 				virtual Model::Node* node() const { return nullptr; }
-				virtual bool equals(std::shared_ptr<PropertyDataConcept> other) const = 0;
+				virtual bool equals(const std::shared_ptr<PropertyDataConcept>& other) const = 0;
 		};
 
 		template <class DataType, class = void>
@@ -63,7 +63,7 @@ class INFORMATIONSCRIPTING_API Property {
 					return boost::python::object(data_);
 				}
 
-				virtual bool equals(std::shared_ptr<PropertyDataConcept> other) const override {
+				virtual bool equals(const std::shared_ptr<PropertyDataConcept>& other) const override {
 					if (auto specificOther = std::dynamic_pointer_cast<PropertyData<DataType>>(other))
 						return data_ == specificOther->data_;
 					return false;
@@ -82,7 +82,7 @@ class INFORMATIONSCRIPTING_API Property {
 					return boost::python::object(boost::python::ptr(data_));
 				}
 
-				virtual bool equals(std::shared_ptr<PropertyDataConcept> other) const override {
+				virtual bool equals(const std::shared_ptr<PropertyDataConcept>& other) const override {
 					if (auto specificOther = std::dynamic_pointer_cast<PropertyData<DataType>>(other))
 						return data_ == specificOther->data_;
 					return false;
@@ -102,7 +102,7 @@ class INFORMATIONSCRIPTING_API Property {
 				}
 				virtual Model::Node* node() const override { return data_; }
 
-				virtual bool equals(std::shared_ptr<PropertyDataConcept> other) const override {
+				virtual bool equals(const std::shared_ptr<PropertyDataConcept>& other) const override {
 					if (auto specificOther = std::dynamic_pointer_cast<PropertyData<DataType>>(other))
 						return data_ == specificOther->data_;
 					return false;

--- a/InformationScripting/src/graph/Property.h
+++ b/InformationScripting/src/graph/Property.h
@@ -45,11 +45,14 @@ class INFORMATIONSCRIPTING_API Property {
 		template <class ConvertTo> inline operator ConvertTo() const;
 		inline operator Model::Node*() const;
 
+		bool operator==(const Property& other) const;
+
 	private:
 		struct PropertyDataConcept {
 				virtual ~PropertyDataConcept() = default;
 				virtual boost::python::object pythonObject() const = 0;
 				virtual Model::Node* node() const { return nullptr; }
+				virtual bool equals(std::shared_ptr<PropertyDataConcept> other) const = 0;
 		};
 
 		template <class DataType, class = void>
@@ -58,6 +61,12 @@ class INFORMATIONSCRIPTING_API Property {
 
 				virtual boost::python::object pythonObject() const override {
 					return boost::python::object(data_);
+				}
+
+				virtual bool equals(std::shared_ptr<PropertyDataConcept> other) const override {
+					if (auto specificOther = std::dynamic_pointer_cast<PropertyData<DataType>>(other))
+						return data_ == specificOther->data_;
+					return false;
 				}
 
 				DataType data_;
@@ -72,6 +81,13 @@ class INFORMATIONSCRIPTING_API Property {
 				virtual boost::python::object pythonObject() const override {
 					return boost::python::object(boost::python::ptr(data_));
 				}
+
+				virtual bool equals(std::shared_ptr<PropertyDataConcept> other) const override {
+					if (auto specificOther = std::dynamic_pointer_cast<PropertyData<DataType>>(other))
+						return data_ == specificOther->data_;
+					return false;
+				}
+
 				DataType data_;
 		};
 		// Template overload for pointer types which inherit from Model::Node
@@ -85,6 +101,13 @@ class INFORMATIONSCRIPTING_API Property {
 					return boost::python::object(boost::python::ptr(data_));
 				}
 				virtual Model::Node* node() const override { return data_; }
+
+				virtual bool equals(std::shared_ptr<PropertyDataConcept> other) const override {
+					if (auto specificOther = std::dynamic_pointer_cast<PropertyData<DataType>>(other))
+						return data_ == specificOther->data_;
+					return false;
+				}
+
 				DataType data_;
 		};
 

--- a/InformationScripting/src/graph/Property.h
+++ b/InformationScripting/src/graph/Property.h
@@ -28,6 +28,8 @@
 
 #include "../informationscripting_api.h"
 
+#include "ModelBase/src/nodes/Node.h"
+
 namespace InformationScripting {
 
 // Inspired by: http://channel9.msdn.com/Events/GoingNative/2013/Inheritance-Is-The-Base-Class-of-Evil
@@ -41,11 +43,13 @@ class INFORMATIONSCRIPTING_API Property {
 		friend boost::python::object pythonObject(const Property& p);
 
 		template <class ConvertTo> inline operator ConvertTo() const;
+		inline operator Model::Node*() const;
 
 	private:
 		struct PropertyDataConcept {
 				virtual ~PropertyDataConcept() = default;
 				virtual boost::python::object pythonObject() const = 0;
+				virtual Model::Node* node() const { return nullptr; }
 		};
 
 		template <class DataType, class = void>
@@ -55,16 +59,32 @@ class INFORMATIONSCRIPTING_API Property {
 				virtual boost::python::object pythonObject() const override {
 					return boost::python::object(data_);
 				}
+
 				DataType data_;
 		};
+		// Template overload for general pointer types:
 		template <class DataType>
-		struct PropertyData<DataType, typename std::enable_if<std::is_pointer<DataType>::value>::type>
+		struct PropertyData<DataType, typename std::enable_if<std::is_pointer<DataType>::value
+								&& !std::is_base_of<Model::Node, std::remove_pointer_t<DataType>>::value>::type>
 				: PropertyDataConcept {
 				PropertyData(DataType data) : data_{data} {}
 
 				virtual boost::python::object pythonObject() const override {
 					return boost::python::object(boost::python::ptr(data_));
 				}
+				DataType data_;
+		};
+		// Template overload for pointer types which inherit from Model::Node
+		template <class DataType>
+		struct PropertyData<DataType, typename std::enable_if<std::is_pointer<DataType>::value
+								&& std::is_base_of<Model::Node, std::remove_pointer_t<DataType>>::value>::type>
+				: PropertyDataConcept {
+				PropertyData(DataType data) : data_{data} {}
+
+				virtual boost::python::object pythonObject() const override {
+					return boost::python::object(boost::python::ptr(data_));
+				}
+				virtual Model::Node* node() const override { return data_; }
 				DataType data_;
 		};
 
@@ -80,5 +100,7 @@ template <class ConvertTo> Property::operator ConvertTo() const
 		return propertyData->data_;
 	throw new std::bad_cast;
 }
+
+InformationScripting::Property::operator Model::Node*() const { return data_->node(); }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/PropertyMap.cpp
+++ b/InformationScripting/src/graph/PropertyMap.cpp
@@ -41,4 +41,11 @@ Property InformationScripting::PropertyMap::operator[](const QString& key) const
 	Q_ASSERT(false);
 }
 
+bool PropertyMap::contains(const QString& key) const
+{
+	for (auto content : properties_)
+		if (content.first == key) return true;
+	return false;
+}
+
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/PropertyMap.cpp
+++ b/InformationScripting/src/graph/PropertyMap.cpp
@@ -33,9 +33,17 @@ boost::python::object PropertyMap::pythonAttribute(const QString& key) const
 	return pythonObject(operator[](key));
 }
 
-Property InformationScripting::PropertyMap::operator[](const QString& key) const
+Property PropertyMap::operator[](const QString& key) const
 {
 	for (auto content : properties_)
+		if (content.first == key) return content.second;
+	qDebug() << "No object with name" << key;
+	Q_ASSERT(false);
+}
+
+Property& InformationScripting::PropertyMap::operator[](const QString& key)
+{
+	for (auto& content : properties_)
 		if (content.first == key) return content.second;
 	qDebug() << "No object with name" << key;
 	Q_ASSERT(false);

--- a/InformationScripting/src/graph/PropertyMap.cpp
+++ b/InformationScripting/src/graph/PropertyMap.cpp
@@ -34,17 +34,9 @@ PropertyMap::PropertyMap(QList<QPair<QString, Property> > initialValues)
 		insert(initialValue.first, initialValue.second);
 }
 
-boost::python::object PropertyMap::pythonAttribute(const QString& key) const
+boost::python::object PropertyMap::pythonAttribute(const QString& key)
 {
 	return pythonObject(operator[](key));
-}
-
-Property PropertyMap::operator[](const QString& key) const
-{
-	for (auto content : properties_)
-		if (content.first == key) return content.second;
-	qDebug() << "No object with name" << key;
-	Q_ASSERT(false);
 }
 
 Property& InformationScripting::PropertyMap::operator[](const QString& key)
@@ -52,14 +44,18 @@ Property& InformationScripting::PropertyMap::operator[](const QString& key)
 	for (auto& content : properties_)
 		if (content.first == key) return content.second;
 	qDebug() << "No object with name" << key;
-	Q_ASSERT(false);
+	properties_.push_back({key, Property()});
+	return properties_.last().second;
 }
 
 bool PropertyMap::contains(const QString& key) const
 {
-	for (auto content : properties_)
-		if (content.first == key) return true;
-	return false;
+	return find(key) != end();
+}
+
+PropertyMap::const_iterator PropertyMap::find(const QString& key) const
+{
+	return std::find_if(properties_.begin(), properties_.end(), [key](auto v) {return v.first == key;});
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/graph/PropertyMap.cpp
+++ b/InformationScripting/src/graph/PropertyMap.cpp
@@ -28,6 +28,12 @@
 
 namespace InformationScripting {
 
+PropertyMap::PropertyMap(QList<QPair<QString, Property> > initialValues)
+{
+	for (auto initialValue : initialValues)
+		insert(initialValue.first, initialValue.second);
+}
+
 boost::python::object PropertyMap::pythonAttribute(const QString& key) const
 {
 	return pythonObject(operator[](key));

--- a/InformationScripting/src/graph/PropertyMap.h
+++ b/InformationScripting/src/graph/PropertyMap.h
@@ -40,6 +40,7 @@ class INFORMATIONSCRIPTING_API PropertyMap
 
 		boost::python::object pythonAttribute(const QString& key) const;
 		Property operator[](const QString& key) const;
+		Property& operator[](const QString& key);
 
 		bool contains(const QString& key) const;
 

--- a/InformationScripting/src/graph/PropertyMap.h
+++ b/InformationScripting/src/graph/PropertyMap.h
@@ -39,8 +39,7 @@ class INFORMATIONSCRIPTING_API PropertyMap
 		template <class DataType>
 		void insert(const QString& key, const DataType& value);
 
-		boost::python::object pythonAttribute(const QString& key) const;
-		Property operator[](const QString& key) const;
+		boost::python::object pythonAttribute(const QString& key);
 		Property& operator[](const QString& key);
 
 		bool contains(const QString& key) const;
@@ -48,6 +47,8 @@ class INFORMATIONSCRIPTING_API PropertyMap
 		// Iterators
 		using iterator = QList<QPair<QString, Property>>::Iterator;
 		using const_iterator = QList<QPair<QString, Property>>::ConstIterator;
+
+		const_iterator find(const QString& key) const;
 
 		iterator begin();
 		const_iterator begin() const;

--- a/InformationScripting/src/graph/PropertyMap.h
+++ b/InformationScripting/src/graph/PropertyMap.h
@@ -37,9 +37,11 @@ class INFORMATIONSCRIPTING_API PropertyMap
 	public:
 		template <class DataType>
 		inline void insert(const QString& key, const DataType& value);
-		boost::python::object pythonAttribute(const QString& key) const;
 
+		boost::python::object pythonAttribute(const QString& key) const;
 		Property operator[](const QString& key) const;
+
+		bool contains(const QString& key) const;
 
 	private:
 		QList<QPair<QString, Property>> properties_{};

--- a/InformationScripting/src/graph/PropertyMap.h
+++ b/InformationScripting/src/graph/PropertyMap.h
@@ -35,6 +35,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API PropertyMap
 {
 	public:
+		PropertyMap(QList<QPair<QString, Property>> initialValues);
 		template <class DataType>
 		inline void insert(const QString& key, const DataType& value);
 

--- a/InformationScripting/src/graph/PropertyMap.h
+++ b/InformationScripting/src/graph/PropertyMap.h
@@ -37,7 +37,7 @@ class INFORMATIONSCRIPTING_API PropertyMap
 	public:
 		PropertyMap(QList<QPair<QString, Property>> initialValues);
 		template <class DataType>
-		inline void insert(const QString& key, const DataType& value);
+		void insert(const QString& key, const DataType& value);
 
 		boost::python::object pythonAttribute(const QString& key) const;
 		Property operator[](const QString& key) const;
@@ -45,14 +45,33 @@ class INFORMATIONSCRIPTING_API PropertyMap
 
 		bool contains(const QString& key) const;
 
+		// Iterators
+		using iterator = QList<QPair<QString, Property>>::Iterator;
+		using const_iterator = QList<QPair<QString, Property>>::ConstIterator;
+
+		iterator begin();
+		const_iterator begin() const;
+		const_iterator cbegin() const;
+		iterator end();
+		const_iterator end() const;
+		const_iterator cend() const;
+
 	private:
 		QList<QPair<QString, Property>> properties_{};
 };
 
+
 template <class DataType>
-void PropertyMap::insert(const QString& key, const DataType& value)
+inline void PropertyMap::insert(const QString& key, const DataType& value)
 {
 	properties_.push_back({key, Property(value)});
 }
+
+inline PropertyMap::iterator PropertyMap::begin() { return properties_.begin(); }
+inline PropertyMap::const_iterator PropertyMap::begin() const { return properties_.begin(); }
+inline PropertyMap::const_iterator PropertyMap::cbegin() const { return properties_.cbegin(); }
+inline PropertyMap::iterator PropertyMap::end() { return properties_.end(); }
+inline PropertyMap::const_iterator PropertyMap::end() const { return properties_.end(); }
+inline PropertyMap::const_iterator PropertyMap::cend() const { return properties_.cend(); }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/precompiled.h
+++ b/InformationScripting/src/precompiled.h
@@ -62,6 +62,8 @@
 #undef PYTHONQT_RESTORE_KEYWORDS
 #endif
 
+#include <QtCore/QQueue>
+
 #endif
 
 #endif

--- a/InformationScripting/src/queries/AstNameFilter.cpp
+++ b/InformationScripting/src/queries/AstNameFilter.cpp
@@ -27,23 +27,26 @@
 #include "AstNameFilter.h"
 
 #include "../graph/InformationNode.h"
-#include "OOModel/src/declarations/Declaration.h"
+
+#include "ModelBase/src/nodes/composite/CompositeNode.h"
+#include "ModelBase/src/nodes/Text.h"
 
 namespace InformationScripting {
 
-AstNameFilter::AstNameFilter(QString nameContains, bool exactMatch)
+AstNameFilter::AstNameFilter(Model::SymbolMatcher matcher)
 	: GenericFilter {
-		  [nameContains, exactMatch](const InformationNode* n) {
+		  [matcher](const InformationNode* n) {
 			auto it = n->find("ast");
 			if (it != n->end())
 			{
 				Model::Node* astNode = it->second;
-				if (auto decl = DCast<OOModel::Declaration>(astNode))
+				if (auto compositeNode = DCast<Model::CompositeNode>(astNode))
 				{
-					if (exactMatch)
-						return decl->name() == nameContains;
-					else
-						return decl->name().contains(nameContains);
+					if (compositeNode->hasAttribute("name"))
+					{
+						if (auto nameText = DCast<Model::Text>(compositeNode->get("name")))
+							return matcher.matches(nameText->get());
+					}
 				}
 			}
 			return false;

--- a/InformationScripting/src/queries/AstNameFilter.cpp
+++ b/InformationScripting/src/queries/AstNameFilter.cpp
@@ -24,33 +24,30 @@
 **
 ***********************************************************************************************************************/
 
-#pragma once
+#include "AstNameFilter.h"
 
-#include "../informationscripting_api.h"
-
-#include "../queries/AstQuery.h"
-
-namespace Model {
-	class Node;
-}
+#include "../graph/InformationNode.h"
+#include "OOModel/src/declarations/Declaration.h"
 
 namespace InformationScripting {
 
-class Graph;
-
-class AstSource
-{
-	public:
-		static AstSource& instance();
-		static void init();
-
-		AstQuery* createClassesQuery(Model::Node* target, QStringList args);
-		AstQuery* createMethodQuery(Model::Node* target, QStringList args);
-		AstQuery* createBaseClassesQuery(Model::Node* target, QStringList args);
-		AstQuery* createToClassNodeQuery(Model::Node* target, QStringList args);
-
-	private:
-		AstSource() = default;
-};
+AstNameFilter::AstNameFilter(QString nameContains, bool exactMatch)
+	: GenericFilter {
+		  [nameContains, exactMatch](const InformationNode* n) {
+			if (n->contains("ast"))
+			{
+				Model::Node* astNode = (*n)["ast"];
+				if (auto decl = DCast<OOModel::Declaration>(astNode))
+				{
+					if (exactMatch)
+						return decl->name() == nameContains;
+					else
+						return decl->name().contains(nameContains);
+				}
+			}
+			return false;
+		}
+	}
+{}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstNameFilter.cpp
+++ b/InformationScripting/src/queries/AstNameFilter.cpp
@@ -34,9 +34,10 @@ namespace InformationScripting {
 AstNameFilter::AstNameFilter(QString nameContains, bool exactMatch)
 	: GenericFilter {
 		  [nameContains, exactMatch](const InformationNode* n) {
-			if (n->contains("ast"))
+			auto it = n->find("ast");
+			if (it != n->end())
 			{
-				Model::Node* astNode = (*n)["ast"];
+				Model::Node* astNode = it->second;
 				if (auto decl = DCast<OOModel::Declaration>(astNode))
 				{
 					if (exactMatch)

--- a/InformationScripting/src/queries/AstNameFilter.h
+++ b/InformationScripting/src/queries/AstNameFilter.h
@@ -28,29 +28,14 @@
 
 #include "../informationscripting_api.h"
 
-#include "../queries/AstQuery.h"
-
-namespace Model {
-	class Node;
-}
+#include "GenericFilter.h"
 
 namespace InformationScripting {
 
-class Graph;
-
-class AstSource
+class INFORMATIONSCRIPTING_API AstNameFilter : public GenericFilter
 {
 	public:
-		static AstSource& instance();
-		static void init();
-
-		AstQuery* createClassesQuery(Model::Node* target, QStringList args);
-		AstQuery* createMethodQuery(Model::Node* target, QStringList args);
-		AstQuery* createBaseClassesQuery(Model::Node* target, QStringList args);
-		AstQuery* createToClassNodeQuery(Model::Node* target, QStringList args);
-
-	private:
-		AstSource() = default;
+		AstNameFilter(QString nameContains, bool exactMatch = false);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstNameFilter.h
+++ b/InformationScripting/src/queries/AstNameFilter.h
@@ -28,6 +28,8 @@
 
 #include "../informationscripting_api.h"
 
+#include "ModelBase/src/SymbolMatcher.h"
+
 #include "GenericFilter.h"
 
 namespace InformationScripting {
@@ -35,7 +37,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API AstNameFilter : public GenericFilter
 {
 	public:
-		AstNameFilter(QString nameContains, bool exactMatch = false);
+		AstNameFilter(Model::SymbolMatcher matcher);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -121,8 +121,9 @@ Graph* AstQuery::methodsQuery(QList<Graph*>& input)
 		auto g = input.takeFirst();
 
 		auto canContainMethod = [](const InformationNode* n) {
-			if (n->contains("ast")) {
-				Model::Node* astNode = (*n)["ast"];
+			auto it = n->find("ast");
+			if (it != n->end()) {
+				Model::Node* astNode = it->second;
 				return DCast<OOModel::Declaration>(astNode) != nullptr;
 			}
 			return false;
@@ -172,9 +173,13 @@ Graph* AstQuery::toClassNode(QList<Graph*>& input)
 	Q_ASSERT(input.size());
 	auto g = input.takeFirst();
 	auto canBeInClass = [](const InformationNode* node) {
-		node->contains("ast");
-		Model::Node* n = (*node)["ast"];
-		return n->firstAncestorOfType<OOModel::Class>() != nullptr;
+		auto it = node->find("ast");
+		if (it != node->end())
+		{
+			Model::Node* n = it->second;
+			return n->firstAncestorOfType<OOModel::Class>() != nullptr;
+		}
+		return false;
 	};
 
 	auto nodes = g->nodes(canBeInClass);

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -128,7 +128,7 @@ Graph* AstQuery::methodsQuery(QList<Graph*>& input)
 			return false;
 		};
 
-		QList<InformationNode*> nodes = g->nodesForWhich(canContainMethod);
+		QList<InformationNode*> nodes = g->nodes(canContainMethod);
 		for (auto node : nodes)
 		{
 			Model::Node* astNode = (*node)["ast"];
@@ -177,7 +177,7 @@ Graph* AstQuery::toClassNode(QList<Graph*>& input)
 		return n->firstAncestorOfType<OOModel::Class>() != nullptr;
 	};
 
-	auto nodes = g->nodesForWhich(canBeInClass);
+	auto nodes = g->nodes(canBeInClass);
 	QList<OOModel::Class*> classes;
 	for (auto node : nodes)
 	{

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -78,19 +78,25 @@ Graph* AstQuery::baseClassesQuery(QList<Graph*>)
 		auto classNode = new InformationNode({{"ast", parentClass}});
 		g->add(classNode);
 
-		auto bases = parentClass->directBaseClasses();
-		for (auto base : bases)
-		{
-			auto baseNode = new InformationNode({{"ast", base}});
-			g->add(baseNode);
-			g->addDirectedEdge(classNode, baseNode, "base class");
-		}
+		addBaseEdgesFor(parentClass, classNode, g);
 	}
 	else if (scope_ == Scope::Global)
 	{
 		// TODO
 	}
 	return g;
+}
+
+void AstQuery::addBaseEdgesFor(OOModel::Class* childClass, InformationNode* classNode, Graph* g)
+{
+	auto bases = childClass->directBaseClasses();
+	for (auto base : bases)
+	{
+		auto baseNode = new InformationNode({{"ast", base}});
+		g->add(baseNode);
+		g->addDirectedEdge(classNode, baseNode, "base class");
+		addBaseEdgesFor(base, baseNode, g);
+	}
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -31,11 +31,15 @@
 #include "../graph/Graph.h"
 #include "../graph/InformationNode.h"
 
+#include "../visitors/AllNodesOfType.h"
+
 namespace InformationScripting {
 
-AstQuery::AstQuery(QueryType type, Model::Node* target, AstQuery::Scope scope)
-	: target_{target}, scope_{scope}, type_{type}
-{}
+AstQuery::AstQuery(QueryType type, Model::Node* target, QStringList args)
+	: target_{target}, type_{type}
+{
+	if (args.size() && args[0] == "g") scope_ = Scope::Global;
+}
 
 Graph* AstQuery::execute(QList<Graph*> input)
 {
@@ -61,7 +65,13 @@ Graph* AstQuery::methodsQuery(QList<Graph*>)
 	}
 	else if (scope_ == Scope::Global)
 	{
-		// TODO
+		auto root = target_->manager()->root();
+		AllNodesOfType<OOModel::Method> visitor;
+		visitor.visit(root);
+		auto allMethods =  visitor.results();
+		for (auto method : allMethods)
+			g->add(new InformationNode({{"ast", method}}));
+
 	}
 	return g;
 }

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -55,8 +55,7 @@ Graph* AstQuery::methodsQuery(QList<Graph*>)
 		auto parentClass = target_->firstAncestorOfType<OOModel::Class>();
 		for (auto method : *parentClass->methods())
 		{
-			auto node = new InformationNode();
-			node->insert("ast", method);
+			auto node = new InformationNode({{"ast", method}});
 			g->add(node);
 		}
 	}
@@ -76,15 +75,13 @@ Graph* AstQuery::baseClassesQuery(QList<Graph*>)
 		OOModel::Class* parentClass = DCast<OOModel::Class>(target_);
 		if (!parentClass) parentClass = target_->firstAncestorOfType<OOModel::Class>();
 
-		auto classNode = new InformationNode();
-		classNode->insert("ast", parentClass);
+		auto classNode = new InformationNode({{"ast", parentClass}});
 		g->add(classNode);
 
 		auto bases = parentClass->directBaseClasses();
 		for (auto base : bases)
 		{
-			auto baseNode = new InformationNode();
-			baseNode->insert("ast", base);
+			auto baseNode = new InformationNode({{"ast", base}});
 			g->add(baseNode);
 			g->addDirectedEdge(classNode, baseNode, "base class");
 		}

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -43,15 +43,26 @@ AstQuery::AstQuery(QueryType type, Model::Node* target, QStringList args)
 
 QList<Graph*> AstQuery::execute(QList<Graph*> input)
 {
+	QList<Graph*> result;
 	switch (type_)
 	{
-		case QueryType::Methods: return {methodsQuery(input)};
-		case QueryType::BaseClasses: return {baseClassesQuery(input)};
-		case QueryType::ToClass: return {toClassNode(input)};
+		case QueryType::Methods:
+			result = {methodsQuery(input)};
+			break;
+		case QueryType::BaseClasses:
+			result = {baseClassesQuery(input)};
+			break;
+		case QueryType::ToClass:
+			result = {toClassNode(input)};
+			break;
 	}
+	// Clean unhandled input:
+	for (auto& g : input) SAFE_DELETE(g);
+
+	return result;
 }
 
-Graph* AstQuery::methodsQuery(QList<Graph*>)
+Graph* AstQuery::methodsQuery(QList<Graph*>&)
 {
 	// TODO handle input
 	auto g = new Graph();
@@ -77,7 +88,7 @@ Graph* AstQuery::methodsQuery(QList<Graph*>)
 	return g;
 }
 
-Graph* AstQuery::baseClassesQuery(QList<Graph*>)
+Graph* AstQuery::baseClassesQuery(QList<Graph*>&)
 {
 	// TODO handle input
 	auto g = new Graph();
@@ -98,10 +109,10 @@ Graph* AstQuery::baseClassesQuery(QList<Graph*>)
 	return g;
 }
 
-Graph* AstQuery::toClassNode(QList<Graph*> input)
+Graph* AstQuery::toClassNode(QList<Graph*>& input)
 {
-	Q_ASSERT(input.size() == 1);
-	auto g = input[0];
+	Q_ASSERT(input.size());
+	auto g = input.takeFirst();
 	auto canBeInClass = [](const InformationNode* node) {
 		node->contains("ast");
 		Model::Node* n = (*node)["ast"];

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -98,7 +98,7 @@ Graph* AstQuery::baseClassesQuery(QList<Graph*>&)
 		if (!parentClass) parentClass = target_->firstAncestorOfType<OOModel::Class>();
 
 		auto classNode = new InformationNode({{"ast", parentClass}});
-		g->add(classNode);
+		classNode = g->add(classNode);
 
 		addBaseEdgesFor(parentClass, classNode, g);
 	}
@@ -140,7 +140,7 @@ void AstQuery::addBaseEdgesFor(OOModel::Class* childClass, InformationNode* clas
 	for (auto base : bases)
 	{
 		auto baseNode = new InformationNode({{"ast", base}});
-		g->add(baseNode);
+		baseNode = g->add(baseNode);
 		g->addDirectedEdge(classNode, baseNode, "base class");
 		addBaseEdgesFor(base, baseNode, g);
 	}

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -24,26 +24,37 @@
 **
 ***********************************************************************************************************************/
 
-#include "AstSource.h"
+#include "AstQuery.h"
 
 #include "OOModel/src/declarations/Class.h"
-
-#include "ModelBase/src/nodes/Node.h"
 
 #include "../graph/Graph.h"
 #include "../graph/InformationNode.h"
 
 namespace InformationScripting {
 
-AstSource& AstSource::instance()
-{
-	static AstSource instance;
-	return instance;
-}
+AstQuery::AstQuery(Model::Node* target, AstQuery::Scope scope)
+	: target_{target}, scope_{scope}
+{}
 
-AstQuery* AstSource::createMethodQuery(Model::Node* target, AstQuery::Scope scope)
+Graph* AstQuery::execute(QList<Graph*>)
 {
-	return new AstQuery(target, scope);
+	auto g = new Graph();
+	if (scope_ == AstQuery::Scope::Local)
+	{
+		auto parentClass = target_->firstAncestorOfType<OOModel::Class>();
+		for (auto method : *parentClass->methods())
+		{
+			auto node = new InformationNode();
+			node->insert("ast", method);
+			g->add(node);
+		}
+	}
+	else if (scope_ == AstQuery::Scope::Global)
+	{
+		// TODO
+	}
+	return g;
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -33,14 +33,24 @@
 
 namespace InformationScripting {
 
-AstQuery::AstQuery(Model::Node* target, AstQuery::Scope scope)
-	: target_{target}, scope_{scope}
+AstQuery::AstQuery(QueryType type, Model::Node* target, AstQuery::Scope scope)
+	: target_{target}, scope_{scope}, type_{type}
 {}
 
-Graph* AstQuery::execute(QList<Graph*>)
+Graph* AstQuery::execute(QList<Graph*> input)
 {
+	switch (type_)
+	{
+		case QueryType::Methods: return methodsQuery(input);
+		case QueryType::BaseClasses: return baseClassesQuery(input);
+	}
+}
+
+Graph* AstQuery::methodsQuery(QList<Graph*>)
+{
+	// TODO handle input
 	auto g = new Graph();
-	if (scope_ == AstQuery::Scope::Local)
+	if (scope_ == Scope::Local)
 	{
 		auto parentClass = target_->firstAncestorOfType<OOModel::Class>();
 		for (auto method : *parentClass->methods())
@@ -50,7 +60,36 @@ Graph* AstQuery::execute(QList<Graph*>)
 			g->add(node);
 		}
 	}
-	else if (scope_ == AstQuery::Scope::Global)
+	else if (scope_ == Scope::Global)
+	{
+		// TODO
+	}
+	return g;
+}
+
+Graph* AstQuery::baseClassesQuery(QList<Graph*>)
+{
+	// TODO handle input
+	auto g = new Graph();
+	if (scope_ == Scope::Local)
+	{
+		OOModel::Class* parentClass = DCast<OOModel::Class>(target_);
+		if (!parentClass) parentClass = target_->firstAncestorOfType<OOModel::Class>();
+
+		auto classNode = new InformationNode();
+		classNode->insert("ast", parentClass);
+		g->add(classNode);
+
+		auto bases = parentClass->directBaseClasses();
+		for (auto base : bases)
+		{
+			auto baseNode = new InformationNode();
+			baseNode->insert("ast", base);
+			g->add(baseNode);
+			g->addDirectedEdge(classNode, baseNode, "base class");
+		}
+	}
+	else if (scope_ == Scope::Global)
 	{
 		// TODO
 	}

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -41,12 +41,12 @@ AstQuery::AstQuery(QueryType type, Model::Node* target, QStringList args)
 	if (args.size() && args[0] == "g") scope_ = Scope::Global;
 }
 
-Graph* AstQuery::execute(QList<Graph*> input)
+QList<Graph*> AstQuery::execute(QList<Graph*> input)
 {
 	switch (type_)
 	{
-		case QueryType::Methods: return methodsQuery(input);
-		case QueryType::BaseClasses: return baseClassesQuery(input);
+		case QueryType::Methods: return {methodsQuery(input)};
+		case QueryType::BaseClasses: return {baseClassesQuery(input)};
 	}
 }
 

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -66,6 +66,8 @@ QList<Graph*> AstQuery::execute(QList<Graph*> input)
 		case QueryType::CallGraph:
 			result = {callGraph(input)};
 			break;
+		default:
+			Q_ASSERT(false);
 	}
 	// Clean unhandled input:
 	for (auto& g : input) SAFE_DELETE(g);

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -223,7 +223,7 @@ void AstQuery::addBaseEdgesFor(OOModel::Class* childClass, InformationNode* clas
 	{
 		auto baseNode = new InformationNode({{"ast", base}});
 		baseNode = g->add(baseNode);
-		g->addDirectedEdge(classNode, baseNode, "base class");
+		g->addEdge(classNode, baseNode, "base class");
 		addBaseEdgesFor(base, baseNode, g);
 	}
 }
@@ -234,7 +234,7 @@ void AstQuery::addCallInformation(Graph* g, OOModel::Method* method, QList<OOMod
 	for (auto callee : callees)
 	{
 		auto calleeNode = g->add(new InformationNode({{"ast", callee}}));
-		g->addDirectedEdge(methodNode, calleeNode, "calls");
+		g->addEdge(methodNode, calleeNode, "calls");
 	}
 }
 

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -36,6 +36,7 @@ namespace Model {
 
 namespace OOModel {
 	class Class;
+	class Method;
 }
 
 namespace InformationScripting {
@@ -46,7 +47,7 @@ class InformationNode;
 class INFORMATIONSCRIPTING_API AstQuery : public Query
 {
 	public:
-		enum class QueryType : int {Classes, Methods, BaseClasses, ToClass};
+		enum class QueryType : int {Classes, Methods, BaseClasses, ToClass, CallGraph};
 		enum class Scope : int {Local, Global, Input};
 
 		AstQuery(QueryType type, Model::Node* target, QStringList args);
@@ -64,11 +65,14 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 		Graph* methodsQuery(QList<Graph*>& input);
 		Graph* baseClassesQuery(QList<Graph*>& input);
 		Graph* toClassNode(QList<Graph*>& input);
+		Graph* callGraph(QList<Graph*>& input);
 
 		void addBaseEdgesFor(OOModel::Class* childClass, InformationNode* classNode, Graph* g);
 
 		template<class NodeType>
 		void addGlobalNodesOfType(Graph* g);
+
+		void addCallInformation(Graph* g, OOModel::Method* method, QList<OOModel::Method*> callees);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -34,9 +34,14 @@ namespace Model {
 	class Node;
 }
 
+namespace OOModel {
+	class Class;
+}
+
 namespace InformationScripting {
 
 class Graph;
+class InformationNode;
 
 class INFORMATIONSCRIPTING_API AstQuery : public Query
 {
@@ -57,6 +62,8 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 
 		Graph* methodsQuery(QList<Graph*> input);
 		Graph* baseClassesQuery(QList<Graph*> input);
+
+		void addBaseEdgesFor(OOModel::Class* childClass, InformationNode* classNode, Graph* g);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -60,9 +60,9 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 		Scope scope_{};
 		QueryType type_{};
 
-		Graph* methodsQuery(QList<Graph*> input);
-		Graph* baseClassesQuery(QList<Graph*> input);
-		Graph* toClassNode(QList<Graph*> input);
+		Graph* methodsQuery(QList<Graph*>& input);
+		Graph* baseClassesQuery(QList<Graph*>& input);
+		Graph* toClassNode(QList<Graph*>& input);
 
 		void addBaseEdgesFor(OOModel::Class* childClass, InformationNode* classNode, Graph* g);
 };

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -49,7 +49,7 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 		enum class QueryType : int {Methods, BaseClasses};
 		enum class Scope : int {Local, Global};
 
-		AstQuery(QueryType type, Model::Node* target, Scope scope);
+		AstQuery(QueryType type, Model::Node* target, QStringList args);
 
 		// TODO for now this is just for methods. We have to figure out how to make this more generic.
 		// Maybe use a function pointer, but where should the function be defined?

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -47,7 +47,7 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 {
 	public:
 		enum class QueryType : int {Classes, Methods, BaseClasses, ToClass};
-		enum class Scope : int {Local, Global};
+		enum class Scope : int {Local, Global, Input};
 
 		AstQuery(QueryType type, Model::Node* target, QStringList args);
 

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -41,9 +41,10 @@ class Graph;
 class INFORMATIONSCRIPTING_API AstQuery : public Query
 {
 	public:
+		enum class QueryType : int {Methods, BaseClasses};
 		enum class Scope : int {Local, Global};
 
-		AstQuery(Model::Node* target, Scope scope);
+		AstQuery(QueryType type, Model::Node* target, Scope scope);
 
 		// TODO for now this is just for methods. We have to figure out how to make this more generic.
 		// Maybe use a function pointer, but where should the function be defined?
@@ -52,6 +53,10 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 	private:
 		Model::Node* target_{};
 		Scope scope_{};
+		QueryType type_{};
+
+		Graph* methodsQuery(QList<Graph*> input);
+		Graph* baseClassesQuery(QList<Graph*> input);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -46,7 +46,7 @@ class InformationNode;
 class INFORMATIONSCRIPTING_API AstQuery : public Query
 {
 	public:
-		enum class QueryType : int {Methods, BaseClasses, ToClass};
+		enum class QueryType : int {Classes, Methods, BaseClasses, ToClass};
 		enum class Scope : int {Local, Global};
 
 		AstQuery(QueryType type, Model::Node* target, QStringList args);
@@ -60,11 +60,15 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 		Scope scope_{};
 		QueryType type_{};
 
+		Graph* classesQuery(QList<Graph*>& input);
 		Graph* methodsQuery(QList<Graph*>& input);
 		Graph* baseClassesQuery(QList<Graph*>& input);
 		Graph* toClassNode(QList<Graph*>& input);
 
 		void addBaseEdgesFor(OOModel::Class* childClass, InformationNode* classNode, Graph* g);
+
+		template<class NodeType>
+		void addGlobalNodesOfType(Graph* g);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -24,26 +24,34 @@
 **
 ***********************************************************************************************************************/
 
-#include "AstSource.h"
+#pragma once
 
-#include "OOModel/src/declarations/Class.h"
+#include "../informationscripting_api.h"
 
-#include "ModelBase/src/nodes/Node.h"
+#include "Query.h"
 
-#include "../graph/Graph.h"
-#include "../graph/InformationNode.h"
+namespace Model {
+	class Node;
+}
 
 namespace InformationScripting {
 
-AstSource& AstSource::instance()
-{
-	static AstSource instance;
-	return instance;
-}
+class Graph;
 
-AstQuery* AstSource::createMethodQuery(Model::Node* target, AstQuery::Scope scope)
+class INFORMATIONSCRIPTING_API AstQuery : public Query
 {
-	return new AstQuery(target, scope);
-}
+	public:
+		enum class Scope : int {Local, Global};
+
+		AstQuery(Model::Node* target, Scope scope);
+
+		// TODO for now this is just for methods. We have to figure out how to make this more generic.
+		// Maybe use a function pointer, but where should the function be defined?
+		virtual Graph* execute(QList<Graph*> input) override;
+
+	private:
+		Model::Node* target_{};
+		Scope scope_{};
+};
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -52,8 +52,6 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 
 		AstQuery(QueryType type, Model::Node* target, QStringList args);
 
-		// TODO for now this is just for methods. We have to figure out how to make this more generic.
-		// Maybe use a function pointer, but where should the function be defined?
 		virtual QList<Graph*> execute(QList<Graph*> input) override;
 
 	private:

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -53,7 +53,7 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 
 		// TODO for now this is just for methods. We have to figure out how to make this more generic.
 		// Maybe use a function pointer, but where should the function be defined?
-		virtual Graph* execute(QList<Graph*> input) override;
+		virtual QList<Graph*> execute(QList<Graph*> input) override;
 
 	private:
 		Model::Node* target_{};

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -46,7 +46,7 @@ class InformationNode;
 class INFORMATIONSCRIPTING_API AstQuery : public Query
 {
 	public:
-		enum class QueryType : int {Methods, BaseClasses};
+		enum class QueryType : int {Methods, BaseClasses, ToClass};
 		enum class Scope : int {Local, Global};
 
 		AstQuery(QueryType type, Model::Node* target, QStringList args);
@@ -62,6 +62,7 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 
 		Graph* methodsQuery(QList<Graph*> input);
 		Graph* baseClassesQuery(QList<Graph*> input);
+		Graph* toClassNode(QList<Graph*> input);
 
 		void addBaseEdgesFor(OOModel::Class* childClass, InformationNode* classNode, Graph* g);
 };

--- a/InformationScripting/src/queries/ComplementOperator.cpp
+++ b/InformationScripting/src/queries/ComplementOperator.cpp
@@ -1,0 +1,45 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "ComplementOperator.h"
+
+#include "../graph/Graph.h"
+
+namespace InformationScripting {
+
+QList<Graph*> ComplementOperator::execute(QList<Graph*> input)
+{
+	Q_ASSERT(input.size() == 2);
+	auto graphA = input[0];
+	auto graphB = input[1];
+
+	for (auto node : graphB->nodes())
+		graphA->remove(node); // As remove works on the hashvalue we can use the pointer from graphB in graphA.
+	SAFE_DELETE(graphB);
+	return {graphA};
+}
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/ComplementOperator.h
+++ b/InformationScripting/src/queries/ComplementOperator.h
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../informationscripting_api.h"
+
+#include "Query.h"
+
+namespace InformationScripting {
+
+class INFORMATIONSCRIPTING_API ComplementOperator : public Query
+{
+	public:
+		virtual QList<Graph*> execute(QList<Graph*> input);
+};
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/CompositeQuery.cpp
+++ b/InformationScripting/src/queries/CompositeQuery.cpp
@@ -41,63 +41,58 @@ QList<Graph*> CompositeQuery::execute(QList<Graph*> input)
 {
 	inNode_->calculatedOutputs_ = input;
 	// Nodes for which we have all dependencies calculated:
-	QQueue<QueryNode*> workingSetNodes;
-	workingSetNodes.enqueue(inNode_);
-	QSet<QueryNode*> visitedNodes;
+	QQueue<QueryNode*> justExecutedQueries;
+	justExecutedQueries.enqueue(inNode_);
+	QSet<QueryNode*> fullyProcessedQueries;
 
 	// Check if we have nodes which take no input:
 	for (auto queryNode : nodes_)
 	{
-		if (queryNode->inputs_.empty())
+		if (queryNode->inputMap_.empty())
 		{
 			Q_ASSERT(queryNode->q_);
 			queryNode->execute();
-			workingSetNodes.enqueue(queryNode);
+			justExecutedQueries.enqueue(queryNode);
 		}
 	}
 
-	while (!workingSetNodes.empty())
+	while (!justExecutedQueries.empty())
 	{
-		auto currentNode = workingSetNodes.dequeue();
+		auto currentNode = justExecutedQueries.dequeue();
 		// TODO: once we allow cyclic dependencies we have to be smarter here:
-		if (visitedNodes.contains(currentNode)) continue;
-		visitedNodes.insert(currentNode);
+		Q_ASSERT (!fullyProcessedQueries.contains(currentNode));
+		fullyProcessedQueries.insert(currentNode);
 
-		for (auto outputMapping : currentNode->outputs_)
+		for (int outIndex = 0; outIndex < currentNode->outputMap_.size(); ++outIndex)
 		{
-			int outIndex = outputMapping.outputIndex_;
+			auto outputMapping = currentNode->outputMap_[outIndex];
 			// TODO: this shouldn't be an assertion later, but rather some error which is presented to the user.
 			Q_ASSERT(outIndex < currentNode->calculatedOutputs_.size());
 
 			// FIXME: multiple output receivers requires Graph copy constructor:
-			Q_ASSERT(outputMapping.outputReceivers_.size() <= 1);
+			Q_ASSERT(outputMapping.size() <= 1);
 
-			if (outputMapping.outputReceivers_.size() == 1)
+			if (outputMapping.size() == 1)
 			{
-				auto receiver = *outputMapping.outputReceivers_.begin();
+				auto receiver = *outputMapping.begin();
 				// find the input mapping of the receiver:
-				auto inputIt = std::find_if(receiver->inputs_.begin(), receiver->inputs_.end(),
+				auto inputIt = std::find_if(receiver->inputMap_.begin(), receiver->inputMap_.end(),
 					[currentNode, outIndex] (const InputMapping& m) {
 					return m.outputFrom_ == currentNode && m.outputIndex_ == outIndex;
 				});
-				Q_ASSERT(inputIt != receiver->inputs_.end());
-				auto inputMapping = *inputIt;
-				receiver->addCalculatedInput(inputMapping.inputIndex_, currentNode->calculatedOutputs_[outIndex]);
+				Q_ASSERT(inputIt != receiver->inputMap_.end());
+				receiver->addCalculatedInput(std::distance(receiver->inputMap_.begin(), inputIt),
+													  currentNode->calculatedOutputs_[outIndex]);
 
 				if (receiver->canExecute())
 				{
 					receiver->execute();
-					workingSetNodes.enqueue(receiver);
+					justExecutedQueries.enqueue(receiver);
 				}
 			}
 		}
 	}
 	return outNode_->calculatedOutputs_;
-}
-
-void CompositeQuery::addQuery(Query* q)
-{
-	if (!nodeForQuery(q)) nodes_.push_back(new QueryNode(q));
 }
 
 void CompositeQuery::connectQuery(Query* from, Query* to)
@@ -134,29 +129,24 @@ CompositeQuery::QueryNode* CompositeQuery::nodeForQuery(Query* q)
 void CompositeQuery::addOutputMapping(CompositeQuery::QueryNode* outNode, int outIndex,
 												  CompositeQuery::QueryNode* inNode)
 {
-	// Add output mapping
-	auto it = std::find_if(outNode->outputs_.begin(), outNode->outputs_.end(),
-					 [outIndex](const OutputMapping& m) {return m.outputIndex_ == outIndex;});
-	if (it != outNode->outputs_.end())
-		it->outputReceivers_.insert(inNode);
-	else
-		outNode->outputs_.push_back({outIndex, {inNode}});
+	if (outIndex >= outNode->outputMap_.size()) outNode->outputMap_.resize(outIndex + 1);
+	outNode->outputMap_[outIndex].insert(inNode);
 }
 
 void CompositeQuery::addInputMapping(CompositeQuery::QueryNode* outNode, int outIndex,
 												 CompositeQuery::QueryNode* inNode, int inIndex)
 {
-	// Add output mapping
-	auto it = std::find_if(inNode->inputs_.begin(), inNode->inputs_.end(),
-					 [inIndex](const InputMapping& m) {return m.inputIndex_ == inIndex;});
-	if (it != inNode->inputs_.end())
+	if (inIndex >= inNode->inputMap_.size()) inNode->inputMap_.resize(inIndex + 1);
+	auto& existingMapping = inNode->inputMap_[inIndex];
+	if (existingMapping.outputFrom_)
 	{
 		// Only single connection to input allowed:
-		Q_ASSERT(it->outputFrom_ == outNode && it->outputIndex_ == outIndex);
+		Q_ASSERT(existingMapping.outputFrom_ == outNode && existingMapping.outputIndex_ == outIndex);
 		// Already there
 		return;
 	}
-	inNode->inputs_.push_back({inIndex, outNode, outIndex});
+	existingMapping.outputFrom_ = outNode;
+	existingMapping.outputIndex_ = outIndex;
 }
 
 CompositeQuery::QueryNode::~QueryNode()
@@ -164,9 +154,7 @@ CompositeQuery::QueryNode::~QueryNode()
 	// For all calculated outputs check if they are mapped to something, if not delete them:
 	for (int i = 0; i < calculatedOutputs_.size(); ++i)
 	{
-		auto it = std::find_if(outputs_.begin(), outputs_.end(),
-									  [i](const OutputMapping& m) {return m.outputIndex_ == i;});
-		if (it == outputs_.end())
+		if (outputMap_[i].empty())
 			SAFE_DELETE(calculatedOutputs_[i]);
 	}
 	SAFE_DELETE(q_);
@@ -180,15 +168,13 @@ void CompositeQuery::QueryNode::addCalculatedInput(int index, Graph* g)
 	// Insert current input at correct location
 	calculatedInputs_[index] = g;
 	// Set the inserted flag
-	auto it = std::find_if(inputs_.begin(), inputs_.end(),
-								  [index](const InputMapping& m) {return m.inputIndex_ == index;});
-	Q_ASSERT(it != inputs_.end());
-	it->inserted_ = true;
+	Q_ASSERT(index < inputMap_.size() && inputMap_[index].outputFrom_);
+	inputMap_[index].inserted_ = true;
 }
 
 bool CompositeQuery::QueryNode::canExecute() const
 {
-	return std::all_of(inputs_.begin(), inputs_.end(), [](const InputMapping& m) {return m.inserted_;});
+	return std::all_of(inputMap_.begin(), inputMap_.end(), [](const InputMapping& m) {return m.inserted_;});
 }
 
 void CompositeQuery::QueryNode::execute()

--- a/InformationScripting/src/queries/CompositeQuery.cpp
+++ b/InformationScripting/src/queries/CompositeQuery.cpp
@@ -1,0 +1,154 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "CompositeQuery.h"
+
+namespace InformationScripting {
+
+CompositeQuery::~CompositeQuery()
+{
+	SAFE_DELETE(inNode_);
+	for (auto node : nodes_) SAFE_DELETE(node);
+}
+
+QList<Graph*> CompositeQuery::execute(QList<Graph*> input)
+{
+	inNode_->calculatedOutputs_ = input;
+	// Nodes for which we have all dependencies calculated:
+	QQueue<QueryNode*> workingSetNodes;
+	workingSetNodes.enqueue(inNode_);
+	QSet<QueryNode*> visitedNodes;
+
+	// Check if we have nodes which take no input:
+	for (auto queryNode : nodes_)
+	{
+		if (queryNode->inputs_.empty())
+		{
+			Q_ASSERT(queryNode->q_);
+			queryNode->execute();
+			workingSetNodes.enqueue(queryNode);
+		}
+	}
+
+	while (!workingSetNodes.empty())
+	{
+		auto currentNode = workingSetNodes.dequeue();
+		// TODO: once we allow cyclic dependencies we have to be smarter here:
+		if (visitedNodes.contains(currentNode)) continue;
+		visitedNodes.insert(currentNode);
+
+		for (auto outputMapping : currentNode->outputs_)
+		{
+			int outIndex = outputMapping.outputIndex_;
+			// TODO: this shouldn't be an assertion later, but rather some error which is presented to the user.
+			Q_ASSERT(outIndex < currentNode->calculatedOutputs_.size());
+
+			// FIXME: multiple output receivers requires Graph copy constructor:
+			Q_ASSERT(outputMapping.outputReceivers_.size() <= 1);
+
+			if (outputMapping.outputReceivers_.size() == 1)
+			{
+				auto receiver = *outputMapping.outputReceivers_.begin();
+				// find the input mapping of the receiver:
+				auto inputIt = std::find_if(receiver->inputs_.begin(), receiver->inputs_.end(),
+					[currentNode, outIndex] (const InputMapping& m) {
+					return m.outputFrom_ == currentNode && m.outputIndex_ == outIndex;
+				});
+				Q_ASSERT(inputIt != receiver->inputs_.end());
+				auto inputMapping = *inputIt;
+				receiver->addCalculatedInput(inputMapping.inputIndex_, currentNode->calculatedOutputs_[outIndex]);
+
+				if (receiver->canExecute())
+				{
+					receiver->execute();
+					workingSetNodes.enqueue(receiver);
+				}
+			}
+		}
+	}
+	return outNode_->calculatedOutputs_;
+}
+
+void CompositeQuery::addQuery(Query* q)
+{
+	if (!nodeForQuery(q)) nodes_.push_back(new QueryNode(q));
+}
+
+void CompositeQuery::connectQuery(Query* from, Query* to)
+{
+	auto fromNode = nodeForQuery(from);
+	auto toNode = nodeForQuery(to);
+
+	addOutputMapping(fromNode, 0, toNode);
+	addInputMapping(fromNode, 0, toNode, 0);
+}
+
+void CompositeQuery::connectToOutput(Query* from, int outIndex)
+{
+	auto fromNode = nodeForQuery(from);
+
+	addOutputMapping(fromNode, 0, outNode_);
+	addInputMapping(fromNode, 0, outNode_, outIndex);
+}
+
+CompositeQuery::QueryNode* CompositeQuery::nodeForQuery(Query* q)
+{
+	auto it = std::find_if(nodes_.begin(), nodes_.end(), [q](QueryNode* d) {return d->q_ == q;});
+	if (it != nodes_.end()) return *it;
+	auto newNode = new QueryNode(q);
+	nodes_.push_back(newNode);
+	return newNode;
+}
+
+void CompositeQuery::addOutputMapping(CompositeQuery::QueryNode* outNode, int outIndex,
+												  CompositeQuery::QueryNode* inNode)
+{
+	// Add output mapping
+	auto it = std::find_if(outNode->outputs_.begin(), outNode->outputs_.end(),
+					 [outIndex](const OutputMapping& m) {return m.outputIndex_ == outIndex;});
+	if (it != outNode->outputs_.end())
+		it->outputReceivers_.insert(inNode);
+	else
+		outNode->outputs_.push_back({outIndex, {inNode}});
+}
+
+void CompositeQuery::addInputMapping(CompositeQuery::QueryNode* outNode, int outIndex,
+												 CompositeQuery::QueryNode* inNode, int inIndex)
+{
+	// Add output mapping
+	auto it = std::find_if(inNode->inputs_.begin(), inNode->inputs_.end(),
+					 [inIndex](const InputMapping& m) {return m.inputIndex_ == inIndex;});
+	if (it != inNode->inputs_.end())
+	{
+		// Only single connection to input allowed:
+		Q_ASSERT(it->outputFrom_ == outNode && it->outputIndex_ == outIndex);
+		// Already there
+		return;
+	}
+	inNode->inputs_.push_back({inIndex, outNode, outIndex});
+}
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/CompositeQuery.cpp
+++ b/InformationScripting/src/queries/CompositeQuery.cpp
@@ -102,11 +102,16 @@ void CompositeQuery::addQuery(Query* q)
 
 void CompositeQuery::connectQuery(Query* from, Query* to)
 {
+	connectQuery(from, 0, to, 0);
+}
+
+void CompositeQuery::connectQuery(Query* from, int outIndex, Query* to, int inIndex)
+{
 	auto fromNode = nodeForQuery(from);
 	auto toNode = nodeForQuery(to);
 
-	addOutputMapping(fromNode, 0, toNode);
-	addInputMapping(fromNode, 0, toNode, 0);
+	addOutputMapping(fromNode, outIndex, toNode);
+	addInputMapping(fromNode, outIndex, toNode, inIndex);
 }
 
 void CompositeQuery::connectToOutput(Query* from, int outIndex)

--- a/InformationScripting/src/queries/CompositeQuery.h
+++ b/InformationScripting/src/queries/CompositeQuery.h
@@ -82,38 +82,16 @@ class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 
 		struct QueryNode {
 				QueryNode(Query* q) : q_{q} {}
-				~QueryNode() { SAFE_DELETE(q_); }
+				~QueryNode();
 				QList<InputMapping> inputs_;
 				QList<OutputMapping> outputs_;
 
 				QList<Graph*> calculatedInputs_;
 				QList<Graph*> calculatedOutputs_;
 
-				void addCalculatedInput(int index, Graph* g) {
-					// Fill non determined inputs with nullptrs:
-					while (calculatedInputs_.size() - 1 < index)
-						calculatedInputs_.push_back(nullptr);
-					// Insert current input at correct location
-					calculatedInputs_[index] = g;
-					// Set the inserted flag
-					auto it = std::find_if(inputs_.begin(), inputs_.end(),
-									 [index](const InputMapping& m) {return m.inputIndex_ == index;});
-					Q_ASSERT(it != inputs_.end());
-					it->inserted_ = true;
-				}
-
-				bool canExecute() const
-				{
-					return std::all_of(inputs_.begin(), inputs_.end(), [](const InputMapping& m) {return m.inserted_;});
-				}
-
-				void execute()
-				{
-					if (q_)
-						calculatedOutputs_ = q_->execute(calculatedInputs_);
-					else
-						calculatedOutputs_ = calculatedInputs_;
-				}
+				void addCalculatedInput(int index, Graph* g);
+				bool canExecute() const;
+				void execute();
 
 				Query* q_{};
 		};

--- a/InformationScripting/src/queries/CompositeQuery.h
+++ b/InformationScripting/src/queries/CompositeQuery.h
@@ -40,11 +40,6 @@ class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 		virtual QList<Graph*> execute(QList<Graph*> input) override;
 
 		/**
-		 * Adds the Query \a q to this CompositeQuery. This query takes ownership of \a q.
-		 */
-		void addQuery(Query* q);
-
-		/**
 		 * Connects output 0 from Query \a from to input 0 of Query \a to.
 		 *
 		 * If either \a from or \a to was not yet inserted they will be and this query will take ownership of it.
@@ -58,35 +53,32 @@ class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 
 	private:
 		struct QueryNode;
-		/**
-		 * Describes an input mapping:
-		 * The output with index \a outputIndex_ from the Query \a outputFrom_
-		 * is mapped to the input with index \a inputIndex_.
-		 *
-		 * Note: 1 Input can only receive a single output.
-		 */
+
 		struct InputMapping {
-				int inputIndex_{};
 				QueryNode* outputFrom_{};
 				int outputIndex_{};
 				// Indicates whether this output has been calculated and set.
 				bool inserted_{};
 		};
 
-		/**
-		 * Decribes an output mapping:
-		 * 1 Output can go to multiple receivers.
-		 */
-		struct OutputMapping {
-				int outputIndex_{};
-				QSet<QueryNode*> outputReceivers_{};
-		};
-
 		struct QueryNode {
 				QueryNode(Query* q) : q_{q} {}
 				~QueryNode();
-				QList<InputMapping> inputs_;
-				QList<OutputMapping> outputs_;
+
+				/**
+				 * Describes an input mapping:
+				 * The output with index \a outputIndex_ from the Query \a outputFrom_
+				 * is mapped to the input with index i in the vector.
+				 *
+				 * Note: 1 Input can only receive a single output.
+				 */
+				QVector<InputMapping> inputMap_;
+
+				/**
+				 * Decribes an output mapping:
+				 * 1 Output can go to multiple receivers.
+				 */
+				QVector<QSet<QueryNode*>> outputMap_;
 
 				QList<Graph*> calculatedInputs_;
 				QList<Graph*> calculatedOutputs_;

--- a/InformationScripting/src/queries/CompositeQuery.h
+++ b/InformationScripting/src/queries/CompositeQuery.h
@@ -51,6 +51,8 @@ class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 		 */
 		void connectQuery(Query* from, Query* to);
 
+		void connectQuery(Query* from, int outIndex, Query* to, int inIndex);
+
 		void connectToOutput(Query* from, int outIndex = 0);
 
 

--- a/InformationScripting/src/queries/CompositeQuery.h
+++ b/InformationScripting/src/queries/CompositeQuery.h
@@ -1,0 +1,132 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../informationscripting_api.h"
+
+#include "Query.h"
+
+namespace InformationScripting {
+
+class INFORMATIONSCRIPTING_API CompositeQuery : public Query
+{
+	public:
+		virtual ~CompositeQuery() override;
+
+		virtual QList<Graph*> execute(QList<Graph*> input) override;
+
+		/**
+		 * Adds the Query \a q to this CompositeQuery. This query takes ownership of \a q.
+		 */
+		void addQuery(Query* q);
+
+		/**
+		 * Connects output 0 from Query \a from to input 0 of Query \a to.
+		 *
+		 * If either \a from or \a to was not yet inserted they will be and this query will take ownership of it.
+		 */
+		void connectQuery(Query* from, Query* to);
+
+		void connectToOutput(Query* from, int outIndex = 0);
+
+
+	private:
+		struct QueryNode;
+		/**
+		 * Describes an input mapping:
+		 * The output with index \a outputIndex_ from the Query \a outputFrom_
+		 * is mapped to the input with index \a inputIndex_.
+		 *
+		 * Note: 1 Input can only receive a single output.
+		 */
+		struct InputMapping {
+				int inputIndex_{};
+				QueryNode* outputFrom_{};
+				int outputIndex_{};
+				// Indicates whether this output has been calculated and set.
+				bool inserted_{};
+		};
+
+		/**
+		 * Decribes an output mapping:
+		 * 1 Output can go to multiple receivers.
+		 */
+		struct OutputMapping {
+				int outputIndex_{};
+				QSet<QueryNode*> outputReceivers_{};
+		};
+
+		struct QueryNode {
+				QueryNode(Query* q) : q_{q} {}
+				~QueryNode() { SAFE_DELETE(q_); }
+				QList<InputMapping> inputs_;
+				QList<OutputMapping> outputs_;
+
+				QList<Graph*> calculatedInputs_;
+				QList<Graph*> calculatedOutputs_;
+
+				void addCalculatedInput(int index, Graph* g) {
+					// Fill non determined inputs with nullptrs:
+					while (calculatedInputs_.size() - 1 < index)
+						calculatedInputs_.push_back(nullptr);
+					// Insert current input at correct location
+					calculatedInputs_[index] = g;
+					// Set the inserted flag
+					auto it = std::find_if(inputs_.begin(), inputs_.end(),
+									 [index](const InputMapping& m) {return m.inputIndex_ == index;});
+					Q_ASSERT(it != inputs_.end());
+					it->inserted_ = true;
+				}
+
+				bool canExecute() const
+				{
+					return std::all_of(inputs_.begin(), inputs_.end(), [](const InputMapping& m) {return m.inserted_;});
+				}
+
+				void execute()
+				{
+					if (q_)
+						calculatedOutputs_ = q_->execute(calculatedInputs_);
+					else
+						calculatedOutputs_ = calculatedInputs_;
+				}
+
+				Query* q_{};
+		};
+		// Pseudo node to connect, to get input from execute method
+		QueryNode* inNode_{new QueryNode(nullptr)};
+		// Pseudo node to connect, to map the output
+		QueryNode* outNode_{new QueryNode(nullptr)};
+		QList<QueryNode*> nodes_;
+
+		QueryNode* nodeForQuery(Query* q);
+
+		void addOutputMapping(QueryNode* outNode, int outIndex, QueryNode* inNode);
+		void addInputMapping(QueryNode* outNode, int outIndex, QueryNode* inNode, int inIndex);
+};
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/GenericFilter.cpp
+++ b/InformationScripting/src/queries/GenericFilter.cpp
@@ -24,33 +24,28 @@
 **
 ***********************************************************************************************************************/
 
-#pragma once
+#include "GenericFilter.h"
 
-#include "../informationscripting_api.h"
-
-#include "../queries/AstQuery.h"
-
-namespace Model {
-	class Node;
-}
+#include "../graph/Graph.h"
 
 namespace InformationScripting {
 
-class Graph;
+GenericFilter::GenericFilter(GenericFilter::KeepNode f) : keepNode_{f}
+{}
 
-class AstSource
+QList<Graph*> GenericFilter::execute(QList<Graph*> input)
 {
-	public:
-		static AstSource& instance();
-		static void init();
+	for (auto g : input) applyFilter(g);
+	return input;
+}
 
-		AstQuery* createClassesQuery(Model::Node* target, QStringList args);
-		AstQuery* createMethodQuery(Model::Node* target, QStringList args);
-		AstQuery* createBaseClassesQuery(Model::Node* target, QStringList args);
-		AstQuery* createToClassNodeQuery(Model::Node* target, QStringList args);
+void GenericFilter::applyFilter(Graph* g)
+{
+	if (!g) return;
 
-	private:
-		AstSource() = default;
-};
+	auto nodes = g->nodes();
+	for (auto n : nodes)
+		if (!keepNode_(n)) g->remove(n);
+}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/GenericFilter.cpp
+++ b/InformationScripting/src/queries/GenericFilter.cpp
@@ -43,8 +43,7 @@ void GenericFilter::applyFilter(Graph* g)
 {
 	if (!g) return;
 
-	auto nodes = g->nodes();
-	for (auto n : nodes)
+	for (auto n : g->nodes())
 		if (!keepNode_(n)) g->remove(n);
 }
 

--- a/InformationScripting/src/queries/GenericFilter.h
+++ b/InformationScripting/src/queries/GenericFilter.h
@@ -28,29 +28,24 @@
 
 #include "../informationscripting_api.h"
 
-#include "../queries/AstQuery.h"
-
-namespace Model {
-	class Node;
-}
+#include "Query.h"
 
 namespace InformationScripting {
 
-class Graph;
+class InformationNode;
 
-class AstSource
+class INFORMATIONSCRIPTING_API GenericFilter : public Query
 {
 	public:
-		static AstSource& instance();
-		static void init();
+		using KeepNode = std::function<bool(const InformationNode*)>;
+		GenericFilter(KeepNode f);
 
-		AstQuery* createClassesQuery(Model::Node* target, QStringList args);
-		AstQuery* createMethodQuery(Model::Node* target, QStringList args);
-		AstQuery* createBaseClassesQuery(Model::Node* target, QStringList args);
-		AstQuery* createToClassNodeQuery(Model::Node* target, QStringList args);
+		virtual QList<Graph*> execute(QList<Graph*> input) override;
 
 	private:
-		AstSource() = default;
+		KeepNode keepNode_;
+
+		void applyFilter(Graph* g);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/Query.h
+++ b/InformationScripting/src/queries/Query.h
@@ -36,7 +36,7 @@ class INFORMATIONSCRIPTING_API Query
 {
 	public:
 		virtual ~Query() = default;
-		virtual Graph* execute(QList<Graph*>) = 0;
+		virtual QList<Graph*> execute(QList<Graph*>) = 0;
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/Query.h
+++ b/InformationScripting/src/queries/Query.h
@@ -24,26 +24,19 @@
 **
 ***********************************************************************************************************************/
 
-#include "AstSource.h"
+#pragma once
 
-#include "OOModel/src/declarations/Class.h"
-
-#include "ModelBase/src/nodes/Node.h"
-
-#include "../graph/Graph.h"
-#include "../graph/InformationNode.h"
+#include "../informationscripting_api.h"
 
 namespace InformationScripting {
 
-AstSource& AstSource::instance()
-{
-	static AstSource instance;
-	return instance;
-}
+class Graph;
 
-AstQuery* AstSource::createMethodQuery(Model::Node* target, AstQuery::Scope scope)
+class INFORMATIONSCRIPTING_API Query
 {
-	return new AstQuery(target, scope);
-}
+	public:
+		virtual ~Query() = default;
+		virtual Graph* execute(QList<Graph*>) = 0;
+};
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/QueryExecutor.cpp
+++ b/InformationScripting/src/queries/QueryExecutor.cpp
@@ -24,26 +24,26 @@
 **
 ***********************************************************************************************************************/
 
-#include "AstSource.h"
+#include "QueryExecutor.h"
 
-#include "OOModel/src/declarations/Class.h"
-
-#include "ModelBase/src/nodes/Node.h"
-
-#include "../graph/Graph.h"
-#include "../graph/InformationNode.h"
+#include "Query.h"
 
 namespace InformationScripting {
 
-AstSource& AstSource::instance()
+QueryExecutor::QueryExecutor(Query* q) : query_{q} {}
+
+QueryExecutor::~QueryExecutor()
 {
-	static AstSource instance;
-	return instance;
+	SAFE_DELETE(query_);
 }
 
-AstQuery* AstSource::createMethodQuery(Model::Node* target, AstQuery::Scope scope)
+void QueryExecutor::execute()
 {
-	return new AstQuery(target, scope);
+	auto result = query_->execute({});
+	if (result)
+	{
+		// TODO visualize
+	}
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/QueryExecutor.cpp
+++ b/InformationScripting/src/queries/QueryExecutor.cpp
@@ -42,11 +42,12 @@ QueryExecutor::~QueryExecutor()
 
 void QueryExecutor::execute()
 {
-	auto result = query_->execute({});
-	if (result)
+	auto results = query_->execute({});
+	if (results.size())
 	{
-		DefaultVisualizer::instance().visualize(result);
-		SAFE_DELETE(result);
+		DefaultVisualizer::instance().visualize(results[0]);
+		for (auto result : results) SAFE_DELETE(result);
+		results.clear();
 	}
 }
 

--- a/InformationScripting/src/queries/QueryExecutor.h
+++ b/InformationScripting/src/queries/QueryExecutor.h
@@ -24,26 +24,24 @@
 **
 ***********************************************************************************************************************/
 
-#include "AstSource.h"
+#pragma once
 
-#include "OOModel/src/declarations/Class.h"
-
-#include "ModelBase/src/nodes/Node.h"
-
-#include "../graph/Graph.h"
-#include "../graph/InformationNode.h"
+#include "../informationscripting_api.h"
 
 namespace InformationScripting {
 
-AstSource& AstSource::instance()
-{
-	static AstSource instance;
-	return instance;
-}
+class Query;
 
-AstQuery* AstSource::createMethodQuery(Model::Node* target, AstQuery::Scope scope)
+class INFORMATIONSCRIPTING_API QueryExecutor
 {
-	return new AstQuery(target, scope);
-}
+	public:
+		QueryExecutor(Query* q);
+		~QueryExecutor();
+
+		void execute();
+
+	private:
+		Query* query_{};
+};
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/SubstractNodesOperator.cpp
+++ b/InformationScripting/src/queries/SubstractNodesOperator.cpp
@@ -24,13 +24,13 @@
 **
 ***********************************************************************************************************************/
 
-#include "ComplementOperator.h"
+#include "SubstractNodesOperator.h"
 
 #include "../graph/Graph.h"
 
 namespace InformationScripting {
 
-QList<Graph*> ComplementOperator::execute(QList<Graph*> input)
+QList<Graph*> SubstractNodesOperator::execute(QList<Graph*> input)
 {
 	Q_ASSERT(input.size() == 2);
 	auto graphA = input[0];

--- a/InformationScripting/src/queries/SubstractNodesOperator.h
+++ b/InformationScripting/src/queries/SubstractNodesOperator.h
@@ -32,7 +32,7 @@
 
 namespace InformationScripting {
 
-class INFORMATIONSCRIPTING_API ComplementOperator : public Query
+class INFORMATIONSCRIPTING_API SubstractNodesOperator : public Query
 {
 	public:
 		virtual QList<Graph*> execute(QList<Graph*> input);

--- a/InformationScripting/src/sources/AstSource.cpp
+++ b/InformationScripting/src/sources/AstSource.cpp
@@ -35,12 +35,6 @@
 
 namespace InformationScripting {
 
-AstSource& AstSource::instance()
-{
-	static AstSource instance;
-	return instance;
-}
-
 void AstSource::init()
 {
 	auto astHash = [](const InformationNode* n) -> QPair<std::size_t, bool> {
@@ -54,31 +48,6 @@ void AstSource::init()
 	};
 
 	Graph::registerNodeHash(astHash);
-}
-
-AstQuery* AstSource::createClassesQuery(Model::Node* target, QStringList args)
-{
-	return new AstQuery(AstQuery::QueryType::Classes, target, args);
-}
-
-AstQuery* AstSource::createMethodQuery(Model::Node* target, QStringList args)
-{
-	return new AstQuery(AstQuery::QueryType::Methods, target, args);
-}
-
-AstQuery* AstSource::createBaseClassesQuery(Model::Node* target, QStringList args)
-{
-	return new AstQuery(AstQuery::QueryType::BaseClasses, target, args);
-}
-
-AstQuery* AstSource::createToClassNodeQuery(Model::Node* target, QStringList args)
-{
-	return new AstQuery(AstQuery::QueryType::ToClass, target, args);
-}
-
-AstQuery* AstSource::createCallgraphQuery(Model::Node* target, QStringList args)
-{
-	return new AstQuery(AstQuery::QueryType::CallGraph, target, args);
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/sources/AstSource.cpp
+++ b/InformationScripting/src/sources/AstSource.cpp
@@ -75,4 +75,9 @@ AstQuery* AstSource::createToClassNodeQuery(Model::Node* target, QStringList arg
 	return new AstQuery(AstQuery::QueryType::ToClass, target, args);
 }
 
+AstQuery* AstSource::createCallgraphQuery(Model::Node* target, QStringList args)
+{
+	return new AstQuery(AstQuery::QueryType::CallGraph, target, args);
+}
+
 } /* namespace InformationScripting */

--- a/InformationScripting/src/sources/AstSource.cpp
+++ b/InformationScripting/src/sources/AstSource.cpp
@@ -44,9 +44,10 @@ AstSource& AstSource::instance()
 void AstSource::init()
 {
 	auto astHash = [](const InformationNode* n) -> QPair<std::size_t, bool> {
-		if (n->contains("ast"))
+		auto it = n->find("ast");
+		if (it != n->end())
 		{
-			Model::Node* nodePtr = (*n)["ast"];
+			Model::Node* nodePtr = it->second;
 			return {std::hash<Model::Node*>()(nodePtr), true};
 		}
 		return {0, false};

--- a/InformationScripting/src/sources/AstSource.cpp
+++ b/InformationScripting/src/sources/AstSource.cpp
@@ -55,6 +55,11 @@ void AstSource::init()
 	Graph::registerNodeHash(astHash);
 }
 
+AstQuery* AstSource::createClassesQuery(Model::Node* target, QStringList args)
+{
+	return new AstQuery(AstQuery::QueryType::Classes, target, args);
+}
+
 AstQuery* AstSource::createMethodQuery(Model::Node* target, QStringList args)
 {
 	return new AstQuery(AstQuery::QueryType::Methods, target, args);

--- a/InformationScripting/src/sources/AstSource.cpp
+++ b/InformationScripting/src/sources/AstSource.cpp
@@ -46,9 +46,14 @@ AstQuery* AstSource::createMethodQuery(Model::Node* target, QStringList args)
 	return new AstQuery(AstQuery::QueryType::Methods, target, args);
 }
 
-AstQuery*AstSource::createBaseClassesQuery(Model::Node* target, QStringList args)
+AstQuery* AstSource::createBaseClassesQuery(Model::Node* target, QStringList args)
 {
 	return new AstQuery(AstQuery::QueryType::BaseClasses, target, args);
+}
+
+AstQuery* AstSource::createToClassNodeQuery(Model::Node* target, QStringList args)
+{
+	return new AstQuery(AstQuery::QueryType::ToClass, target, args);
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/sources/AstSource.cpp
+++ b/InformationScripting/src/sources/AstSource.cpp
@@ -1,0 +1,64 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "AstSource.h"
+
+#include "OOModel/src/declarations/Class.h"
+
+#include "ModelBase/src/nodes/Node.h"
+
+#include "../graph/Graph.h"
+#include "../graph/InformationNode.h"
+
+namespace InformationScripting {
+
+AstSource& AstSource::instance()
+{
+	static AstSource instance;
+	return instance;
+}
+
+Graph AstSource::methods(Model::Node* target, AstSource::Scope scope)
+{
+	Graph g;
+	if (scope == AstSource::Scope::Local)
+	{
+		auto parentClass = target->firstAncestorOfType<OOModel::Class>();
+		for (auto method : *parentClass->methods())
+		{
+			auto node = new InformationNode();
+			node->insert("ast", method);
+			g.add(node);
+		}
+	}
+	else if (scope == AstSource::Scope::Global)
+	{
+		// TODO
+	}
+	return g;
+}
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/sources/AstSource.cpp
+++ b/InformationScripting/src/sources/AstSource.cpp
@@ -41,6 +41,20 @@ AstSource& AstSource::instance()
 	return instance;
 }
 
+void AstSource::init()
+{
+	auto astHash = [](const InformationNode* n) -> QPair<std::size_t, bool> {
+		if (n->contains("ast"))
+		{
+			Model::Node* nodePtr = (*n)["ast"];
+			return {std::hash<Model::Node*>()(nodePtr), true};
+		}
+		return {0, false};
+	};
+
+	Graph::registerNodeHash(astHash);
+}
+
 AstQuery* AstSource::createMethodQuery(Model::Node* target, QStringList args)
 {
 	return new AstQuery(AstQuery::QueryType::Methods, target, args);

--- a/InformationScripting/src/sources/AstSource.cpp
+++ b/InformationScripting/src/sources/AstSource.cpp
@@ -41,14 +41,14 @@ AstSource& AstSource::instance()
 	return instance;
 }
 
-AstQuery* AstSource::createMethodQuery(Model::Node* target, AstQuery::Scope scope)
+AstQuery* AstSource::createMethodQuery(Model::Node* target, QStringList args)
 {
-	return new AstQuery(AstQuery::QueryType::Methods, target, scope);
+	return new AstQuery(AstQuery::QueryType::Methods, target, args);
 }
 
-AstQuery*AstSource::createBaseClassesQuery(Model::Node* target, AstQuery::Scope scope)
+AstQuery*AstSource::createBaseClassesQuery(Model::Node* target, QStringList args)
 {
-	return new AstQuery(AstQuery::QueryType::BaseClasses, target, scope);
+	return new AstQuery(AstQuery::QueryType::BaseClasses, target, args);
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/sources/AstSource.cpp
+++ b/InformationScripting/src/sources/AstSource.cpp
@@ -43,7 +43,12 @@ AstSource& AstSource::instance()
 
 AstQuery* AstSource::createMethodQuery(Model::Node* target, AstQuery::Scope scope)
 {
-	return new AstQuery(target, scope);
+	return new AstQuery(AstQuery::QueryType::Methods, target, scope);
+}
+
+AstQuery*AstSource::createBaseClassesQuery(Model::Node* target, AstQuery::Scope scope)
+{
+	return new AstQuery(AstQuery::QueryType::BaseClasses, target, scope);
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/sources/AstSource.h
+++ b/InformationScripting/src/sources/AstSource.h
@@ -44,6 +44,7 @@ class AstSource
 		static AstSource& instance();
 
 		AstQuery* createMethodQuery(Model::Node* target, AstQuery::Scope scope = AstQuery::Scope::Local);
+		AstQuery* createBaseClassesQuery(Model::Node* target, AstQuery::Scope scope = AstQuery::Scope::Local);
 
 	private:
 		AstSource() = default;

--- a/InformationScripting/src/sources/AstSource.h
+++ b/InformationScripting/src/sources/AstSource.h
@@ -41,17 +41,8 @@ class Graph;
 class AstSource
 {
 	public:
-		static AstSource& instance();
+		AstSource() = delete;
 		static void init();
-
-		AstQuery* createClassesQuery(Model::Node* target, QStringList args);
-		AstQuery* createMethodQuery(Model::Node* target, QStringList args);
-		AstQuery* createBaseClassesQuery(Model::Node* target, QStringList args);
-		AstQuery* createToClassNodeQuery(Model::Node* target, QStringList args);
-		AstQuery* createCallgraphQuery(Model::Node* target, QStringList args);
-
-	private:
-		AstSource() = default;
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/sources/AstSource.h
+++ b/InformationScripting/src/sources/AstSource.h
@@ -48,6 +48,7 @@ class AstSource
 		AstQuery* createMethodQuery(Model::Node* target, QStringList args);
 		AstQuery* createBaseClassesQuery(Model::Node* target, QStringList args);
 		AstQuery* createToClassNodeQuery(Model::Node* target, QStringList args);
+		AstQuery* createCallgraphQuery(Model::Node* target, QStringList args);
 
 	private:
 		AstSource() = default;

--- a/InformationScripting/src/sources/AstSource.h
+++ b/InformationScripting/src/sources/AstSource.h
@@ -42,6 +42,7 @@ class AstSource
 {
 	public:
 		static AstSource& instance();
+		static void init();
 
 		AstQuery* createMethodQuery(Model::Node* target, QStringList args);
 		AstQuery* createBaseClassesQuery(Model::Node* target, QStringList args);

--- a/InformationScripting/src/sources/AstSource.h
+++ b/InformationScripting/src/sources/AstSource.h
@@ -28,6 +28,8 @@
 
 #include "../informationscripting_api.h"
 
+#include "../queries/AstQuery.h"
+
 namespace Model {
 	class Node;
 }
@@ -39,11 +41,9 @@ class Graph;
 class AstSource
 {
 	public:
-		enum class Scope : int {Local, Global};
-
 		static AstSource& instance();
 
-		Graph methods(Model::Node* target, Scope scope = Scope::Local);
+		AstQuery* createMethodQuery(Model::Node* target, AstQuery::Scope scope = AstQuery::Scope::Local);
 
 	private:
 		AstSource() = default;

--- a/InformationScripting/src/sources/AstSource.h
+++ b/InformationScripting/src/sources/AstSource.h
@@ -1,0 +1,52 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../informationscripting_api.h"
+
+namespace Model {
+	class Node;
+}
+
+namespace InformationScripting {
+
+class Graph;
+
+class AstSource
+{
+	public:
+		enum class Scope : int {Local, Global};
+
+		static AstSource& instance();
+
+		Graph methods(Model::Node* target, Scope scope = Scope::Local);
+
+	private:
+		AstSource() = default;
+};
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/sources/AstSource.h
+++ b/InformationScripting/src/sources/AstSource.h
@@ -45,6 +45,7 @@ class AstSource
 
 		AstQuery* createMethodQuery(Model::Node* target, QStringList args);
 		AstQuery* createBaseClassesQuery(Model::Node* target, QStringList args);
+		AstQuery* createToClassNodeQuery(Model::Node* target, QStringList args);
 
 	private:
 		AstSource() = default;

--- a/InformationScripting/src/visitors/AllNodesOfType.h
+++ b/InformationScripting/src/visitors/AllNodesOfType.h
@@ -28,26 +28,34 @@
 
 #include "../informationscripting_api.h"
 
-#include "../queries/AstQuery.h"
-
-namespace Model {
-	class Node;
-}
+#include "ModelBase/src/visitor/VisitorDefinition.h"
 
 namespace InformationScripting {
 
-class Graph;
-
-class AstSource
+template <class NodeType>
+class INFORMATIONSCRIPTING_API AllNodesOfType : public Model::Visitor<AllNodesOfType<NodeType>>
 {
 	public:
-		static AstSource& instance();
+		static void init();
 
-		AstQuery* createMethodQuery(Model::Node* target, QStringList args);
-		AstQuery* createBaseClassesQuery(Model::Node* target, QStringList args);
+		QList<NodeType*> results() const;
 
 	private:
-		AstSource() = default;
+		QList<NodeType*> results_;
+		static void visitNodeType(AllNodesOfType<NodeType>* self, NodeType* n);
 };
+
+template <class NodeType>
+void AllNodesOfType<NodeType>::init() { AllNodesOfType<NodeType>::template addType<NodeType>(visitNodeType);}
+
+template <class NodeType>
+QList<NodeType*> AllNodesOfType<NodeType>::results() const { return results_; }
+
+template <class NodeType>
+void AllNodesOfType<NodeType>::visitNodeType(AllNodesOfType<NodeType>* self, NodeType* n)
+{
+	self->results_.push_back(n);
+}
+
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/visualization/DefaultVisualizer.cpp
+++ b/InformationScripting/src/visualization/DefaultVisualizer.cpp
@@ -29,14 +29,17 @@
 #include "ModelBase/src/nodes/Node.h"
 
 #include "VisualizationBase/src/items/Item.h"
+#include "VisualizationBase/src/overlays/ArrowOverlay.h"
 #include "VisualizationBase/src/overlays/SelectionOverlay.h"
 
 #include "../graph/Graph.h"
+#include "../graph/InformationEdge.h"
 #include "../graph/InformationNode.h"
 
 namespace InformationScripting {
 
 const QString DefaultVisualizer::HIGHLIGHT_OVERLAY_GROUP = {"default graph highlight"};
+const QString DefaultVisualizer::ARROW_OVERLAY_GROUP = {"default arrow"};
 
 DefaultVisualizer DefaultVisualizer::instance()
 {
@@ -46,20 +49,60 @@ DefaultVisualizer DefaultVisualizer::instance()
 
 void DefaultVisualizer::visualize(Graph* g)
 {
-	auto condition = [](const InformationNode* node) {
-		return node->contains("ast");
-	};
-	auto nodes = g->nodesForWhich(condition);
-
-	for (auto informationNode : nodes)
+	auto edgeCondition = [](const InformationEdge *) { return true; };
+	QList<InformationEdge*> edges = g->edgesFowWhich(edgeCondition);
+	if (!edges.empty())
 	{
-		Model::Node* node = (*informationNode)["ast"];
-		auto nodeVisualization = Visualization::Item::nodeItemsMap().find(node);
-		Q_ASSERT(nodeVisualization != Visualization::Item::nodeItemsMap().end());
-		auto item = *nodeVisualization;
-		auto overlay = new Visualization::SelectionOverlay(
-					item, Visualization::SelectionOverlay::itemStyles().get());
-		item->addOverlay(overlay, HIGHLIGHT_OVERLAY_GROUP);
+		// First check if all edges are of the same type
+		QString edgeName = edges[0]->name();
+		bool isSame = std::all_of(edges.begin(), edges.end(),
+										  [edgeName](InformationEdge *e) {return e->name() == edgeName;});
+		if (isSame)
+		{
+			// TODO for now we assume directed
+			for (auto edge : edges)
+			{
+				auto from = edge->from();
+				auto to = edge->to();
+				// TODO for now we just support nodes that have AST property
+				Q_ASSERT(from->contains("ast"));
+				Q_ASSERT(to->contains("ast"));
+
+				Model::Node* fromNode = (*from)["ast"];
+				Model::Node* toNode = (*to)["ast"];
+				auto fromVisualization = Visualization::Item::nodeItemsMap().find(fromNode);
+				Q_ASSERT(fromVisualization != Visualization::Item::nodeItemsMap().end());
+				auto toVisualization = Visualization::Item::nodeItemsMap().find(toNode);
+				Q_ASSERT(toVisualization != Visualization::Item::nodeItemsMap().end());
+				auto fromVisualizationItem = *fromVisualization;
+
+				auto overlay = new Visualization::ArrowOverlay(
+							fromVisualizationItem, *toVisualization, Visualization::ArrowOverlay::itemStyles().get());
+				fromVisualizationItem->addOverlay(overlay, ARROW_OVERLAY_GROUP);
+			}
+		}
+		else
+		{
+			// TODO
+		}
+	}
+	else
+	{
+		auto condition = [](const InformationNode* node) {
+			return node->contains("ast");
+		};
+		auto nodes = g->nodesForWhich(condition);
+
+		for (auto informationNode : nodes)
+		{
+			Model::Node* node = (*informationNode)["ast"];
+			auto nodeVisualization = Visualization::Item::nodeItemsMap().find(node);
+			Q_ASSERT(nodeVisualization != Visualization::Item::nodeItemsMap().end());
+			auto item = *nodeVisualization;
+			auto overlay = new Visualization::SelectionOverlay(
+						item, Visualization::SelectionOverlay::itemStyles().get());
+			item->addOverlay(overlay, HIGHLIGHT_OVERLAY_GROUP);
+		}
 	}
 }
 

--- a/InformationScripting/src/visualization/DefaultVisualizer.cpp
+++ b/InformationScripting/src/visualization/DefaultVisualizer.cpp
@@ -28,8 +28,6 @@
 
 #include "ModelBase/src/nodes/Node.h"
 
-#include "OOModel/src/declarations/Method.h"
-
 #include "VisualizationBase/src/items/Item.h"
 #include "VisualizationBase/src/overlays/SelectionOverlay.h"
 
@@ -55,8 +53,7 @@ void DefaultVisualizer::visualize(Graph* g)
 
 	for (auto informationNode : nodes)
 	{
-		// FIXME: this should be Model::Node* we first have to adapt the property converter for this.
-		OOModel::Method* node = (*informationNode)["ast"];
+		Model::Node* node = (*informationNode)["ast"];
 		auto nodeVisualization = Visualization::Item::nodeItemsMap().find(node);
 		Q_ASSERT(nodeVisualization != Visualization::Item::nodeItemsMap().end());
 		auto item = *nodeVisualization;

--- a/InformationScripting/src/visualization/DefaultVisualizer.cpp
+++ b/InformationScripting/src/visualization/DefaultVisualizer.cpp
@@ -41,7 +41,7 @@ namespace InformationScripting {
 const QString DefaultVisualizer::HIGHLIGHT_OVERLAY_GROUP = {"default graph highlight"};
 const QString DefaultVisualizer::ARROW_OVERLAY_GROUP = {"default arrow"};
 
-DefaultVisualizer DefaultVisualizer::instance()
+DefaultVisualizer& DefaultVisualizer::instance()
 {
 	static DefaultVisualizer instance;
 	return instance;
@@ -49,8 +49,7 @@ DefaultVisualizer DefaultVisualizer::instance()
 
 void DefaultVisualizer::visualize(Graph* g)
 {
-	auto edgeCondition = [](const InformationEdge *) { return true; };
-	QList<InformationEdge*> edges = g->edgesFowWhich(edgeCondition);
+	QList<InformationEdge*> edges = g->edges();
 	if (!edges.empty())
 	{
 		// First check if all edges are of the same type
@@ -91,7 +90,7 @@ void DefaultVisualizer::visualize(Graph* g)
 		auto condition = [](const InformationNode* node) {
 			return node->contains("ast");
 		};
-		auto nodes = g->nodesForWhich(condition);
+		auto nodes = g->nodes(condition);
 
 		for (auto informationNode : nodes)
 		{

--- a/InformationScripting/src/visualization/DefaultVisualizer.h
+++ b/InformationScripting/src/visualization/DefaultVisualizer.h
@@ -24,30 +24,24 @@
 **
 ***********************************************************************************************************************/
 
-#include "QueryExecutor.h"
+#pragma once
 
-#include "Query.h"
-
-#include "../graph/Graph.h"
-#include "visualization/DefaultVisualizer.h"
+#include "../informationscripting_api.h"
 
 namespace InformationScripting {
 
-QueryExecutor::QueryExecutor(Query* q) : query_{q} {}
+class Graph;
 
-QueryExecutor::~QueryExecutor()
+class INFORMATIONSCRIPTING_API DefaultVisualizer
 {
-	SAFE_DELETE(query_);
-}
+	public:
+		static DefaultVisualizer instance();
 
-void QueryExecutor::execute()
-{
-	auto result = query_->execute({});
-	if (result)
-	{
-		DefaultVisualizer::instance().visualize(result);
-		SAFE_DELETE(result);
-	}
-}
+		void visualize(Graph* g);
+	private:
+		DefaultVisualizer() = default;
+
+		static const QString HIGHLIGHT_OVERLAY_GROUP;
+};
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/visualization/DefaultVisualizer.h
+++ b/InformationScripting/src/visualization/DefaultVisualizer.h
@@ -35,7 +35,7 @@ class Graph;
 class INFORMATIONSCRIPTING_API DefaultVisualizer
 {
 	public:
-		static DefaultVisualizer instance();
+		static DefaultVisualizer& instance();
 
 		void visualize(Graph* g);
 	private:

--- a/InformationScripting/src/visualization/DefaultVisualizer.h
+++ b/InformationScripting/src/visualization/DefaultVisualizer.h
@@ -42,6 +42,7 @@ class INFORMATIONSCRIPTING_API DefaultVisualizer
 		DefaultVisualizer() = default;
 
 		static const QString HIGHLIGHT_OVERLAY_GROUP;
+		static const QString ARROW_OVERLAY_GROUP;
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/wrappers/NodeApi.cpp
+++ b/InformationScripting/src/wrappers/NodeApi.cpp
@@ -36,7 +36,7 @@ using namespace boost::python;
 BOOST_PYTHON_MODULE(NodeApi) {
 		class_<PropertyMap>("PropertyMap", no_init)
 				.def("__getattr__", &PropertyMap::pythonAttribute);
-		class_<InformationNode, bases<PropertyMap>>("InformationNode");
+		class_<InformationNode, bases<PropertyMap>>("InformationNode", no_init);
 }
 
 } /* namespace InformationScripting */


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23issuecomment-127714362%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23issuecomment-127995963%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23issuecomment-128035299%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36214129%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36214660%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36214891%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36215257%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36215443%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36215625%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36215794%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36215913%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36216058%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36216266%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36216517%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36216726%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217067%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217235%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217437%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217626%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217725%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217781%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217798%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36218106%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36218493%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36218714%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36219011%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36219158%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36219260%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36219290%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36219828%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36219895%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220135%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220212%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220349%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220359%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220482%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220823%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220896%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220899%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36221085%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36221810%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36222400%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36222801%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36222994%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36223120%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36223322%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36224354%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36224672%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36224923%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36225098%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36225293%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36225555%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36225679%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36225718%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36226037%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36226236%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36226775%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36276557%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36276626%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36277748%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36277786%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36277965%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36278197%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36278215%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36278344%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36278396%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36278588%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36278608%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36278720%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36278841%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36279097%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36279149%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36279343%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36279470%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36279692%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36280062%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36280164%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36280333%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36280342%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36280434%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36280725%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36280777%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36281032%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36281855%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36282017%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36291292%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36291366%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36293676%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36293684%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36293713%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36293815%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36294198%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295099%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295102%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295103%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295105%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295109%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295112%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295115%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295119%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295122%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295126%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295130%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295135%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295137%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295142%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295144%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295145%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295149%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295154%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295157%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295160%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295162%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295165%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295168%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295170%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295173%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36295174%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36297927%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36297932%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36297938%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36297939%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36300215%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36300218%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/commands/CScript.cpp%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36214660%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20this%20case%2C%20do%20we%20need%20a%20composite%20query%20at%20all%3F%20Can%27t%20we%20just%20pass%20query%20directly%3F%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A14%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20that%20was%20the%20first%20test%20of%20the%20CompositeQuery%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A51%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/commands/CScript.cpp%3AL98-167%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.h%20101%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36215794%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20don%27t%20need%20two%20functions.%20Ideally%20just%20have%20%60nodes%28condition%20%3D%20%7B%7D%29%60.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A24%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A22%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.h%3AL1-130%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.h%20106%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36215913%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Same%20as%20above.%20I%20assume%20that%20at%20some%20point%20we%20will%20also%20need%20%60edges%28%29%60%20so%20just%20go%20ahead%20and%20make%20a%20common%20%60edges%28condition%20%3D%20%7B%7D%29%60%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A25%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A22%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.h%3AL1-130%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/CompositeQuery.cpp%2063%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36222400%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22For%20now%2C%20I%27d%20say%20detecting%20a%20cycle%20should%20be%20an%20assertion%20failure.%20I%20don%27t%20think%20we%27ll%20need%20to%20allow%20this.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A16%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A22%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/CompositeQuery.cpp%3AL1-203%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/CompositeQuery.cpp%20137%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36223120%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20comment%20is%20identical%20to%20the%20method%20name%2C%20remove%20it%20or%20make%20it%20useful.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A21%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A22%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/CompositeQuery.cpp%3AL1-203%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/CompositeQuery.cpp%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36222801%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Call%20this%20something%20more%20descriptive.%20It%20seems%20like%20you%20put%20here%20things%20that%20have%20been%20just%20executed%2C%20so%20why%20not%3A%5Cr%5Cn%60justExecuted%60.%5Cr%5Cn%5Cr%5CnThen%20you%20can%20also%20rename%20the%20set%20below%20from%60visitedNodes%60%20to%20%60fullyProcessedQueries%60%20or%20something%20else%20that%20is%20more%20descriptive%20than%20the%20current%20one.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A19%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A22%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/CompositeQuery.cpp%3AL1-203%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/ComplementOperator.cpp%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36221810%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20how%20did%20you%20name%20this%20operator%3F%20In%20graph%20theory%20there%20is%20already%20a%20meaning%20for%20the%20term%20graph%20complement%2C%20and%20it%27s%20not%20what%20we%27re%20doing%20here.%20Perhaps%20give%20it%20a%20more%20descriptive%20name.%20But%20i%27d%20still%20like%20to%20know%20where%20the%20names%20comes%20from%20currently.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A11%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20name%20is%20from%20Set%20theory.%20Any%20suggestions%20for%20a%20better%20name%3F%5Cr%5CnDifference%3F%5Cr%5CnSubstract%3F%20%5Cr%5CnBut%20those%20might%20suggest%20an%20commutative%20operation%20which%20it%20is%20not.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A32%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20since%20we%20work%20on%20the%20nodes%20in%20this%20case%2C%20I%20would%20suggest%20%60SubtractNodesOperator%60.%20Just%20subtract%20is%20still%20a%20bit%20vague%20for%20graphs.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A51%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A22%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/ComplementOperator.cpp%3AL1-46%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/visualization/DefaultVisualizer.h%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36225555%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20returns%20a%20copy%20of%20the%20default%20initializer%20every%20time%20you%20call%20%60instance%28%29%60.%20Return%20a%20reference%20instead.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A40%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A22%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/visualization/DefaultVisualizer.h%3AL1-49%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.h%2083%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36215625%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Since%20we%20have%20both%2C%20it%27s%20better%20to%20be%20explicit%2C%20call%20this%20%60addUndirectedEdge%60%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A23%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A22%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.h%3AL1-130%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23issuecomment-127714362%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20a%20mountain%20of%20work.%20I%27d%20really%20like%20to%20merge%20this%20as%20soon%20as%20possible%2C%20before%20you%20introduce%20much%20other%20functionality.%20Please%20focus%20on%20fixing%20the%20small%20issues%20and%20let%20me%20merge%20before%20you%20go%20on%20to%20add%20a%20ton%20of%20other%20things%20%3AD%5Cr%5Cn%5Cr%5CnThings%20that%20need%20further%20discussion%20%28e.g.%20hashing%20and%20equality%29%20could%20be%20merged%20later.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A53%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20I%20fixed%20most%20discussed%20things.%20Everything%20that%20is%20not%20fixed%20I%20think%20should%20go%20in%20a%20new%20PR%22%2C%20%22created_at%22%3A%20%222015-08-05T13%3A24%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-08-05T15%3A23%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/InformationEdge.h%2063%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217725%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%20should%20all%20be%20inline.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A40%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/InformationEdge.h%3AL1-68%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/InformationScriptingPlugin.cpp%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36214129%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20this%20supposed%20to%20be%20an%20initialization%20of%20a%20filter%3F%20Why%20do%20we%20need%20to%20initialize%20here%3F%20Something%20is%20fishy%2C%20we%20shouldn%27t%20have%20to%20initialize%20this%20for%20each%20and%20every%20type.%20We%20should%20find%20a%20way%20to%20make%20this%20unnecessary.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A09%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nope%20it%27s%20Visitor%20which%20visits%20all%20nodes%20of%20a%20certain%20type%20and%20stores%20them%20in%20a%20list.%20E.g.%20it%20is%20not%20a%20filter%20but%20rather%20a%20data%20source.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A53%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/InformationScriptingPlugin.cpp%3AL28-51%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/sources/AstSource.cpp%2060%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36225098%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20I%27m%20beginning%20to%20doubt%20the%20need%20for%20a%20factory%20at%20all.%20Why%20not%20create%20the%20queries%20directly%3F%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A36%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A58%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/sources/AstSource.cpp%3AL1-84%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Property.h%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36218714%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20not%20take%20a%20%60%26%60%20to%20%60other%60.%20This%20will%20make%20the%20method%20faster%20and%20we%20don%27t%20really%20need%20to%20take%20ownership%20for%20it.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A48%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22True%2C%20but%20additionally%20%60%60%60const%20%26%60%60%60%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A11%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Property.h%3AL43-59%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/commands/CScript.cpp%2078%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36214891%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20should%20talk%20about%20these%20filters%20and%20try%20to%20find%20as%20a%20generic%20as%20possible%20way%20of%20implementing/using%20them.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A16%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/commands/CScript.cpp%3AL98-167%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Property.h%2084%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36219011%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60inline%60%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A50%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Property.h%3AL124-130%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/visitors/AllNodesOfType.h%2036%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36225293%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Aha%2C%20this%20is%20visitor%20and%20that%27s%20why%20you%20have%20to%20initialize%20it.%20Hmm%2C%20I%20am%20not%20very%20happy%20about%20this%2C%20but%20I%27m%20not%20sure%20what%20should%20be%20done.%20Any%20suggestions%20are%20welcome.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A37%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Maybe%20add%20everything%20in%20a%20single%20visitor%20somehow%3F%20e.g.%20just%20make%20the%20visit%20method%20templated%3F%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A42%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22To%20be%20honest%2C%20especially%20if%20we%20make%20thinds%20a%20bit%20more%20dynamic%20and%20using%20%60node-%3EtypeName%60%20we%20will%20use%20a%20different%20approach%20%28the%20current%20visitor%20classes%20are%20all%20template%20based%20and%20not%20dynamic%29.%20So%20let%27s%20not%20try%20to%20fix%20this%20for%20now.%22%2C%20%22created_at%22%3A%20%222015-08-05T09%3A04%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/visitors/AllNodesOfType.h%3AL1-62%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.h%20127%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36216266%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22declare%20this%20as%20%60inline%60%20or%20you%27ll%20eventually%20get%20duplicate%20symbol%20definitions.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A27%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20mixed%20up%20inline%20in%20various%20places%3A%20I%20added%20the%20inline%20keyword%20at%20the%20declaration%20instead%20of%20definition%2C%20I%20will%20fix%20that.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A56%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.h%3AL1-130%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/AstNameFilter.cpp%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220135%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22if%20you%20want%20to%20be%20super%20generic%2C%20you%20don%27t%20need%20to%20cast%20to%20Declaration.%20You%20can%20cast%20to%20CompositeNode%20and%20use%20it%27s%20methods%20to%20see%20if%20the%20node%20has%20a%20field%20called%20%5C%22name%5C%22%20which%20is%20something%20you%20can%20DCast%20to%20text.%20If%20so%20just%20check%20that.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A59%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T13%3A22%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstNameFilter.cpp%3AL1-54%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.cpp%20171%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217437%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Yeah%2C%20as%20I%20mentioned%20before%2C%20just%20looking%20at%20the%20hash%20is%20not%20enough%2C%20we%20need%20to%20test%20for%20equality.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A37%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.cpp%3AL1-192%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/InformationEdge.cpp%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217798%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22put%20in%20.h%20and%20inline%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A41%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/InformationEdge.cpp%3AL1-56%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/InformationEdge.cpp%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217781%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22put%20in%20.h%20and%20inline%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A41%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A22%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/InformationEdge.cpp%3AL1-56%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Property.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36218493%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20wonder%20if%20this%20would%20enable%20us%20to%20simply%20ask%20the%20question%3A%20%60InofrmationNodeA%20%3D%3D%20InformationNodeB%60%3F%20If%20so%2C%20then%20this%20means%20that%20two%20nodes%20are%20equal%20if%20%2Aall%2A%20of%20their%20data%20is%20equal%2C%20but%20I%20can%20imagine%20cases%20where%20we%20want%20a%20less%20strict%20definition%20of%20equality%2C%20as%20data%20might%20have%20been%20attached/altered%20in%20one%20node%20and%20not%20in%20the%20other%2C%20even%20though%20on%20some%20logical%20level%20they%20represent%20the%20same%20entity.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A46%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20InformationNode%20is%20a%20PropertMap%2C%20but%20yeah%20as%20you%20say%20with%20this%20you%20can%20compare%20all%20properties.%20For%20the%20definition%20of%20equality%20of%20nodes%20we%20will%20have%20to%20discuss%20together%20with%20the%20hashing.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A05%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20you%20had%20pretty%20much%20an%20identical%20point%20to%20what%20I%20say%20here%2C%20in%20an%20answer%20to%20the%20hashing%20question%20I%20had%20yesterday.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A09%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Property.cpp%3AL33-43%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.h%20114%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36216058%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22can%27t%20we%20just%20call%20this%20%60hash%60%20or%20%60hashOf%60%3F%20Is%20there%20any%20room%20for%20confusion%3F%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A26%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20use%20hashOf%20now%20to%20make%20it%20clearly%20distinct%20from%20std%3A%3Ahash%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A02%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22sounds%20good.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A02%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.h%3AL1-130%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/sources/AstSource.h%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36224923%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20there%20a%20reason%20why%20we%20need%20a%20singleton%20and%20why%20the%20methods%20below%20are%20not%20simply%20static%20methods%3F%20This%20class%20has%20no%20data%2C%20so%20why%20not%20just%20use%20it%20for%20scoping%3F%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A34%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A58%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/sources/AstSource.h%3AL1-58%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/PropertyMap.cpp%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36219260%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Here%20and%20above%20in%20the%20const%20version%2C%20is%20this%20what%20we%20want%3F%20Typically%20%60%5B%5D%60%20inserts%20a%20default%20element%20if%20the%20key%20is%20not%20found.%20Would%20it%20be%20bad%20to%20code%20it%20like%20usual%3F%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A52%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20during%20development%20this%20is%20suitable%2C%20later%20on%20we%20should%20change%20it%20as%20you%20suggest.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A15%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20I%27m%20not%20sure%20I%20agree.%20Why%20would%20it%20not%20be%20suitable%20now%2C%20but%20suitable%20later%3F%20We%20should%20decide%20what%20to%20do%20and%20do%20it%20from%20now%20so%20that%20we%20get%20to%20test%20the%20code%20the%20way%20it%27s%20meant%20to%20be.%20Unless%20there%20is%20a%20compelling%20reason%20to%20leave%20it%20as%20it%20is%2C%20I%20would%20rather%20change%20it%20to%20the%20more%20standard%20behavior.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A19%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Do%20a%20typo%20in%20the%20key%20you%20type%20in%20%5B...%5D%20and%20you%20get%20a%20default%20property%2C%20somewhere%20down%20the%20road%20the%20program%20will%20probably%20crash%2C%20then%20I%20think%20it%20could%20be%20hard%20to%20track%20back%20to%20this.%5Cr%5Cn%5Cr%5CnI%20suggest%20to%20remove%20the%20Q_ASSERT%28%29%20and%20return%20a%20default%20Property%2C%20but%20to%20leave%20the%20qDebug%20statement%2C%20with%20a%20TODO%20to%20remove%20it%20later%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A23%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22alright.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A42%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/PropertyMap.cpp%3AL47-66%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/visualization/DefaultVisualizer.cpp%2053%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36225679%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20use%20the%20method%20that%20you%20should%20introduce%20%60edges%28%29%60%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A41%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20will%20also%20make%20the%20lambda%20above%20unnecessary.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A41%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/visualization/DefaultVisualizer.cpp%3AL1-111%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/AstQuery.h%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220359%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20wonder%20if%20there%20is%20a%20reasonable%20way%20to%20be%20more%20generic%2C%20rather%20that%20implementing%20all%20special%20cases%20independently.%5Cr%5Cn%5Cr%5CnAny%20thoughts%3F%20Perhaps%20using%20the%20generic%3A%20%60Node%3A%3AtypeName%60%3F%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A00%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20in%20this%20comment%20you%20mean%20just%20the%20nodes%20of%20a%20certain%20type%20queries%3F%5Cr%5Cn%5Cr%5CnHow%20would%20you%20use%20%60%60%60Node%3A%3AtypeName%60%60%60%3F%20comparing%20the%20typename%20to%20supported%20typenames%3F%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A27%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20I%20do%20mean%20only%20nodes%20of%20a%20certain%20type.%20I%20haven%27t%20thought%20this%20trough%2C%20but%20let%27s%20just%20say%20the%20user%20writes%20a%20query%20%5C%22nodeTypes%20Expression%5C%22%20or%20%5C%22nodeTypes%20Class%5C%22%20or%20%5C%22nodeTypes%20BinaryOperation%5C%22%20or%20%5C%22nodeTypes%20Methods%5C%22%20or%20anything%20really.%20We%20can%20just%20get%20that%20second%20string%20and%20look%20for%20all%20nodes%20in%20the%20tree%20that%20match%20that%20type%20and%20return%20them.%20This%20is%20not%20even%20OO%20specific.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A47%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstQuery.h%3AL1-79%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/CompositeQuery.cpp%20100%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36222994%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20this%20be%20assertion%20violation%20as%20opposed%20to%20a%20silent%20no-op%3F%20Why%20would%20we%20want%20to%20add%20the%20same%20query%20twice%2C%20on%20the%20client%20side%3F%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A20%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20I%20have%20to%20look%20at%20this%20again.%20As%20I%20have%20it%20currently%20nodeForQuery%20will%20create%20a%20node%20if%20there%20is%20none%20and%20thus%20never%20returns%200.%20I%20will%20fix%20that%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A38%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Actually%20that%20method%20is%20never%20used.%20And%20I%20think%20it%20shouldn%27t%20be.%20The%20client%20should%20just%20need%20to%20say%20how%20he%20wants%20to%20connect%20the%20queries%2C%20the%20CompositeQuery%20should%20figure%20out%20on%20its%20own%20how%20it%20solves%20this.%20%28i.e.%20when%20to%20create%20a%20QueryNode%20etc.%29%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A01%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20then%20delete%20this%20method.%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A09%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/CompositeQuery.cpp%3AL1-203%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/AstQuery.h%2057%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220482%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20do%20you%20mean%2C%20just%20for%20methods%3F%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A01%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20comment%20is%20outdated.%20It%20was%20before%20I%20had%20the%20QueryType%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A04%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A58%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstQuery.h%3AL1-79%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/AstNameFilter.h%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36219895%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22And%20if%20the%20match%20is%20not%20exact%20then%20what%20exactly%20is%20it%3F%20A%20substring%3F%20A%20better%20approach%20to%20this%20in%20general%20is%20to%20allow%20for%20something%20more%20general%2C%20e.g.%20a%20Regex.%20To%20complicate%20matters%20further%2C%20using%20just%20a%20regex%20is%20slow%2C%20even%20in%20cases%20where%20the%20regex%20is%20essentially%20an%20exact%20match.%20This%20however%20can%20be%20avoided%20by%20using%20an%20intermediate%20matcher%20structure.%20I%27ve%20done%20this%20before%2C%20look%20here%3A%5Cr%5Cnhttps%3A//github.com/dimitar-asenov/Envision/blob/development/ModelBase/src/SymbolMatcher.h%5Cr%5Cn%5Cr%5CnThis%20is%20generic%20enough%2C%20that%20you%20should%20be%20able%20to%20use%20it%20directly.%20If%20so%2C%20then%20we%27ll%20probably%20just%20rename%20it%20to%20stringMatcher%20%28and%20maybe%20even%20put%20it%20in%20the%20Core%20project%29.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A57%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Not%20exact%20calls%20contains%20now.%20%5Cr%5Cn%5Cr%5CnThe%20rest%20I%20think%20is%20for%20a%20later%20PR%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A23%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20we%20should%20do%20it%20now%2C%20using%20the%20symbol%20matcher%20is%20real%20easy%3A%5Cr%5Cn%2A%20Get%20a%20single%20symbol%20matcher%20as%20argument%5Cr%5Cn%2A%20Store%20it%5Cr%5Cn%2A%20Call%20its%20match%20method%20when%20needed%5Cr%5Cn%2A%20Done%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A43%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T13%3A22%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstNameFilter.h%3AL1-42%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.cpp%20187%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217626%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20OK%20for%20now%2C%20but%20down%20the%20road%2C%20we%20might%20need%20to%20make%20the%20%60into%60%20or%20%60from%60%20node%20dominant%2C%20which%20would%20mean%20that%20in%20case%20of%20conflict%20we%20just%20pick%20its%20value.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A39%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.cpp%3AL1-192%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.cpp%20109%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217067%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22By%20the%20way%2C%20this%20comment%20reminded%20me%20that%20hash%20functions%20do%20not%20typically%20work%20the%20way%20we%20seem%20to%20expect.%20In%20general%20a%20hash%20function%20guarantees%20that%20equal%20data%20will%20have%20equal%20hash.%20But%20there%20is%20no%20guarantee%20that%20different%20data%20will%20have%20different%20hash.%20So%20just%20registering%20a%20hashing%20function%20is%20not%20enough.%20We%20always%20need%20an%20additional%20function%20to%20compare%20for%20equality%2C%20one%20that%20is%20always%20correct.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A34%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20should%20discuss%20the%20whole%20hashing/equality%20approach%20in%20more%20detail.%20A%20problem%20is%20that%20we%20can%20add%20properties%20to%20nodes%2C%20but%20that%20should%20not%20affect%20the%20hash%20value%2C%20otherwise%20we%20lose%20the%20uniqueness%20property%2C%20e.g.%20A%20node%20which%20contains%20only%20the%20AST%20property%20with%20method%20X%20should%20be%20seen%20as%20the%20same%20as%20A%20node%20which%20contains%20the%20AST%20property%20with%20method%20X%20and%20additional%20properties.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A59%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.cpp%3AL1-192%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/CompositeQuery.cpp%20138%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36223322%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22wow%2C%20can%27t%20we%20just%20do%20something%20along%20the%20lines%20of%20%60outNode-%3Eoutput%282%29%60%20%3F%20The%20current%20code%20looks%20like%20total%20overkill.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A23%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22How%20do%20you%20know%20in%20advance%20how%20long%20this%20list%20has%20to%20be%3F%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A40%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sure%20I%20understand%20your%20question.%20What%20I%20see%20here%20is%20that%20we%20are%20iterating%20over%20a%20collection%2C%20looking%20for%20an%20element%20with%20a%20specific%20index%2C%20so%20why%20not%20access%20directly%20that%20element%20in%20the%20collection%3F%5Cr%5Cn%5Cr%5CnI%20guess%20the%20problem%20stems%20from%20the%20%60OutputMapping%60%20structure.%20Why%20do%20we%20need%20that%20one%20as%20well%2C%20why%20not%20just%20have%20the%20following%20in%20%60QueryNode%60%3A%20%60QList%3C%20QSet%3CQueryNode%2A%3E%20%3E%20outputs_%3B%60%20So%20the%20output%20index%20is%20encoded%20in%20the%20list%20position.%5Cr%5Cn%5Cr%5CnWe%20should%20make%20the%20same%20change%20for%20Inputs.%5Cr%5Cn%5Cr%5CnIs%20there%20a%20good%20reason%20to%20keep%20the%20index%20in%20a%20separate%20data%20structure%2C%20and%20not%20use%20%60Qlist%60%27s%20own%20indexing%3F%20%28it%20seems%20to%20me%20that%20right%20now%2C%20in%20%60QueryNode%60%2C%20it%20makes%20no%20difference%20whether%20we%20use%20%60QList%60%20or%20%60QSet%60%2C%20which%20should%20tell%20us%20that%20something%20is%20fishy%29%22%2C%20%22created_at%22%3A%20%222015-08-05T09%3A02%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/CompositeQuery.cpp%3AL1-203%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/QueryExecutor.cpp%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36224672%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20it%20might%20be%20nice%20to%20remember%20the%20results%2C%20and%20possibly%20use%20them%20later.%20A%20bit%20like%20a%20clipboard%20manager%2C%20that%20lets%20you%20use%20past%20clippings.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A32%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Noted%20for%20later%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A03%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/QueryExecutor.cpp%3AL1-55%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/visualization/DefaultVisualizer.cpp%2073%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36226236%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20both%20of%20these%20cases%20you%20assume%20that%20a%20single%20node%20is%20represented%20by%20a%20single%20item.%20That%27s%20not%20necessarily%20the%20case%2C%20there%20might%20be%20multiple%20items.%20Since%20we%20don%27t%20know%20any%20better%2C%20we%20should%20include%20all%20of%20them%20here%20%28so%20there%20might%20be%20multiple%20visual%20arrows%20for%20a%20single%20edge%29%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A45%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cr%5CnThat%20should%20happen%20together%20with%20the%20change%20above%20I%20guess%3F%20i.e.%20the%20method%20to%20get%20the%20visualization%20item%20should%20return%20a%20list%20of%20Items%22%2C%20%22created_at%22%3A%20%222015-08-05T11%3A22%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes.%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A02%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/visualization/DefaultVisualizer.cpp%3AL1-111%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/AstQuery.cpp%2069%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220823%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20always%20a%20good%20idea%20to%20add%20%60default%3A%20Q_ASSERT%28false%29%60%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A04%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Just%20as%20a%20side%20note%20clang%20does%20this%20at%20compile%20time%2C%20i.e.%20it%20warns%20for%20each%20unhandled%20case.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A29%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22nice%2C%20I%20should%20switch%20to%20using%20clang%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A48%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A58%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstQuery.cpp%3AL1-253%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/visualization/DefaultVisualizer.cpp%2068%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36226037%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20this%20functionality%20should%20be%20independent%20of%20Nodes.%20Perhaps%20we%20can%20make%20each%20InformationNode%20have%20a%20method%20that%20returns%20the%20Node%20%28if%20any%29%20and%20the%20Item%28if%20any%29%20it%20is%20represented%20by.%20This%20will%20make%20it%20sufficiently%20generic%20and%20allow%20us%20to%20highlight%20even%20InfoNodes%20that%20are%20not%20associated%20with%20an%20ASTNode%20%28but%20have%20an%20item%29.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A44%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Now%20or%20in%20next%20PR%3F%22%2C%20%22created_at%22%3A%20%222015-08-05T11%3A21%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Up%20to%20you.%20whatever%20is%20more%20convenient.%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A01%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/visualization/DefaultVisualizer.cpp%3AL1-111%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/GenericFilter.cpp%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36224354%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22you%20can%20safely%20put%20g-%3Enodes%28%29%20on%20the%20next%20line.%20It%20will%20be%20called%20only%20once.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A30%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/GenericFilter.cpp%3AL1-52%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.h%2041%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36215257%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20this%20a%20hard%20restriction%20%281%20function%20per%20source%29%20%3F%20An%20information%20source%20should%20be%20able%20to%20register%20as%20many%20node%20hash%20functions%20as%20it%20wants.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A19%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.h%3AL1-130%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.cpp%2084%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36216726%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20function%20is%20almost%20identical%20to%20the%20one%20above.%20We%20should%20have%20only%20one%20function%20%60addEdge%60%20%28I%20know%20I%20said%20otherwise%20before%2C%20but%20that%27s%20before%20I%20saw%20the%20implementations%29.%20This%20one%20function%20should%20take%20an%20enum%20as%20the%20last%20argument%20that%20is%20either%20Directed%20or%20Undirected%2C%20and%20should%20have%20a%20default%20value%20%28pick%20one%2C%20I%27m%20not%20sure%20what%20will%20be%20more%20common%29.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A31%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.cpp%3AL1-192%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.h%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36215443%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20all%20sounds%20quite%20complicated.%20Can%27t%20we%20just%20have%20a%20hash%20function%20that%3A%5Cr%5Cn%2A%20always%20works%2C%20for%20all%20nodes%5Cr%5Cn%2A%20is%20configurable%20by%20the%20different%20sources%5Cr%5Cn%2A%20encodes%20the%20source%20as%20part%20of%20the%20hash%2C%20therefore%20guaranteeing%20that%20nodes%20from%20different%20sources%20will%20have%20a%20different%20hash.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A21%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.h%3AL1-130%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/queries/AstQuery.cpp%2071%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36220896%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22How%20do%20we%20know%20it%27s%20unhandled%3F%20Is%20it%20null%3F%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A04%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Each%20method%20removes%20all%20the%20inputs%20it%20used.%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A06%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstQuery.cpp%3AL1-253%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.cpp%20123%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36217235%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20such%20short%20cases%2C%20avoid%20the%20%60%7B%7D%60%20braces%20and%20just%20have%20one%20line.%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A36%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Since%20I%20have%20to%20have%20%7B%7D%20in%20the%20if%2C%20I%20also%20have%20%7B%7D%20in%20the%20else%20part%2C%20as%20defined%20in%20the%20guidelines%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A00%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20find%20where%20in%20the%20guide%20lines%20I%20say%20that.%20Could%20you%20give%20me%20a%20pointer%3F%20Here%20is%20the%20link%20for%20your%20convenience%3A%20http%3A//dimitar-asenov.github.io/Envision/contribution.html%22%2C%20%22created_at%22%3A%20%222015-08-04T18%3A50%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20true%20it%27s%20from%20the%20Qt%20style%3A%20http%3A//wiki.qt.io/Qt_Coding_Style%20%28search%20for%20Exception%202%29.%20I%20can%20remove%20it%20if%20you%20prefer%22%2C%20%22created_at%22%3A%20%222015-08-05T07%3A42%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20please.%20I%20find%20that%20otherwise%20there%27s%20a%20bit%20too%20much%20empty%20space.%22%2C%20%22created_at%22%3A%20%222015-08-05T07%3A43%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.cpp%3AL1-192%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/Graph.cpp%2066%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36216517%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Put%20a%20TODO%3A%20here%20to%20watch%20out%20for%20performance%20issues%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A30%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-05T12%3A23%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/Graph.cpp%3AL1-192%22%7D%2C%20%22Pull%209f687c5ae7ba765433803e73956d5cce7b6fe25c%20InformationScripting/src/graph/InformationEdge.cpp%2047%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/122%23discussion_r36218106%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20confused%20by%20this%20statement.%20Does%20it%20call%20an%20explicit%20conversion%20to%20%60int%60%3F%20Can%27t%20we%20make%20this%20implicit%3F%20and%20if%20we%20did%2C%20it%20should%20be%20possible%20to%20just%20do%20this%20on%20one%20line%3A%20%60%2B%2B%28%2Athis%29%5BCOUNT_PROPERTY_%5D%3B%60%22%2C%20%22created_at%22%3A%20%222015-08-04T17%3A43%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20here%20we%20have%20to%20use%20explicit%20conversion.%20The%20problem%20is%20that%20if%20we%20just%20call%20%2B%20or%20%2B%2B%20on%20a%20property%20it%20is%20ambiguous%2C%20i.e.%20the%20implicit%20conversion%20could%20convert%20to%20anything%20that%20supports%20%2B%2B%20or%20%2B%20%28int%29%20thus%20we%20have%20to%20be%20explicit.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A09%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20calling%20%2B%2B%20should%20not%20be%20ambiguous%2C%20it%20should%20just%20call%20%2B%2B%20on%20the%20value%20of%20the%20property.%20I%27m%20not%20sure%20where%20the%20ambiguity%20comes%20from.%20In%20fact%2C%20in%20that%20case%20there%20would%20be%20no%20conversion%20at%20all.%5Cr%5Cn%5Cr%5CnBut%20I%20guess%20that%27s%20a%20separate%20question%3A%20is%20it%20worth%20declaring%20a%20few%20standard%20operators%20like%20%2B%2C%20%2B%2B%2C%20etc%2C%20to%20directly%20map%20to%20the%20operations%20of%20the%20underlying%20types.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A12%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20if%20you%20define%20the%20operator%20then%20there%20is%20no%20ambiguity%20but%20as%20long%20as%20there%20are%20no%20operators%20defined%20it%20has%20to%20convert%20it%20to%20something%20which%20has%20an%20operator.%5Cr%5Cn%5Cr%5CnI%20think%20if%20we%20use%20similar%20things%20in%20a%20lot%20of%20cases%20it%20definitely%20makes%20sense%20to%20implement%20such%20operators.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A15%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Alright%2C%20leave%20it%20as%20it%20for%20now%2C%20and%20let%27s%20keep%20in%20mind%20this%20improvement%20for%20the%20future%2C%20if%20needed.%22%2C%20%22created_at%22%3A%20%222015-08-05T08%3A17%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/graph/InformationEdge.cpp%3AL1-56%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/dimitar-asenov%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/dimitar-asenov'><img src='https://avatars.githubusercontent.com/u/1152976?v=3' width=34 height=34></a>
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/commands/CScript.cpp 78'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36214891'>File: InformationScripting/src/commands/CScript.cpp:L98-167</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> We should talk about these filters and try to find as a generic as possible way of implementing/using them.
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.h 41'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36215257'>File: InformationScripting/src/graph/Graph.h:L1-130</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Is this a hard restriction (1 function per source) ? An information source should be able to register as many node hash functions as it wants.
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.h 44'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36215443'>File: InformationScripting/src/graph/Graph.h:L1-130</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This all sounds quite complicated. Can't we just have a hash function that:
- always works, for all nodes
- is configurable by the different sources
- encodes the source as part of the hash, therefore guaranteeing that nodes from different sources will have a different hash.
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.cpp 109'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36217067'>File: InformationScripting/src/graph/Graph.cpp:L1-192</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> By the way, this comment reminded me that hash functions do not typically work the way we seem to expect. In general a hash function guarantees that equal data will have equal hash. But there is no guarantee that different data will have different hash. So just registering a hashing function is not enough. We always need an additional function to compare for equality, one that is always correct.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> We should discuss the whole hashing/equality approach in more detail. A problem is that we can add properties to nodes, but that should not affect the hash value, otherwise we lose the uniqueness property, e.g. A node which contains only the AST property with method X should be seen as the same as A node which contains the AST property with method X and additional properties.
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.cpp 171'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36217437'>File: InformationScripting/src/graph/Graph.cpp:L1-192</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Yeah, as I mentioned before, just looking at the hash is not enough, we need to test for equality.
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.cpp 187'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36217626'>File: InformationScripting/src/graph/Graph.cpp:L1-192</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This is OK for now, but down the road, we might need to make the `into` or `from` node dominant, which would mean that in case of conflict we just pick its value.
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/InformationEdge.cpp 47'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36218106'>File: InformationScripting/src/graph/InformationEdge.cpp:L1-56</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I'm confused by this statement. Does it call an explicit conversion to `int`? Can't we make this implicit? and if we did, it should be possible to just do this on one line: `++(*this)[COUNT_PROPERTY_];`
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Yes here we have to use explicit conversion. The problem is that if we just call + or ++ on a property it is ambiguous, i.e. the implicit conversion could convert to anything that supports ++ or + (int) thus we have to be explicit.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, calling ++ should not be ambiguous, it should just call ++ on the value of the property. I'm not sure where the ambiguity comes from. In fact, in that case there would be no conversion at all.
  But I guess that's a separate question: is it worth declaring a few standard operators like +, ++, etc, to directly map to the operations of the underlying types.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Well if you define the operator then there is no ambiguity but as long as there are no operators defined it has to convert it to something which has an operator.
  I think if we use similar things in a lot of cases it definitely makes sense to implement such operators.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Alright, leave it as it for now, and let's keep in mind this improvement for the future, if needed.
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Property.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36218493'>File: InformationScripting/src/graph/Property.cpp:L33-43</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I wonder if this would enable us to simply ask the question: `InofrmationNodeA == InformationNodeB`? If so, then this means that two nodes are equal if _all_ of their data is equal, but I can imagine cases where we want a less strict definition of equality, as data might have been attached/altered in one node and not in the other, even though on some logical level they represent the same entity.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Well InformationNode is a PropertMap, but yeah as you say with this you can compare all properties. For the definition of equality of nodes we will have to discuss together with the hashing.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Yes, you had pretty much an identical point to what I say here, in an answer to the hashing question I had yesterday.
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/AstQuery.h 50'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36220359'>File: InformationScripting/src/queries/AstQuery.h:L1-79</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I wonder if there is a reasonable way to be more generic, rather that implementing all special cases independently.
  Any thoughts? Perhaps using the generic: `Node::typeName`?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> I think in this comment you mean just the nodes of a certain type queries?
  How would you use `Node::typeName`? comparing the typename to supported typenames?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Yes, I do mean only nodes of a certain type. I haven't thought this trough, but let's just say the user writes a query "nodeTypes Expression" or "nodeTypes Class" or "nodeTypes BinaryOperation" or "nodeTypes Methods" or anything really. We can just get that second string and look for all nodes in the tree that match that type and return them. This is not even OO specific.
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/QueryExecutor.cpp 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36224672'>File: InformationScripting/src/queries/QueryExecutor.cpp:L1-55</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, it might be nice to remember the results, and possibly use them later. A bit like a clipboard manager, that lets you use past clippings.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Noted for later
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/visitors/AllNodesOfType.h 36'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36225293'>File: InformationScripting/src/visitors/AllNodesOfType.h:L1-62</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Aha, this is visitor and that's why you have to initialize it. Hmm, I am not very happy about this, but I'm not sure what should be done. Any suggestions are welcome.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Maybe add everything in a single visitor somehow? e.g. just make the visit method templated?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> To be honest, especially if we make thinds a bit more dynamic and using `node->typeName` we will use a different approach (the current visitor classes are all template based and not dynamic). So let's not try to fix this for now.
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/visualization/DefaultVisualizer.cpp 68'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36226037'>File: InformationScripting/src/visualization/DefaultVisualizer.cpp:L1-111</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, this functionality should be independent of Nodes. Perhaps we can make each InformationNode have a method that returns the Node (if any) and the Item(if any) it is represented by. This will make it sufficiently generic and allow us to highlight even InfoNodes that are not associated with an ASTNode (but have an item).
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Now or in next PR?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Up to you. whatever is more convenient.
- [ ] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/visualization/DefaultVisualizer.cpp 73'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36226236'>File: InformationScripting/src/visualization/DefaultVisualizer.cpp:L1-111</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> In both of these cases you assume that a single node is represented by a single item. That's not necessarily the case, there might be multiple items. Since we don't know any better, we should include all of them here (so there might be multiple visual arrows for a single edge)
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> That should happen together with the change above I guess? i.e. the method to get the visualization item should return a list of Items
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Yes.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/InformationScriptingPlugin.cpp 19'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36214129'>File: InformationScripting/src/InformationScriptingPlugin.cpp:L28-51</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Is this supposed to be an initialization of a filter? Why do we need to initialize here? Something is fishy, we shouldn't have to initialize this for each and every type. We should find a way to make this unnecessary.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Nope it's Visitor which visits all nodes of a certain type and stores them in a list. E.g. it is not a filter but rather a data source.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/commands/CScript.cpp 52'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36214660'>File: InformationScripting/src/commands/CScript.cpp:L98-167</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> In this case, do we need a composite query at all? Can't we just pass query directly?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> No that was the first test of the CompositeQuery
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.h 83'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36215625'>File: InformationScripting/src/graph/Graph.h:L1-130</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Since we have both, it's better to be explicit, call this `addUndirectedEdge`
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.h 101'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36215794'>File: InformationScripting/src/graph/Graph.h:L1-130</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You don't need two functions. Ideally just have `nodes(condition = {})`.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.h 106'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36215913'>File: InformationScripting/src/graph/Graph.h:L1-130</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Same as above. I assume that at some point we will also need `edges()` so just go ahead and make a common `edges(condition = {})`
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.h 114'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36216058'>File: InformationScripting/src/graph/Graph.h:L1-130</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> can't we just call this `hash` or `hashOf`? Is there any room for confusion?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> I use hashOf now to make it clearly distinct from std::hash
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> sounds good.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.h 127'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36216266'>File: InformationScripting/src/graph/Graph.h:L1-130</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> declare this as `inline` or you'll eventually get duplicate symbol definitions.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> I mixed up inline in various places: I added the inline keyword at the declaration instead of definition, I will fix that.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.cpp 66'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36216517'>File: InformationScripting/src/graph/Graph.cpp:L1-192</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Put a TODO: here to watch out for performance issues
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.cpp 84'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36216726'>File: InformationScripting/src/graph/Graph.cpp:L1-192</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This function is almost identical to the one above. We should have only one function `addEdge` (I know I said otherwise before, but that's before I saw the implementations). This one function should take an enum as the last argument that is either Directed or Undirected, and should have a default value (pick one, I'm not sure what will be more common).
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Graph.cpp 123'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36217235'>File: InformationScripting/src/graph/Graph.cpp:L1-192</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> In such short cases, avoid the `{}` braces and just have one line.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Since I have to have {} in the if, I also have {} in the else part, as defined in the guidelines
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I don't find where in the guide lines I say that. Could you give me a pointer? Here is the link for your convenience: http://dimitar-asenov.github.io/Envision/contribution.html
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Hm true it's from the Qt style: http://wiki.qt.io/Qt_Coding_Style (search for Exception 2). I can remove it if you prefer
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Yes, please. I find that otherwise there's a bit too much empty space.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/InformationEdge.h 63'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36217725'>File: InformationScripting/src/graph/InformationEdge.h:L1-68</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> These should all be inline.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/InformationEdge.cpp 39'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36217781'>File: InformationScripting/src/graph/InformationEdge.cpp:L1-56</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> put in .h and inline
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/InformationEdge.cpp 50'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36217798'>File: InformationScripting/src/graph/InformationEdge.cpp:L1-56</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> put in .h and inline
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Property.h 22'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36218714'>File: InformationScripting/src/graph/Property.h:L43-59</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> why not take a `&` to `other`. This will make the method faster and we don't really need to take ownership for it.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> True, but additionally `const &`
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/Property.h 84'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36219011'>File: InformationScripting/src/graph/Property.h:L124-130</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `inline`
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/graph/PropertyMap.cpp 28'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36219260'>File: InformationScripting/src/graph/PropertyMap.cpp:L47-66</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Here and above in the const version, is this what we want? Typically `[]` inserts a default element if the key is not found. Would it be bad to code it like usual?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> I think during development this is suitable, later on we should change it as you suggest.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Well, I'm not sure I agree. Why would it not be suitable now, but suitable later? We should decide what to do and do it from now so that we get to test the code the way it's meant to be. Unless there is a compelling reason to leave it as it is, I would rather change it to the more standard behavior.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Do a typo in the key you type in [...] and you get a default property, somewhere down the road the program will probably crash, then I think it could be hard to track back to this.
  I suggest to remove the Q_ASSERT() and return a default Property, but to leave the qDebug statement, with a TODO to remove it later
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> alright.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/AstNameFilter.h 38'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36219895'>File: InformationScripting/src/queries/AstNameFilter.h:L1-42</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> And if the match is not exact then what exactly is it? A substring? A better approach to this in general is to allow for something more general, e.g. a Regex. To complicate matters further, using just a regex is slow, even in cases where the regex is essentially an exact match. This however can be avoided by using an intermediate matcher structure. I've done this before, look here:
  https://github.com/dimitar-asenov/Envision/blob/development/ModelBase/src/SymbolMatcher.h
  This is generic enough, that you should be able to use it directly. If so, then we'll probably just rename it to stringMatcher (and maybe even put it in the Core project).
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Not exact calls contains now.
  The rest I think is for a later PR
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I think we should do it now, using the symbol matcher is real easy:
- Get a single symbol matcher as argument
- Store it
- Call its match method when needed
- Done
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/AstNameFilter.cpp 40'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36220135'>File: InformationScripting/src/queries/AstNameFilter.cpp:L1-54</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> if you want to be super generic, you don't need to cast to Declaration. You can cast to CompositeNode and use it's methods to see if the node has a field called "name" which is something you can DCast to text. If so just check that.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/AstQuery.h 57'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36220482'>File: InformationScripting/src/queries/AstQuery.h:L1-79</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> What do you mean, just for methods?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> That comment is outdated. It was before I had the QueryType
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/AstQuery.cpp 69'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36220823'>File: InformationScripting/src/queries/AstQuery.cpp:L1-253</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> It's always a good idea to add `default: Q_ASSERT(false)`
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Just as a side note clang does this at compile time, i.e. it warns for each unhandled case.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> nice, I should switch to using clang :)
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/AstQuery.cpp 71'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36220896'>File: InformationScripting/src/queries/AstQuery.cpp:L1-253</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> How do we know it's unhandled? Is it null?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Each method removes all the inputs it used.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/ComplementOperator.cpp 33'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36221810'>File: InformationScripting/src/queries/ComplementOperator.cpp:L1-46</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, how did you name this operator? In graph theory there is already a meaning for the term graph complement, and it's not what we're doing here. Perhaps give it a more descriptive name. But i'd still like to know where the names comes from currently.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> The name is from Set theory. Any suggestions for a better name?
  Difference?
  Substract?
  But those might suggest an commutative operation which it is not.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Well, since we work on the nodes in this case, I would suggest `SubtractNodesOperator`. Just subtract is still a bit vague for graphs.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/CompositeQuery.cpp 63'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36222400'>File: InformationScripting/src/queries/CompositeQuery.cpp:L1-203</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> For now, I'd say detecting a cycle should be an assertion failure. I don't think we'll need to allow this.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/CompositeQuery.cpp 44'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36222801'>File: InformationScripting/src/queries/CompositeQuery.cpp:L1-203</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Call this something more descriptive. It seems like you put here things that have been just executed, so why not:
  `justExecuted`.
  Then you can also rename the set below from`visitedNodes` to `fullyProcessedQueries` or something else that is more descriptive than the current one.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/CompositeQuery.cpp 100'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36222994'>File: InformationScripting/src/queries/CompositeQuery.cpp:L1-203</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Shouldn't this be assertion violation as opposed to a silent no-op? Why would we want to add the same query twice, on the client side?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Hm I have to look at this again. As I have it currently nodeForQuery will create a node if there is none and thus never returns 0. I will fix that
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Actually that method is never used. And I think it shouldn't be. The client should just need to say how he wants to connect the queries, the CompositeQuery should figure out on its own how it solves this. (i.e. when to create a QueryNode etc.)
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> OK, then delete this method.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/CompositeQuery.cpp 137'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36223120'>File: InformationScripting/src/queries/CompositeQuery.cpp:L1-203</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> this comment is identical to the method name, remove it or make it useful.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/CompositeQuery.cpp 138'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36223322'>File: InformationScripting/src/queries/CompositeQuery.cpp:L1-203</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> wow, can't we just do something along the lines of `outNode->output(2)` ? The current code looks like total overkill.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> How do you know in advance how long this list has to be?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I'm not sure I understand your question. What I see here is that we are iterating over a collection, looking for an element with a specific index, so why not access directly that element in the collection?
  I guess the problem stems from the `OutputMapping` structure. Why do we need that one as well, why not just have the following in `QueryNode`: `QList< QSet<QueryNode*> > outputs_;` So the output index is encoded in the list position.
  We should make the same change for Inputs.
  Is there a good reason to keep the index in a separate data structure, and not use `Qlist`'s own indexing? (it seems to me that right now, in `QueryNode`, it makes no difference whether we use `QList` or `QSet`, which should tell us that something is fishy)
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/queries/GenericFilter.cpp 46'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36224354'>File: InformationScripting/src/queries/GenericFilter.cpp:L1-52</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> you can safely put g->nodes() on the next line. It will be called only once.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/sources/AstSource.h 44'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36224923'>File: InformationScripting/src/sources/AstSource.h:L1-58</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Is there a reason why we need a singleton and why the methods below are not simply static methods? This class has no data, so why not just use it for scoping?
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/sources/AstSource.cpp 60'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36225098'>File: InformationScripting/src/sources/AstSource.cpp:L1-84</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, I'm beginning to doubt the need for a factory at all. Why not create the queries directly?
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/visualization/DefaultVisualizer.h 38'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36225555'>File: InformationScripting/src/visualization/DefaultVisualizer.h:L1-49</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This returns a copy of the default initializer every time you call `instance()`. Return a reference instead.
- [x] <a href='#crh-comment-Pull 9f687c5ae7ba765433803e73956d5cce7b6fe25c InformationScripting/src/visualization/DefaultVisualizer.cpp 53'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#discussion_r36225679'>File: InformationScripting/src/visualization/DefaultVisualizer.cpp:L1-111</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This should use the method that you should introduce `edges()`
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> That will also make the lambda above unnecessary.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/122#issuecomment-127714362'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This is a mountain of work. I'd really like to merge this as soon as possible, before you introduce much other functionality. Please focus on fixing the small issues and let me merge before you go on to add a ton of other things :D
  Things that need further discussion (e.g. hashing and equality) could be merged later.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> So I fixed most discussed things. Everything that is not fixed I think should go in a new PR

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/122?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/122?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/122?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/122'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
