### PR TITLE
Script queries

### DIFF
--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -46,7 +46,6 @@ SOURCES += src/InformationScriptingException.cpp \
     src/helpers/BoostPythonHelpers.cpp \
     src/wrappers/AstApi.cpp \
     src/graph/InformationNode.cpp \
-    src/wrappers/NodeApi.cpp \
     src/graph/PropertyMap.cpp \
     src/graph/Property.cpp \
     src/graph/Graph.cpp \
@@ -63,6 +62,15 @@ SOURCES += src/InformationScriptingException.cpp \
     src/queries/UnionOperator.cpp \
     src/queries/ScriptQuery.cpp
 
+# Workaround to not have any pragma's in NodeApi.cpp
+# (because of unused local typedef in BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS):
+# see also: http://stackoverflow.com/a/14608296
+nodeApiCompiler.input = SOURCES_NODEAPI
+nodeApiCompiler.output = ${QMAKE_FILE_BASE}.o
+nodeApiCompiler.commands = \$(CXX) -c \$(CXXFLAGS) \$(INCPATH) -Wno-unused-local-typedef ${QMAKE_FILE_NAME} -o ${QMAKE_FILE_OUT}
+QMAKE_EXTRA_COMPILERS += nodeApiCompiler
+
+SOURCES_NODEAPI = src/wrappers/NodeApi.cpp
 
 # HACK to only include the AstApi_Generated file if it exists.
 exists(src/wrappers/AstApi_Generated.cpp): {

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -37,7 +37,8 @@ HEADERS += src/precompiled.h \
     src/queries/AstNameFilter.h \
     src/queries/SubstractNodesOperator.h \
     src/queries/NodePropertyAdder.h \
-    src/queries/UnionOperator.h
+    src/queries/UnionOperator.h \
+    src/queries/ScriptQuery.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -59,7 +60,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/queries/AstNameFilter.cpp \
     src/queries/SubstractNodesOperator.cpp \
     src/queries/NodePropertyAdder.cpp \
-    src/queries/UnionOperator.cpp
+    src/queries/UnionOperator.cpp \
+    src/queries/ScriptQuery.cpp
 
 
 # HACK to only include the AstApi_Generated file if it exists.

--- a/InformationScripting/src/InformationScriptingPlugin.cpp
+++ b/InformationScripting/src/InformationScriptingPlugin.cpp
@@ -34,6 +34,7 @@
 #include "commands/CScript.h"
 #include "helpers/BoostPythonHelpers.h"
 #include "sources/AstSource.h"
+#include "queries/ScriptQuery.h"
 
 #include "visitors/AllNodesOfType.h"
 
@@ -46,11 +47,13 @@ bool InformationScriptingPlugin::initialize(Core::EnvisionManager&)
 	AllNodesOfType<OOModel::Method>::init();
 	AllNodesOfType<OOModel::Class>::init();
 	OOInteraction::HStatementItemList::instance()->addCommand(new CScript());
+	ScriptQuery::initPythonEnvironment();
 	return true;
 }
 
 void InformationScriptingPlugin::unload()
 {
+	ScriptQuery::unloadPythonEnvironment();
 }
 
 void InformationScriptingPlugin::selfTest(QString testid)

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -32,9 +32,6 @@
 #include "OOModel/src/declarations/Class.h"
 #include "OOModel/src/declarations/Method.h"
 
-#include "../wrappers/AstApi.h"
-#include "../wrappers/NodeApi.h"
-#include "../helpers/BoostPythonHelpers.h"
 #include "../graph/InformationNode.h"
 #include "../queries/QueryExecutor.h"
 #include "../queries/CompositeQuery.h"
@@ -43,6 +40,7 @@
 #include "../queries/AstQuery.h"
 #include "../queries/NodePropertyAdder.h"
 #include "../queries/UnionOperator.h"
+#include "../queries/ScriptQuery.h"
 
 namespace InformationScripting {
 
@@ -70,36 +68,16 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 
 	if (command == "script")
 	{
-
-		auto parentClass = node->firstAncestorOfType<OOModel::Class>();
-
-		try {
-			PyImport_AppendInittab("AstApi", PyInit_AstApi);
-			PyImport_AppendInittab("NodeApi", PyInit_NodeApi);
-			Py_Initialize();
-
-			python::object main_module = python::import("__main__");
-			python::dict main_namespace = python::extract<python::dict>(main_module.attr("__dict__"));
-
-			python::object astApi = python::import("AstApi");
-			python::object nodeApi = python::import("NodeApi");
-			python::object sys = python::import("sys");
-
-			python::list methods;
-			for (auto method : *parentClass->methods())
-			{
-				// TODO: this leaks currently
-				auto infoNode = new InformationNode({{"ast", method}});
-				methods.append(python::ptr(infoNode));
-			}
-
-			main_namespace["methods"] = methods;
-
-			exec_file("../InformationScripting/test/scripts/methods.py", main_namespace, main_namespace);
-			// Workaround to get output
-			sys.attr("stdout").attr("flush")();
-		} catch (python::error_already_set ) {
-			qDebug() << "Error in Python: " << BoostPythonHelpers::parsePythonException();
+		if (args.size())
+		{
+			auto classesQuery = new AstQuery(AstQuery::QueryType::Classes, node, {"g"});
+			// TODO we could be more fancy in script file name detection, e.g. if .py is already entered don't append it.
+			auto scriptQuery = new ScriptQuery(QString("../InformationScripting/test/scripts/%1.py").arg(args[0]));
+			auto compositeQuery = new CompositeQuery();
+			compositeQuery->connectQuery(classesQuery, scriptQuery);
+			compositeQuery->connectToOutput(scriptQuery);
+			QueryExecutor queryExecutor(compositeQuery);
+			queryExecutor.execute();
 		}
 	}
 	else if (command == "methods")

--- a/InformationScripting/src/helpers/BoostPythonHelpers.cpp
+++ b/InformationScripting/src/helpers/BoostPythonHelpers.cpp
@@ -26,6 +26,9 @@
 
 #include "BoostPythonHelpers.h"
 
+#include "../graph/InformationNode.h"
+#include "../graph/InformationEdge.h"
+
 namespace InformationScripting {
 
 namespace PythonConverters {
@@ -67,6 +70,22 @@ struct QString_from_python_str
 			// in-place construct the new QString using the character data extraced from the python object
 			new (storageBytes) QString(PyBytes_AsString(rawBytesHandle.get()));
 			data->convertible = storageBytes;
+		}
+};
+
+// Currently we don't need any value lists:
+template<class T>
+struct QList_to_python_list;
+
+// Specialization for pointer lists:
+template<class T>
+struct QList_to_python_list<T*>
+{
+		static PyObject* convert(QList<T*> toConvert)
+		{
+			python::list list;
+			for (auto val : toConvert) list.append(python::ptr(val));
+			return python::incref(list.ptr());
 		}
 };
 
@@ -119,10 +138,13 @@ void BoostPythonHelpers::initializeQStringConverters()
 {
 	using namespace boost;
 
-	// register the to-python converter
+	// register the to-python converters
 	python::to_python_converter<QString, PythonConverters::QString_to_python_str>();
 
-	// register the from-python converter
+	python::to_python_converter<QList<InformationNode*>, PythonConverters::QList_to_python_list<InformationNode*>>();
+	python::to_python_converter<QList<InformationEdge*>, PythonConverters::QList_to_python_list<InformationEdge*>>();
+
+	// register the from-python converters
 	PythonConverters::QString_from_python_str();
 }
 

--- a/InformationScripting/src/precompiled.h
+++ b/InformationScripting/src/precompiled.h
@@ -56,6 +56,7 @@
 #endif
 
 #include <boost/python.hpp>
+#include <boost/python/stl_iterator.hpp>
 
 #ifdef PYTHONQT_RESTORE_KEYWORDS
 #define slots Q_SLOTS

--- a/InformationScripting/src/queries/ScriptQuery.cpp
+++ b/InformationScripting/src/queries/ScriptQuery.cpp
@@ -38,6 +38,18 @@ ScriptQuery::ScriptQuery(const QString& scriptPath)
 	: scriptPath_{scriptPath}
 {}
 
+void ScriptQuery::initPythonEnvironment()
+{
+	PyImport_AppendInittab("AstApi", PyInit_AstApi);
+	PyImport_AppendInittab("NodeApi", PyInit_NodeApi);
+	Py_Initialize();
+}
+
+void ScriptQuery::unloadPythonEnvironment()
+{
+	Py_Finalize();
+}
+
 QList<Graph*> ScriptQuery::execute(QList<Graph*> input)
 {
 	using namespace boost;
@@ -45,10 +57,6 @@ QList<Graph*> ScriptQuery::execute(QList<Graph*> input)
 	QList<Graph*> result;
 
 	try {
-		PyImport_AppendInittab("AstApi", PyInit_AstApi);
-		PyImport_AppendInittab("NodeApi", PyInit_NodeApi);
-		Py_Initialize();
-
 		python::object main_module = python::import("__main__");
 		python::dict main_namespace = python::extract<python::dict>(main_module.attr("__dict__"));
 

--- a/InformationScripting/src/queries/ScriptQuery.cpp
+++ b/InformationScripting/src/queries/ScriptQuery.cpp
@@ -1,0 +1,82 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "ScriptQuery.h"
+
+#include "../wrappers/AstApi.h"
+#include "../wrappers/NodeApi.h"
+#include "../helpers/BoostPythonHelpers.h"
+
+#include "../graph/Graph.h"
+
+namespace InformationScripting {
+
+ScriptQuery::ScriptQuery(const QString& scriptPath)
+	: scriptPath_{scriptPath}
+{}
+
+QList<Graph*> ScriptQuery::execute(QList<Graph*> input)
+{
+	using namespace boost;
+
+	QList<Graph*> result;
+
+	try {
+		PyImport_AppendInittab("AstApi", PyInit_AstApi);
+		PyImport_AppendInittab("NodeApi", PyInit_NodeApi);
+		Py_Initialize();
+
+		python::object main_module = python::import("__main__");
+		python::dict main_namespace = python::extract<python::dict>(main_module.attr("__dict__"));
+
+		python::object astApi = python::import("AstApi");
+		python::object nodeApi = python::import("NodeApi");
+		python::object sys = python::import("sys");
+
+		// TODO we have to consider how we can make sure that we don't have any memory leaks here:
+		// In general we need to figure out memory management for the scripting environment, where ownership is clearly
+		// defined.
+		// (see also: http://stackoverflow.com/questions/28653886/delete-a-pointer-in-stdvector-exposed-by-boostpython)
+		python::list inputGraphs;
+		for (auto g : input)
+			inputGraphs.append(python::ptr(g));
+
+		main_namespace["inputs"] = inputGraphs;
+
+		exec_file(scriptPath_.toLatin1().data(), main_namespace, main_namespace);
+		// Workaround to get output
+		sys.attr("stdout").attr("flush")();
+
+		python::list results = python::extract<python::list>(main_namespace["results"]);
+		python::stl_input_iterator<Graph*> begin(results), end;
+		result = QList<Graph*>::fromStdList(std::list<Graph*>(begin, end));
+	} catch (python::error_already_set ) {
+		qDebug() << "Error in Python: " << BoostPythonHelpers::parsePythonException();
+	}
+	return result;
+}
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/ScriptQuery.h
+++ b/InformationScripting/src/queries/ScriptQuery.h
@@ -1,0 +1,45 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../informationscripting_api.h"
+
+#include "Query.h"
+
+namespace InformationScripting {
+
+class ScriptQuery : public Query
+{
+	public:
+		ScriptQuery(const QString& scriptPath);
+		virtual QList<Graph*> execute(QList<Graph*> input) override;
+
+	private:
+		QString scriptPath_;
+};
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/ScriptQuery.h
+++ b/InformationScripting/src/queries/ScriptQuery.h
@@ -36,6 +36,10 @@ class ScriptQuery : public Query
 {
 	public:
 		ScriptQuery(const QString& scriptPath);
+
+		static void initPythonEnvironment();
+		static void unloadPythonEnvironment();
+
 		virtual QList<Graph*> execute(QList<Graph*> input) override;
 
 	private:

--- a/InformationScripting/src/wrappers/NodeApi.cpp
+++ b/InformationScripting/src/wrappers/NodeApi.cpp
@@ -28,15 +28,38 @@
 
 #include "../graph/PropertyMap.h"
 #include "../graph/InformationNode.h"
+#include "../graph/InformationEdge.h"
+#include "../graph/Graph.h"
 
 namespace InformationScripting {
 
 using namespace boost::python;
 
+// The following macro has unused local typdef so we disable the warning for this.
+// (Note that this also works with clang)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-local-typedef"
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(addEdge_overloads, Graph::addEdge, 3, 5)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(nodes_overloads, Graph::nodes, 0, 1)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(edges_overloads, Graph::edges, 0, 1)
+#pragma GCC diagnostic pop
+
 BOOST_PYTHON_MODULE(NodeApi) {
 		class_<PropertyMap, boost::noncopyable>("PropertyMap", no_init)
 				.def("__getattr__", &PropertyMap::pythonAttribute);
 		class_<InformationNode, bases<PropertyMap>>("InformationNode", no_init);
+		class_<InformationEdge, bases<PropertyMap>>("InformationEdge", no_init);
+
+		void (Graph::*remove1)(InformationNode*)        = &Graph::remove;
+		void (Graph::*remove2)(QList<InformationNode*>) = &Graph::remove;
+
+		class_<Graph>("Graph")
+				.def("add", &Graph::add, return_value_policy<reference_existing_object>())
+				.def("addEdge", &Graph::addEdge, addEdge_overloads()[return_value_policy<reference_existing_object>()])
+				.def("remove", remove1)
+				.def("remove", remove2)
+				.def("nodes", &Graph::nodes, nodes_overloads())
+				.def("edges", &Graph::edges, edges_overloads());
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/wrappers/NodeApi.cpp
+++ b/InformationScripting/src/wrappers/NodeApi.cpp
@@ -35,14 +35,9 @@ namespace InformationScripting {
 
 using namespace boost::python;
 
-// The following macro has unused local typdef so we disable the warning for this.
-// (Note that this also works with clang)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedef"
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(addEdge_overloads, Graph::addEdge, 3, 5)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(nodes_overloads, Graph::nodes, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(edges_overloads, Graph::edges, 0, 1)
-#pragma GCC diagnostic pop
 
 BOOST_PYTHON_MODULE(NodeApi) {
 		class_<PropertyMap, boost::noncopyable>("PropertyMap", no_init)

--- a/InformationScripting/test/scripts/test.py
+++ b/InformationScripting/test/scripts/test.py
@@ -1,0 +1,8 @@
+results = [];
+
+for g in inputs:
+    nodes = g.nodes()
+    for node in nodes:
+        ast = node.ast;
+        print(ast.constructKind)
+    results.append(g)


### PR DESCRIPTION
Enables the execution of a script as a Query
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/dimitar-asenov%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23issuecomment-132934525%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-08-20T08%3A25%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201b874867a94fed9e0fca78699f127d9bf0e3e487%20InformationScripting/src/queries/ScriptQuery.cpp%2059%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37393589%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Let%27s%20discuss%20this%20during%20our%20next%20meeting.%22%2C%20%22created_at%22%3A%20%222015-08-19T09%3A03%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/ScriptQuery.cpp%3AL1-83%22%7D%2C%20%22Pull%201b874867a94fed9e0fca78699f127d9bf0e3e487%20InformationScripting/src/wrappers/NodeApi.cpp%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37392997%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Patrick%20will%20be%20very%20happy%20to%20see%20this%20%3A%29%5Cr%5Cn%5Cr%5CnIs%20there%20some%20way%20to%20avoid%20the%20use%20of%20pragmas%20%28without%20disabling%20the%20flag%20altogether%29%3F%20Why%20does%20the%20macro%20have%20an%20unused%20typedef%3F%20Can%27t%20we%20hackaround%20that%20somehow%3F%5Cr%5Cn%5Cr%5CnDisabling%20warning%20just%20for%20this%20file%2C%20somehow%20in%20the%20.pro%20file%2C%20might%20be%20a%20better%20solution%2C%20if%20possible.%22%2C%20%22created_at%22%3A%20%222015-08-19T08%3A57%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20could%20use%20an%20extra%20compiler%20for%20this%20as%20described%20here%3A%5Cr%5Cnhttp%3A//stackoverflow.com/a/14608296%22%2C%20%22created_at%22%3A%20%222015-08-19T09%3A02%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20not%20that%20pretty%20but%20at%20least%20it%20avoids%20the%20pragmas%20here.%20Could%20you%20please%20try%20that%20and%20see%20if%20it%20works%3F%22%2C%20%22created_at%22%3A%20%222015-08-19T09%3A08%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20a%20commit%20which%20does%20this.%20However%20there%20is%20no%20easy%20way%20to%20pick%20up%20the%20precompiled%20settings%2C%20but%20it%20still%20works.%22%2C%20%22created_at%22%3A%20%222015-08-19T09%3A30%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/wrappers/NodeApi.cpp%3AL28-66%22%7D%2C%20%22Pull%201b874867a94fed9e0fca78699f127d9bf0e3e487%20InformationScripting/src/queries/ScriptQuery.cpp%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37393543%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20it%20reasonable%20to%20create%20a%20new%20main%20module%20for%20every%20script%20execution%2C%20or%20might%20it%20be%20better%20to%20reuse%20one%3F%22%2C%20%22created_at%22%3A%20%222015-08-19T09%3A03%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20should%20discuss%20this%20together%20with%20memory%20management%22%2C%20%22created_at%22%3A%20%222015-08-20T07%3A07%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/ScriptQuery.cpp%3AL1-83%22%7D%2C%20%22Pull%201b874867a94fed9e0fca78699f127d9bf0e3e487%20InformationScripting/src/queries/ScriptQuery.cpp%2048%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37393266%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20does%20not%20make%20sense%20to%20initialize%20the%20API%20every%20time%20we%20execute.%20This%20should%20be%20done%20once%2C%20from%20InformationSystemPlugin.cpp%22%2C%20%22created_at%22%3A%20%222015-08-19T08%3A59%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%22%2C%20%22created_at%22%3A%20%222015-08-20T07%3A07%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/ScriptQuery.cpp%3AL1-83%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23issuecomment-132934525%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37392997%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37393266%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37393512%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37393543%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37393589%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37394017%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37395752%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37500494%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/131%23discussion_r37500511%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/dimitar-asenov'><img src='https://avatars.githubusercontent.com/u/1152976?v=3' width=34 height=34></a>
- [ ] <a href='#crh-comment-Pull 1b874867a94fed9e0fca78699f127d9bf0e3e487 InformationScripting/src/wrappers/NodeApi.cpp 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/131#discussion_r37392997'>File: InformationScripting/src/wrappers/NodeApi.cpp:L28-66</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Patrick will be very happy to see this :)
  Is there some way to avoid the use of pragmas (without disabling the flag altogether)? Why does the macro have an unused typedef? Can't we hackaround that somehow?
  Disabling warning just for this file, somehow in the .pro file, might be a better solution, if possible.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> We could use an extra compiler for this as described here:
  http://stackoverflow.com/a/14608296
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, not that pretty but at least it avoids the pragmas here. Could you please try that and see if it works?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Added a commit which does this. However there is no easy way to pick up the precompiled settings, but it still works.
- [ ] <a href='#crh-comment-Pull 1b874867a94fed9e0fca78699f127d9bf0e3e487 InformationScripting/src/queries/ScriptQuery.cpp 48'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/131#discussion_r37393266'>File: InformationScripting/src/queries/ScriptQuery.cpp:L1-83</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> It does not make sense to initialize the API every time we execute. This should be done once, from InformationSystemPlugin.cpp
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Done
- [ ] <a href='#crh-comment-Pull 1b874867a94fed9e0fca78699f127d9bf0e3e487 InformationScripting/src/queries/ScriptQuery.cpp 52'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/131#discussion_r37393543'>File: InformationScripting/src/queries/ScriptQuery.cpp:L1-83</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Is it reasonable to create a new main module for every script execution, or might it be better to reuse one?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> We should discuss this together with memory management
- [ ] <a href='#crh-comment-Pull 1b874867a94fed9e0fca78699f127d9bf0e3e487 InformationScripting/src/queries/ScriptQuery.cpp 59'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/131#discussion_r37393589'>File: InformationScripting/src/queries/ScriptQuery.cpp:L1-83</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Let's discuss this during our next meeting.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/131?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/131?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/131?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/131'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
