### PR TITLE
More scripting

### DIFF
--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -78,6 +78,11 @@ exists(src/wrappers/AstApi_Generated.cpp): {
     DEFINES+=AST_API_GENERATED
 }
 
+# Install script files into the script directory:
+test_scripts.path = $${BUILD_DIR}/scripts
+test_scripts.files = test/scripts/*.py
+INSTALLS += test_scripts
+
 # The below piece is borrowed and adapted from: https://github.com/mkeeter/antimony/blob/master/qt/python.pri
 cygwin {
     QMAKE_CXXFLAGS += $$system(python3-config --includes)

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -28,7 +28,6 @@ HEADERS += src/precompiled.h \
     src/queries/CompositeQuery.h \
     src/queries/GenericFilter.h \
     src/queries/AstNameFilter.h \
-    src/queries/SubstractNodesOperator.h \
     src/queries/NodePropertyAdder.h \
     src/queries/UnionOperator.h \
     src/queries/ScriptQuery.h \
@@ -38,7 +37,8 @@ HEADERS += src/precompiled.h \
     src/dataformat/Property.h \
     src/helpers/PythonSet.h \
     src/wrappers/DataApi.h \
-    src/queries/QueryRegistry.h
+    src/queries/QueryRegistry.h \
+    src/queries/SubstractOperator.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -51,7 +51,6 @@ SOURCES += src/InformationScriptingException.cpp \
     src/queries/CompositeQuery.cpp \
     src/queries/GenericFilter.cpp \
     src/queries/AstNameFilter.cpp \
-    src/queries/SubstractNodesOperator.cpp \
     src/queries/NodePropertyAdder.cpp \
     src/queries/UnionOperator.cpp \
     src/queries/ScriptQuery.cpp \
@@ -61,7 +60,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/dataformat/TupleSet.cpp \
     src/dataformat/Property.cpp \
     src/helpers/PythonSet.cpp \
-    src/queries/QueryRegistry.cpp
+    src/queries/QueryRegistry.cpp \
+    src/queries/SubstractOperator.cpp
 
 # Workaround to not have any pragma's in NodeApi.cpp
 # (because of unused local typedef in BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS):

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -37,7 +37,8 @@ HEADERS += src/precompiled.h \
     src/dataformat/TupleSet.h \
     src/dataformat/Property.h \
     src/helpers/PythonSet.h \
-    src/wrappers/DataApi.h
+    src/wrappers/DataApi.h \
+    src/queries/QueryRegistry.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -59,7 +60,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/dataformat/Tuple.cpp \
     src/dataformat/TupleSet.cpp \
     src/dataformat/Property.cpp \
-    src/helpers/PythonSet.cpp
+    src/helpers/PythonSet.cpp \
+    src/queries/QueryRegistry.cpp
 
 # Workaround to not have any pragma's in NodeApi.cpp
 # (because of unused local typedef in BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS):

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -32,6 +32,7 @@ HEADERS += src/precompiled.h \
     src/queries/NodePropertyAdder.h \
     src/queries/UnionOperator.h \
     src/queries/ScriptQuery.h \
+    src/parsing/QueryBuilder.h \
     src/dataformat/Tuple.h \
     src/dataformat/TupleSet.h \
     src/dataformat/Property.h \
@@ -54,6 +55,7 @@ SOURCES += src/InformationScriptingException.cpp \
     src/queries/UnionOperator.cpp \
     src/queries/ScriptQuery.cpp \
     src/visitors/AllNodesOfType.cpp \
+    src/parsing/QueryBuilder.cpp \
     src/dataformat/Tuple.cpp \
     src/dataformat/TupleSet.cpp \
     src/dataformat/Property.cpp \

--- a/InformationScripting/src/InformationScriptingPlugin.cpp
+++ b/InformationScripting/src/InformationScriptingPlugin.cpp
@@ -34,6 +34,8 @@
 #include "commands/CScript.h"
 #include "helpers/BoostPythonHelpers.h"
 #include "queries/ScriptQuery.h"
+#include "queries/AstQuery.h"
+#include "queries/AstNameFilter.h"
 
 namespace InformationScripting {
 
@@ -42,6 +44,8 @@ bool InformationScriptingPlugin::initialize(Core::EnvisionManager&)
 	BoostPythonHelpers::initializeConverters();
 	OOInteraction::HStatementItemList::instance()->addCommand(new CScript());
 	ScriptQuery::initPythonEnvironment();
+	AstQuery::registerDefaultQueries();
+	AstNameFilter::registerDefaultQueries();
 	return true;
 }
 

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -35,7 +35,7 @@
 #include "../queries/QueryExecutor.h"
 #include "../queries/CompositeQuery.h"
 #include "../queries/AstNameFilter.h"
-#include "../queries/SubstractNodesOperator.h"
+#include "../queries/SubstractOperator.h"
 #include "../queries/AstQuery.h"
 #include "../queries/NodePropertyAdder.h"
 #include "../queries/UnionOperator.h"
@@ -155,7 +155,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 			// $"methods g" - "callgraph"$
 			auto allMethodsQuery = new AstQuery(AstQuery::QueryType::Methods, node, {"g"});
 			auto callGraphQuery = new AstQuery(AstQuery::QueryType::CallGraph, node, args);
-			auto complement = new SubstractNodesOperator();
+			auto complement = new SubstractOperator();
 			auto compositeQuery = new CompositeQuery();
 			compositeQuery->connectQuery(allMethodsQuery, complement);
 			compositeQuery->connectQuery(callGraphQuery, 0, complement, 1);

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -81,7 +81,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 
 		if (command == "script")
 		{
-			if (args.size())
+			if (args.size() > 1)
 			{
 				// $"classes g" | "script test"$
 				auto classesQuery = new AstQuery(AstQuery::QueryType::Classes, node, {"g"});

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -41,6 +41,8 @@
 #include "../queries/UnionOperator.h"
 #include "../queries/ScriptQuery.h"
 
+#include "../parsing/QueryBuilder.h"
+
 namespace InformationScripting {
 
 CScript::CScript() : Command{"script"} {}
@@ -65,120 +67,137 @@ Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization
 	QString command = args[0];
 	args = args.mid(1);
 
-	if (command == "script")
+	if (command != "fallback")
 	{
-		if (args.size())
+		args.prepend(command);
+		auto q = QueryBuilder::instance().buildQueryFrom(args.join(""), node);
+		QueryExecutor queryExecutor(q);
+		queryExecutor.execute();
+	}
+	else
+	{
+		QString command = args[0];
+		args = args.mid(1);
+
+		if (command == "script")
 		{
-			auto classesQuery = new AstQuery(AstQuery::QueryType::Classes, node, {"g"});
-			// TODO we could be more fancy in script file name detection, e.g. if .py is already entered don't append it.
-			auto scriptQuery = new ScriptQuery(QString("../InformationScripting/test/scripts/%1.py").arg(args[0]));
+			if (args.size())
+			{
+				// $"classes g" | "script test"$
+				auto classesQuery = new AstQuery(AstQuery::QueryType::Classes, node, {"g"});
+				// TODO we could be more fancy in script file name detection, e.g. if .py is already entered don't append it.
+				auto scriptQuery = new ScriptQuery(QString("../InformationScripting/test/scripts/%1.py").arg(args[0]));
+				auto compositeQuery = new CompositeQuery();
+				compositeQuery->connectQuery(classesQuery, scriptQuery);
+				compositeQuery->connectToOutput(scriptQuery);
+				QueryExecutor queryExecutor(compositeQuery);
+				queryExecutor.execute();
+			}
+		}
+		else if (command == "methods")
+		{
+			// "methods"
+			auto query = new AstQuery(AstQuery::QueryType::Methods, node, args);
+			QueryExecutor queryExecutor(query);
+			queryExecutor.execute();
+		}
+		else if (command == "bases")
+		{
+			// "bases"
+			auto query = new AstQuery(AstQuery::QueryType::BaseClasses, node, args);
+			QueryExecutor queryExecutor(query);
+			queryExecutor.execute();
+		}
+		else if (command == "pipe")
+		{
+			// $"methods" | "toClass"$
+			auto methodQuery = new AstQuery(AstQuery::QueryType::Methods, node, args);
+			auto toBaseQuery = new AstQuery(AstQuery::QueryType::ToClass, node, args);
 			auto compositeQuery = new CompositeQuery();
-			compositeQuery->connectQuery(classesQuery, scriptQuery);
-			compositeQuery->connectToOutput(scriptQuery);
+			compositeQuery->connectQuery(methodQuery, toBaseQuery);
+			compositeQuery->connectToOutput(toBaseQuery);
 			QueryExecutor queryExecutor(compositeQuery);
 			queryExecutor.execute();
 		}
-	}
-	else if (command == "methods")
-	{
-		auto query = new AstQuery(AstQuery::QueryType::Methods, node, args);
-		QueryExecutor queryExecutor(query);
-		queryExecutor.execute();
-	}
-	else if (command == "bases")
-	{
-		auto query = new AstQuery(AstQuery::QueryType::BaseClasses, node, args);
-		QueryExecutor queryExecutor(query);
-		queryExecutor.execute();
-	}
-	else if (command == "pipe")
-	{
-		auto methodQuery = new AstQuery(AstQuery::QueryType::Methods, node, args);
-		auto toBaseQuery = new AstQuery(AstQuery::QueryType::ToClass, node, args);
-		auto compositeQuery = new CompositeQuery();
-		compositeQuery->connectQuery(methodQuery, toBaseQuery);
-		compositeQuery->connectToOutput(toBaseQuery);
-		QueryExecutor queryExecutor(compositeQuery);
-		queryExecutor.execute();
-	}
-	else if (command == "query21")
-	{
-		// Find all classes for which the name contains X and which have a method named Y
-		// 5 queries seems like a lot for this :S
-		auto classesQuery = new AstQuery(AstQuery::QueryType::Classes, node, {"g"});
-		auto filterQuery = new AstNameFilter(Model::SymbolMatcher(new QRegExp("\\w*Matcher\\w*")));
-		auto methodsOfQuery = new AstQuery(AstQuery::QueryType::Methods, node, {"of"});
-		auto methodsFilter = new AstNameFilter(Model::SymbolMatcher("matches"));
-		auto toBaseQuery = new AstQuery(AstQuery::QueryType::ToClass, node, args);
-		auto compositeQuery = new CompositeQuery();
-		compositeQuery->connectQuery(classesQuery, filterQuery);
-		compositeQuery->connectQuery(filterQuery, methodsOfQuery);
-		compositeQuery->connectQuery(methodsOfQuery, methodsFilter);
-		compositeQuery->connectQuery(methodsFilter, toBaseQuery);
-		compositeQuery->connectToOutput(toBaseQuery);
-		QueryExecutor queryExecutor(compositeQuery);
-		queryExecutor.execute();
-	}
-	else if (command == "callgraph")
-	{
-		auto query = new AstQuery(AstQuery::QueryType::CallGraph, node, args);
-		auto compositeQuery = new CompositeQuery();
-		compositeQuery->connectToOutput(query);
-		QueryExecutor queryExecutor(compositeQuery);
-		queryExecutor.execute();
-	}
-	else if (command == "query19")
-	{
-		// Find all methods that are not called transitively from the TARGET method.
-		auto allMethodsQuery = new AstQuery(AstQuery::QueryType::Methods, node, {"g"});
-		auto callGraphQuery = new AstQuery(AstQuery::QueryType::CallGraph, node, args);
-		auto complement = new SubstractNodesOperator();
-		auto compositeQuery = new CompositeQuery();
-		compositeQuery->connectQuery(allMethodsQuery, complement);
-		compositeQuery->connectQuery(callGraphQuery, 0, complement, 1);
-		compositeQuery->connectToOutput(complement);
-		QueryExecutor queryExecutor(compositeQuery);
-		queryExecutor.execute();
-	}
-	else if (command == "color")
-	{
-		auto colorMatcher = new NodePropertyAdder("color", QString("blue"),
-			[](const Tuple& tuple) {
-				auto it = tuple.find("ast");
-				if (it != tuple.end()) {
-					Model::Node* astNode = it->second;
-					if (auto methodNode = DCast<OOModel::Method>(astNode))
-						return methodNode->name().contains("brackets");
-				}
-				return false;
-		});
+		else if (command == "query21")
+		{
+			// Find all classes for which the name contains X and which have a method named Y
+			// 5 queries seems like a lot for this :S
 
-		auto colorDescription = new NodePropertyAdder("color", QString("green"),
-			[](const Tuple& tuple) {
-				auto it = tuple.find("ast");
-				if (it != tuple.end()) {
-					Model::Node* astNode = it->second;
-					if (auto methodNode = DCast<OOModel::Method>(astNode))
-						return methodNode->name().contains("quotes");
-				}
-				return false;
-		});
+			// $"classes g" | "filter *Matcher*" | "methods of" | "filter matches" | "toClass"$
+			auto classesQuery = new AstQuery(AstQuery::QueryType::Classes, node, {"g"});
+			auto filterQuery = new AstNameFilter(Model::SymbolMatcher(new QRegExp("\\w*Matcher\\w*")));
+			auto methodsOfQuery = new AstQuery(AstQuery::QueryType::Methods, node, {"of"});
+			auto methodsFilter = new AstNameFilter(Model::SymbolMatcher("matches"));
+			auto toBaseQuery = new AstQuery(AstQuery::QueryType::ToClass, node, args);
+			auto compositeQuery = new CompositeQuery();
+			compositeQuery->connectQuery(classesQuery, filterQuery);
+			compositeQuery->connectQuery(filterQuery, methodsOfQuery);
+			compositeQuery->connectQuery(methodsOfQuery, methodsFilter);
+			compositeQuery->connectQuery(methodsFilter, toBaseQuery);
+			compositeQuery->connectToOutput(toBaseQuery);
+			QueryExecutor queryExecutor(compositeQuery);
+			queryExecutor.execute();
+		}
+		else if (command == "callgraph")
+		{
+			// "callgraph"
+			auto query = new AstQuery(AstQuery::QueryType::CallGraph, node, args);
+			auto compositeQuery = new CompositeQuery();
+			compositeQuery->connectToOutput(query);
+			QueryExecutor queryExecutor(compositeQuery);
+			queryExecutor.execute();
+		}
+		else if (command == "query19")
+		{
+			// Find all methods that are not called transitively from the TARGET method.
 
-		auto methods = new AstQuery(AstQuery::QueryType::Methods, node, {});
-		auto unionOp = new UnionOperator();
+			// $"methods g" - "callgraph"$
+			auto allMethodsQuery = new AstQuery(AstQuery::QueryType::Methods, node, {"g"});
+			auto callGraphQuery = new AstQuery(AstQuery::QueryType::CallGraph, node, args);
+			auto complement = new SubstractNodesOperator();
+			auto compositeQuery = new CompositeQuery();
+			compositeQuery->connectQuery(allMethodsQuery, complement);
+			compositeQuery->connectQuery(callGraphQuery, 0, complement, 1);
+			compositeQuery->connectToOutput(complement);
+			QueryExecutor queryExecutor(compositeQuery);
+			queryExecutor.execute();
+		}
+		else if (command == "color")
+		{
+			// $"methods" | {$"filter *quotes*" | "color = blue"$, $"filter *brackets*" | "color = green"$} U$
+			auto colorQuotes = new NodePropertyAdder("color", QString("blue"));
+			auto colorBrackets = new NodePropertyAdder("color", QString("green"));
 
-		auto composite = new CompositeQuery();
+			auto quotesFilter = new AstNameFilter(Model::SymbolMatcher(new QRegExp("\\w*quotes\\w*")));
+			auto bracketsFilter = new AstNameFilter(Model::SymbolMatcher(new QRegExp("\\w*brackets\\w*")));
 
-		composite->connectQuery(methods, colorMatcher);
-		composite->connectQuery(methods, colorDescription);
+			auto quotes = new CompositeQuery();
+			quotes->connectInput(0, quotesFilter);
+			quotes->connectQuery(quotesFilter, colorQuotes);
+			quotes->connectToOutput(colorQuotes);
 
-		composite->connectQuery(colorMatcher, unionOp);
-		composite->connectQuery(colorDescription, 0, unionOp, 1);
+			auto brackets = new CompositeQuery();
+			brackets->connectInput(0, bracketsFilter);
+			brackets->connectQuery(bracketsFilter, colorBrackets);
+			brackets->connectToOutput(colorBrackets);
 
-		composite->connectToOutput(unionOp);
+			auto methods = new AstQuery(AstQuery::QueryType::Methods, node, {});
+			auto unionOp = new UnionOperator();
 
-		QueryExecutor queryExecutor(composite);
-		queryExecutor.execute();
+			auto composite = new CompositeQuery();
+
+			composite->connectQuery(methods, quotes);
+			composite->connectQuery(methods, brackets);
+
+			composite->connectQuery(quotes, unionOp);
+			composite->connectQuery(brackets, 0, unionOp, 1);
+
+			composite->connectToOutput(unionOp);
+
+			QueryExecutor queryExecutor(composite);
+			queryExecutor.execute();
+		}
 	}
 	return new Interaction::CommandResult();
 }

--- a/InformationScripting/src/dataformat/Tuple.cpp
+++ b/InformationScripting/src/dataformat/Tuple.cpp
@@ -67,14 +67,14 @@ uint qHash(const Tuple& t, uint seed)
 
 Property& Tuple::operator[](const QString& name)
 {
-	auto it = std::find_if(begin(), end(), [name](const auto& np) {return np.first == name;});
+	auto it = find(name);
 	Q_ASSERT(it != end());
 	return it->second;
 }
 
 const Property& Tuple::operator[](const QString& name) const
 {
-	auto it = std::find_if(begin(), end(), [name](const auto& np) {return np.first == name;});
+	auto it = find(name);
 	Q_ASSERT(it != end());
 	return it->second;
 }

--- a/InformationScripting/src/dataformat/Tuple.cpp
+++ b/InformationScripting/src/dataformat/Tuple.cpp
@@ -47,7 +47,12 @@ void Tuple::add(const NamedProperty& p)
 
 uint Tuple::hashValue(uint seed) const
 {
+// FIXME remove this workaround after ubuntu has 5.5 in repos
+#if QT_VERSION >= 0x050500
 	return qHashRange(begin(), end(), seed);
+#else
+	return 0;
+#endif
 }
 
 Tuple::const_iterator Tuple::find(const QString& name) const

--- a/InformationScripting/src/dataformat/TupleSet.h
+++ b/InformationScripting/src/dataformat/TupleSet.h
@@ -35,8 +35,6 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API TupleSet
 {
 	public:
-		using TupleCondition = std::function<bool (const Tuple& t)>;
-
 		template<class Condition>
 		QSet<Tuple> tuples(Condition condition) const;
 		/**

--- a/InformationScripting/src/dataformat/TupleSet.h
+++ b/InformationScripting/src/dataformat/TupleSet.h
@@ -55,6 +55,12 @@ class INFORMATIONSCRIPTING_API TupleSet
 		QSet<Tuple> takeAll();
 		void unite(const TupleSet& with);
 
+		/**
+		 * Adds all properties of type \a T as single Tuples with tag \a tag.
+		 */
+		template<class T>
+		void addAllPropertiesTo(const QString& tag);
+
 	private:
 		QHash<QString, QSet<Tuple>> tuples_;
 };
@@ -100,6 +106,21 @@ inline QSet<Tuple> TupleSet::take(Condition condition)
 		}
 	}
 	return result;
+}
+
+template <class T>
+inline void TupleSet::addAllPropertiesTo(const QString& tag)
+{
+	for (auto hashIt = tuples_.begin(); hashIt != tuples_.end(); ++hashIt)
+	{
+		if (hashIt.key() != tag)
+		for (const auto& t : hashIt.value())
+		{
+			auto properties = t.valuesOfType<T>();
+			for (const auto& p : properties)
+				tuples_[tag].insert({{tag, p}});
+		}
+	}
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/dataformat/TupleSet.h
+++ b/InformationScripting/src/dataformat/TupleSet.h
@@ -59,7 +59,7 @@ class INFORMATIONSCRIPTING_API TupleSet
 		 * Adds all properties of type \a T as single Tuples with tag \a tag.
 		 */
 		template<class T>
-		void addAllPropertiesTo(const QString& tag);
+		void addPropertiesAsTuples(const QString& tag);
 
 	private:
 		QHash<QString, QSet<Tuple>> tuples_;
@@ -109,7 +109,7 @@ inline QSet<Tuple> TupleSet::take(Condition condition)
 }
 
 template <class T>
-inline void TupleSet::addAllPropertiesTo(const QString& tag)
+inline void TupleSet::addPropertiesAsTuples(const QString& tag)
 {
 	for (auto hashIt = tuples_.begin(); hashIt != tuples_.end(); ++hashIt)
 	{

--- a/InformationScripting/src/helpers/BoostPythonHelpers.cpp
+++ b/InformationScripting/src/helpers/BoostPythonHelpers.cpp
@@ -164,6 +164,7 @@ void BoostPythonHelpers::initializeConverters()
 
 	python::to_python_converter<QSet<Tuple>, PythonConverters::QSet_to_python_set<Tuple>>();
 
+	python::to_python_converter<QList<QString>, PythonConverters::QList_to_python_list<QString>>();
 	python::to_python_converter<QList<TupleSet>, PythonConverters::QList_to_python_list<TupleSet>>();
 	python::to_python_converter<QList<NamedProperty>, PythonConverters::QList_to_python_list<NamedProperty>>();
 

--- a/InformationScripting/src/parsing/QueryBuilder.cpp
+++ b/InformationScripting/src/parsing/QueryBuilder.cpp
@@ -28,7 +28,7 @@
 
 #include "../queries/CompositeQuery.h"
 #include "../queries/Query.h"
-#include "../queries/SubstractNodesOperator.h"
+#include "../queries/SubstractOperator.h"
 #include "../queries/UnionOperator.h"
 
 
@@ -160,7 +160,7 @@ Query* QueryBuilder::parseOperator(const QString& text, bool connectInput)
 			else if (operators[i-1] == '-')
 			{
 				// TODO maybe minus should look like a union op, i.e. multiple input single output?
-				auto minus = new SubstractNodesOperator();
+				auto minus = new SubstractOperator();
 				composite->connectQuery(previousQueries[0], minus);
 				composite->connectQuery(currentQueries[0], 0, minus, 1);
 				currentQueries = {minus};

--- a/InformationScripting/src/parsing/QueryBuilder.cpp
+++ b/InformationScripting/src/parsing/QueryBuilder.cpp
@@ -104,7 +104,8 @@ QueryBuilder::QueryBuilder()
 		return new AstNameFilter(Model::SymbolMatcher(args[0]));
 	});
 	registerQueryConstructor("script", [](Model::Node*, QStringList args) {
-		return new ScriptQuery(QString("../InformationScripting/test/scripts/%1.py").arg(args[0]));
+		QString scriptName = args.takeFirst();
+		return new ScriptQuery(QString("../InformationScripting/test/scripts/%1.py").arg(scriptName), args);
 	});
 }
 

--- a/InformationScripting/src/parsing/QueryBuilder.cpp
+++ b/InformationScripting/src/parsing/QueryBuilder.cpp
@@ -1,0 +1,255 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "QueryBuilder.h"
+
+#include "../queries/CompositeQuery.h"
+#include "../queries/Query.h"
+#include "../queries/AstQuery.h"
+#include "../queries/AstNameFilter.h"
+#include "../queries/SubstractNodesOperator.h"
+#include "../queries/UnionOperator.h"
+#include "../queries/NodePropertyAdder.h"
+#include "../queries/ScriptQuery.h"
+
+namespace InformationScripting {
+
+static const QStringList OPEN_SCOPE_SYMBOL{"$", "\"", "{"};
+static const QStringList CLOSE_SCOPE_SYMBOL{"$", "\"", "}"};
+
+QueryBuilder& QueryBuilder::instance()
+{
+	static QueryBuilder instance;
+	return instance;
+}
+
+Query* QueryBuilder::buildQueryFrom(const QString& text, Model::Node* target)
+{
+	target_ = target;
+	Q_ASSERT(text.size());
+	auto type = typeOf(text);
+	if (Type::Operator == type)
+		return parseOperator(text);
+	else if (Type::Query == type)
+		return parseQuery(text);
+	else if (Type::List == type)
+	{
+		auto queries = parseList(text);
+		auto result = new CompositeQuery();
+		for (int i = 0; i < queries.size(); ++i)
+		{
+			result->connectInput(i, queries[i]);
+			result->connectToOutput(queries[i], i);
+		}
+		return result;
+	}
+	Q_ASSERT(false);
+	return nullptr;
+}
+
+void QueryBuilder::registerQueryConstructor(const QString& command, QueryBuilder::QueryConstructor constructor)
+{
+	constructors_[command] = constructor;
+}
+
+QueryBuilder::QueryBuilder()
+{
+	// TODO find a better place to register queries:
+	registerQueryConstructor("classes", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::Classes, target, args);
+	});
+	registerQueryConstructor("methods", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::Methods, target, args);
+	});
+	registerQueryConstructor("bases", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::BaseClasses, target, args);
+	});
+	registerQueryConstructor("toClass", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::ToClass, target, args);
+	});
+	registerQueryConstructor("callgraph", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::CallGraph, target, args);
+	});
+	registerQueryConstructor("filter", [](Model::Node*, QStringList args) {
+		Q_ASSERT(args.size());
+		if (args[0].contains("*"))
+		{
+			QString regexString = args[0];
+			regexString.replace("*", "\\w*");
+			return new AstNameFilter(Model::SymbolMatcher(new QRegExp(regexString)));
+		}
+		return new AstNameFilter(Model::SymbolMatcher(args[0]));
+	});
+	registerQueryConstructor("script", [](Model::Node*, QStringList args) {
+		return new ScriptQuery(QString("../InformationScripting/test/scripts/%1.py").arg(args[0]));
+	});
+}
+
+QueryBuilder::Type QueryBuilder::typeOf(const QString& text)
+{
+	int index = OPEN_SCOPE_SYMBOL.indexOf(text[0]);
+	Q_ASSERT(index >= 0);
+	return static_cast<Type>(index);
+}
+
+QPair<QStringList, QList<QChar>> QueryBuilder::split(const QString& text, const QList<QChar>& splitChars)
+{
+	QPair<QStringList, QList<QChar>> result;
+	QString currentString;
+	QVector<int> openScopes(3, 0);
+	for (int i = 1; i < text.size() - 1; ++i)
+	{
+		QChar currentChar = text.at(i);
+		int openIndex = OPEN_SCOPE_SYMBOL.indexOf(currentChar);
+		if (openIndex >= 0) ++openScopes[openIndex];
+		int closeIndex = CLOSE_SCOPE_SYMBOL.indexOf(currentChar);
+		if (closeIndex >= 0) --openScopes[closeIndex];
+		bool isInScope = std::all_of(openScopes.begin(), openScopes.end(), [](int i) { return i == 0;});
+		if (isInScope && splitChars.contains(currentChar))
+		{
+			result.second << currentChar;
+			if (!currentString.isEmpty()) result.first << currentString;
+			currentString = "";
+		}
+		else
+			currentString.append(currentChar);
+	}
+	if (!currentString.isEmpty()) result.first << currentString;
+
+	return result;
+}
+
+Query* QueryBuilder::parseQuery(const QString& text)
+{
+	Q_ASSERT(typeOf(text) == Type::Query);
+	QStringList data = text.mid(1, text.size()-2).split(" ", QString::SkipEmptyParts);
+	Q_ASSERT(data.size());
+	QString command = data[0];
+	auto constructor = constructors_[command];
+	if (!constructor && (data.size() > 2 && data[1] == "="))
+	{
+		// TODO we need some way to specify a condition on the node.
+		// Or eventually decide that we don't allow condition in the property adder
+		return new NodePropertyAdder(data[0], data[2]);
+	}
+	// TODO this should only be an error presented to the user:
+	Q_ASSERT(constructor);
+	return constructor(target_, data.mid(1));
+}
+
+QList<Query*> QueryBuilder::parseList(const QString& text)
+{
+	Q_ASSERT(text.size());
+	QStringList parts = split(text, {','}).first;
+	QList<Query*> result;
+	for (QString part : parts)
+	{
+		auto type = typeOf(part);
+		if (Type::Operator == type)
+			result.push_back(parseOperator(part, true));
+		else if (Type::Query == type)
+			result.push_back(parseQuery(part));
+		else
+			Q_ASSERT(false); // TODO error for user
+	}
+	return result;
+}
+
+Query* QueryBuilder::parseOperator(const QString& text, bool connectInput)
+{
+	// TODO it might be better to be able to register operators.
+	// But that need some additional information on how they are used, thus we currently hardcode the operators.
+	auto splitted = split(text, {'|', '-', 'U'});
+	auto parts = splitted.first;
+	auto operators = splitted.second;
+	Q_ASSERT(parts.size()); // TODO error for user
+	CompositeQuery* composite = new CompositeQuery();
+	auto previousQueries = parseOperatorPart(parts[0]);
+	if (connectInput)
+	{
+		for (int i = 0; i < previousQueries.size(); ++i)
+			composite->connectInput(i, previousQueries[i]);
+	}
+
+	for (int i = 1; i < parts.size(); ++i)
+	{
+		auto currentQueries = parseOperatorPart(parts[i]);
+		// If left and right are both lists we don't know how to map things:
+		Q_ASSERT(!(previousQueries.size() > 1 && currentQueries.size() > 1)); // TODO error for user
+		if (previousQueries.size() == 1 && currentQueries.size() == 1)
+		{
+			if (operators[i-1] == '|')
+				composite->connectQuery(previousQueries[0], currentQueries[0]);
+			else if (operators[i-1] == '-')
+			{
+				// TODO maybe minus should look like a union op, i.e. multiple input single output?
+				auto minus = new SubstractNodesOperator();
+				composite->connectQuery(previousQueries[0], minus);
+				composite->connectQuery(currentQueries[0], 0, minus, 1);
+				currentQueries = {minus};
+			}
+		}
+		else if (previousQueries.size() > currentQueries.size())
+		{
+			auto unionOp = new UnionOperator();
+			for (int i = 0; i < previousQueries.size(); ++i)
+				composite->connectQuery(previousQueries[i], 0, unionOp, i);
+			composite->connectQuery(unionOp, currentQueries[0]);
+		}
+		else
+		{
+			for (auto currentQuery : currentQueries)
+				composite->connectQuery(previousQueries[0], currentQuery);
+		}
+		previousQueries = currentQueries;
+	}
+	// It might be that we have an operator at the end
+	if (parts.size() > operators.size() || operators.last() == '|')
+	{
+		for (int i = 0; i < previousQueries.size(); ++i)
+			composite->connectToOutput(previousQueries[i], i);
+	}
+	else if (operators.last() == 'U')
+	{
+		auto unionOp = new UnionOperator();
+		for (int i = 0; i < previousQueries.size(); ++i)
+			composite->connectQuery(previousQueries[i], 0, unionOp, i);
+		composite->connectToOutput(unionOp);
+	}
+	else // No other case allowed
+		Q_ASSERT(false); // TODO error for user
+	return composite;
+}
+
+QList<Query*> QueryBuilder::parseOperatorPart(const QString& text)
+{
+	auto type = typeOf(text);
+	if (Type::Query == type) return {parseQuery(text)};
+	else if (Type::List == type) return parseList(text);
+	Q_ASSERT(false);
+}
+
+} /* namespace InformationScripting  */

--- a/InformationScripting/src/parsing/QueryBuilder.cpp
+++ b/InformationScripting/src/parsing/QueryBuilder.cpp
@@ -136,9 +136,9 @@ Query* QueryBuilder::parseOperator(const QString& text, bool connectInput)
 {
 	// TODO it might be better to be able to register operators.
 	// But that need some additional information on how they are used, thus we currently hardcode the operators.
-	auto splitted = split(text, {'|', '-', 'U'});
-	auto parts = splitted.first;
-	auto operators = splitted.second;
+	auto splitText = split(text, {'|', '-', 'U'});
+	auto parts = splitText.first;
+	auto operators = splitText.second;
 	Q_ASSERT(parts.size()); // TODO error for user
 	CompositeQuery* composite = new CompositeQuery();
 	auto previousQueries = parseOperatorPart(parts[0]);

--- a/InformationScripting/src/parsing/QueryBuilder.h
+++ b/InformationScripting/src/parsing/QueryBuilder.h
@@ -1,0 +1,77 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../informationscripting_api.h"
+
+namespace Model {
+	class Node;
+}
+
+namespace InformationScripting {
+
+class CompositeQuery;
+class Query;
+
+class INFORMATIONSCRIPTING_API QueryBuilder
+{
+	public:
+		static QueryBuilder& instance();
+		/**
+		 * Parses the \a text in the following language:
+		 *
+		 * char			:= a-z
+		 * word			:= char [char|SPACE]+
+		 * query			:= "word"
+		 * queryOrList := query | list
+		 * op				:= | - U
+		 * operator		:= $queryOrList [op queryOrList]+$
+		 * queryOrOp	:= query | operator
+		 * list			:= {queryOrOp [, queryOrOp]+}
+		 */
+		Query* buildQueryFrom(const QString& text, Model::Node* target);
+
+		using QueryConstructor = std::function<Query* (Model::Node*, QStringList)>;
+
+		void registerQueryConstructor(const QString& command, QueryConstructor constructor);
+
+	private:
+		QueryBuilder();
+		enum class Type: int {Operator = 0, Query = 1, List = 2};
+		Type typeOf(const QString& text);
+		QPair<QStringList, QList<QChar> > split(const QString& text, const QList<QChar>& splitChars);
+
+		Query* parseQuery(const QString& text);
+		QList<Query*> parseList(const QString& text);
+		Query* parseOperator(const QString& text, bool connectInput = false);
+		QList<Query*> parseOperatorPart(const QString& text);
+
+		QHash<QString, QueryConstructor> constructors_;
+		Model::Node* target_{};
+};
+
+} /* namespace InformationScripting  */

--- a/InformationScripting/src/queries/AstNameFilter.cpp
+++ b/InformationScripting/src/queries/AstNameFilter.cpp
@@ -29,6 +29,8 @@
 #include "ModelBase/src/nodes/composite/CompositeNode.h"
 #include "ModelBase/src/nodes/Text.h"
 
+#include "QueryRegistry.h"
+
 namespace InformationScripting {
 
 AstNameFilter::AstNameFilter(Model::SymbolMatcher matcher)
@@ -49,7 +51,21 @@ AstNameFilter::AstNameFilter(Model::SymbolMatcher matcher)
 			}
 			return false;
 		}
-	}
+}
 {}
+
+void AstNameFilter::registerDefaultQueries()
+{
+	QueryRegistry::instance().registerQueryConstructor("filter", [](Model::Node*, QStringList args) {
+		Q_ASSERT(args.size());
+		if (args[0].contains("*"))
+		{
+			QString regexString = args[0];
+			regexString.replace("*", "\\w*");
+			return new AstNameFilter(Model::SymbolMatcher(new QRegExp(regexString)));
+		}
+		return new AstNameFilter(Model::SymbolMatcher(args[0]));
+	});
+}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstNameFilter.h
+++ b/InformationScripting/src/queries/AstNameFilter.h
@@ -38,6 +38,8 @@ class INFORMATIONSCRIPTING_API AstNameFilter : public GenericFilter
 {
 	public:
 		AstNameFilter(Model::SymbolMatcher matcher);
+
+		static void registerDefaultQueries();
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -30,6 +30,7 @@
 #include "OOModel/src/declarations/Project.h"
 
 #include "../visitors/AllNodesOfType.h"
+#include "QueryRegistry.h"
 
 namespace InformationScripting {
 
@@ -68,6 +69,26 @@ QList<TupleSet> AstQuery::execute(QList<TupleSet> input)
 	}
 
 	return result;
+}
+
+void AstQuery::registerDefaultQueries()
+{
+	auto& registry = QueryRegistry::instance();
+	registry.registerQueryConstructor("classes", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::Classes, target, args);
+	});
+	registry.registerQueryConstructor("methods", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::Methods, target, args);
+	});
+	registry.registerQueryConstructor("bases", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::BaseClasses, target, args);
+	});
+	registry.registerQueryConstructor("toClass", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::ToClass, target, args);
+	});
+	registry.registerQueryConstructor("callgraph", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::CallGraph, target, args);
+	});
 }
 
 TupleSet AstQuery::classesQuery(QList<TupleSet>)

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -51,6 +51,8 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 
 		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
 
+		static void registerDefaultQueries();
+
 	private:
 		Model::Node* target_{};
 		Scope scope_{};

--- a/InformationScripting/src/queries/NodePropertyAdder.cpp
+++ b/InformationScripting/src/queries/NodePropertyAdder.cpp
@@ -28,19 +28,18 @@
 
 namespace InformationScripting {
 
-NodePropertyAdder::NodePropertyAdder(const QString& propertyName, Property value, TupleSet::TupleCondition condition)
- : condition_{condition}, name_{propertyName}, value_{value}
+NodePropertyAdder::NodePropertyAdder(const QString& propertyName, Property value)
+ : name_{propertyName}, value_{value}
 {}
 
 QList<TupleSet> NodePropertyAdder::execute(QList<TupleSet> input)
 {
-	for (auto& g : input)
+	for (auto& ts : input)
 	{
-		for (auto node : g.tuples(condition_))
+		for (auto node : ts.takeAll())
 		{
-			g.remove(node);
 			node.add({name_, value_});
-			g.add(node);
+			ts.add(node);
 		}
 	}
 	return input;

--- a/InformationScripting/src/queries/NodePropertyAdder.cpp
+++ b/InformationScripting/src/queries/NodePropertyAdder.cpp
@@ -38,6 +38,7 @@ QList<TupleSet> NodePropertyAdder::execute(QList<TupleSet> input)
 	{
 		for (auto node : g.tuples(condition_))
 		{
+			g.remove(node);
 			node.add({name_, value_});
 			g.add(node);
 		}

--- a/InformationScripting/src/queries/NodePropertyAdder.h
+++ b/InformationScripting/src/queries/NodePropertyAdder.h
@@ -35,11 +35,10 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API NodePropertyAdder : public Query
 {
 	public:
-		NodePropertyAdder(const QString& propertyName, Property value, TupleSet::TupleCondition condition = nullptr);
+		NodePropertyAdder(const QString& propertyName, Property value);
 		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
 
 	private:
-		TupleSet::TupleCondition condition_{};
 		QString name_;
 		Property value_{};
 };

--- a/InformationScripting/src/queries/QueryRegistry.cpp
+++ b/InformationScripting/src/queries/QueryRegistry.cpp
@@ -26,8 +26,6 @@
 
 #include "QueryRegistry.h"
 
-#include "../queries/AstQuery.h"
-#include "../queries/AstNameFilter.h"
 #include "../queries/NodePropertyAdder.h"
 #include "../queries/ScriptQuery.h"
 
@@ -52,44 +50,6 @@ Query* QueryRegistry::buildQuery(const QString& command, Model::Node* target, QS
 	if (auto script = tryBuildQueryFromScript(command, args))
 		return script;
 	return nullptr;
-}
-
-QueryRegistry::QueryRegistry()
-{
-	registerDefaultQueries();
-}
-
-void QueryRegistry::registerDefaultQueries()
-{
-	registerQueryConstructor("classes", [](Model::Node* target, QStringList args) {
-		return new AstQuery(AstQuery::QueryType::Classes, target, args);
-	});
-	registerQueryConstructor("methods", [](Model::Node* target, QStringList args) {
-		return new AstQuery(AstQuery::QueryType::Methods, target, args);
-	});
-	registerQueryConstructor("bases", [](Model::Node* target, QStringList args) {
-		return new AstQuery(AstQuery::QueryType::BaseClasses, target, args);
-	});
-	registerQueryConstructor("toClass", [](Model::Node* target, QStringList args) {
-		return new AstQuery(AstQuery::QueryType::ToClass, target, args);
-	});
-	registerQueryConstructor("callgraph", [](Model::Node* target, QStringList args) {
-		return new AstQuery(AstQuery::QueryType::CallGraph, target, args);
-	});
-	registerQueryConstructor("filter", [](Model::Node*, QStringList args) {
-		Q_ASSERT(args.size());
-		if (args[0].contains("*"))
-		{
-			QString regexString = args[0];
-			regexString.replace("*", "\\w*");
-			return new AstNameFilter(Model::SymbolMatcher(new QRegExp(regexString)));
-		}
-		return new AstNameFilter(Model::SymbolMatcher(args[0]));
-	});
-	registerQueryConstructor("script", [](Model::Node*, QStringList args) {
-		QString scriptName = args.takeFirst();
-		return new ScriptQuery(QString("../InformationScripting/test/scripts/%1.py").arg(scriptName), args);
-	});
 }
 
 Query* QueryRegistry::tryBuildQueryFromScript(const QString& name, QStringList args)

--- a/InformationScripting/src/queries/QueryRegistry.cpp
+++ b/InformationScripting/src/queries/QueryRegistry.cpp
@@ -62,35 +62,35 @@ QueryRegistry::QueryRegistry()
 
 void QueryRegistry::registerDefaultQueries()
 {
-		registerQueryConstructor("classes", [](Model::Node* target, QStringList args) {
-			return new AstQuery(AstQuery::QueryType::Classes, target, args);
-		});
-		registerQueryConstructor("methods", [](Model::Node* target, QStringList args) {
-			return new AstQuery(AstQuery::QueryType::Methods, target, args);
-		});
-		registerQueryConstructor("bases", [](Model::Node* target, QStringList args) {
-			return new AstQuery(AstQuery::QueryType::BaseClasses, target, args);
-		});
-		registerQueryConstructor("toClass", [](Model::Node* target, QStringList args) {
-			return new AstQuery(AstQuery::QueryType::ToClass, target, args);
-		});
-		registerQueryConstructor("callgraph", [](Model::Node* target, QStringList args) {
-			return new AstQuery(AstQuery::QueryType::CallGraph, target, args);
-		});
-		registerQueryConstructor("filter", [](Model::Node*, QStringList args) {
-			Q_ASSERT(args.size());
-			if (args[0].contains("*"))
-			{
-				QString regexString = args[0];
-				regexString.replace("*", "\\w*");
-				return new AstNameFilter(Model::SymbolMatcher(new QRegExp(regexString)));
-			}
-			return new AstNameFilter(Model::SymbolMatcher(args[0]));
-		});
-		registerQueryConstructor("script", [](Model::Node*, QStringList args) {
-			QString scriptName = args.takeFirst();
-			return new ScriptQuery(QString("../InformationScripting/test/scripts/%1.py").arg(scriptName), args);
-		});
+	registerQueryConstructor("classes", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::Classes, target, args);
+	});
+	registerQueryConstructor("methods", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::Methods, target, args);
+	});
+	registerQueryConstructor("bases", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::BaseClasses, target, args);
+	});
+	registerQueryConstructor("toClass", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::ToClass, target, args);
+	});
+	registerQueryConstructor("callgraph", [](Model::Node* target, QStringList args) {
+		return new AstQuery(AstQuery::QueryType::CallGraph, target, args);
+	});
+	registerQueryConstructor("filter", [](Model::Node*, QStringList args) {
+		Q_ASSERT(args.size());
+		if (args[0].contains("*"))
+		{
+			QString regexString = args[0];
+			regexString.replace("*", "\\w*");
+			return new AstNameFilter(Model::SymbolMatcher(new QRegExp(regexString)));
+		}
+		return new AstNameFilter(Model::SymbolMatcher(args[0]));
+	});
+	registerQueryConstructor("script", [](Model::Node*, QStringList args) {
+		QString scriptName = args.takeFirst();
+		return new ScriptQuery(QString("../InformationScripting/test/scripts/%1.py").arg(scriptName), args);
+	});
 }
 
 void QueryRegistry::registerDefaultScriptLocations()

--- a/InformationScripting/src/queries/QueryRegistry.cpp
+++ b/InformationScripting/src/queries/QueryRegistry.cpp
@@ -57,7 +57,6 @@ Query* QueryRegistry::buildQuery(const QString& command, Model::Node* target, QS
 QueryRegistry::QueryRegistry()
 {
 	registerDefaultQueries();
-	registerDefaultScriptLocations();
 }
 
 void QueryRegistry::registerDefaultQueries()
@@ -93,19 +92,11 @@ void QueryRegistry::registerDefaultQueries()
 	});
 }
 
-void QueryRegistry::registerDefaultScriptLocations()
-{
-	scriptLocations_ << "../InformationScripting/test/scripts/";
-}
-
 Query* QueryRegistry::tryBuildQueryFromScript(const QString& name, QStringList args)
 {
-	for (const auto& scriptLocation : scriptLocations_)
-	{
-		QString scriptName{scriptLocation + name + ".py"};
-		if (QFile::exists(scriptName))
-			return new ScriptQuery(scriptName, args);
-	}
+	QString scriptName{scriptLocation_ + name + ".py"};
+	if (QFile::exists(scriptName))
+		return new ScriptQuery(scriptName, args);
 	return nullptr;
 }
 

--- a/InformationScripting/src/queries/QueryRegistry.cpp
+++ b/InformationScripting/src/queries/QueryRegistry.cpp
@@ -1,0 +1,112 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "QueryRegistry.h"
+
+#include "../queries/AstQuery.h"
+#include "../queries/AstNameFilter.h"
+#include "../queries/NodePropertyAdder.h"
+#include "../queries/ScriptQuery.h"
+
+namespace InformationScripting {
+
+QueryRegistry& QueryRegistry::instance()
+{
+	static QueryRegistry instance;
+	return instance;
+}
+
+Query* QueryRegistry::buildQuery(const QString& command, Model::Node* target, QStringList args)
+{
+	if (auto constructor = constructors_[command])
+		return constructor(target, args);
+	if (args.size() > 1 && args[0] == "=")
+	{
+		// TODO we need some way to specify a condition on the node.
+		// Or eventually decide that we don't allow condition in the property adder
+		return new NodePropertyAdder(command, args[1]);
+	}
+	if (auto script = tryBuildQueryFromScript(command, args))
+		return script;
+	return nullptr;
+}
+
+QueryRegistry::QueryRegistry()
+{
+	registerDefaultQueries();
+	registerDefaultScriptLocations();
+}
+
+void QueryRegistry::registerDefaultQueries()
+{
+		registerQueryConstructor("classes", [](Model::Node* target, QStringList args) {
+			return new AstQuery(AstQuery::QueryType::Classes, target, args);
+		});
+		registerQueryConstructor("methods", [](Model::Node* target, QStringList args) {
+			return new AstQuery(AstQuery::QueryType::Methods, target, args);
+		});
+		registerQueryConstructor("bases", [](Model::Node* target, QStringList args) {
+			return new AstQuery(AstQuery::QueryType::BaseClasses, target, args);
+		});
+		registerQueryConstructor("toClass", [](Model::Node* target, QStringList args) {
+			return new AstQuery(AstQuery::QueryType::ToClass, target, args);
+		});
+		registerQueryConstructor("callgraph", [](Model::Node* target, QStringList args) {
+			return new AstQuery(AstQuery::QueryType::CallGraph, target, args);
+		});
+		registerQueryConstructor("filter", [](Model::Node*, QStringList args) {
+			Q_ASSERT(args.size());
+			if (args[0].contains("*"))
+			{
+				QString regexString = args[0];
+				regexString.replace("*", "\\w*");
+				return new AstNameFilter(Model::SymbolMatcher(new QRegExp(regexString)));
+			}
+			return new AstNameFilter(Model::SymbolMatcher(args[0]));
+		});
+		registerQueryConstructor("script", [](Model::Node*, QStringList args) {
+			QString scriptName = args.takeFirst();
+			return new ScriptQuery(QString("../InformationScripting/test/scripts/%1.py").arg(scriptName), args);
+		});
+}
+
+void QueryRegistry::registerDefaultScriptLocations()
+{
+	scriptLocations_ << "../InformationScripting/test/scripts/";
+}
+
+Query* QueryRegistry::tryBuildQueryFromScript(const QString& name, QStringList args)
+{
+	for (const auto& scriptLocation : scriptLocations_)
+	{
+		QString scriptName{scriptLocation + name + ".py"};
+		if (QFile::exists(scriptName))
+			return new ScriptQuery(scriptName, args);
+	}
+	return nullptr;
+}
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/QueryRegistry.h
+++ b/InformationScripting/src/queries/QueryRegistry.h
@@ -47,9 +47,7 @@ class INFORMATIONSCRIPTING_API QueryRegistry
 		Query* buildQuery(const QString& command, Model::Node* target, QStringList args);
 
 	private:
-		QueryRegistry();
-
-		void registerDefaultQueries();
+		QueryRegistry() = default;
 
 		Query* tryBuildQueryFromScript(const QString& name, QStringList args);
 

--- a/InformationScripting/src/queries/QueryRegistry.h
+++ b/InformationScripting/src/queries/QueryRegistry.h
@@ -50,12 +50,11 @@ class INFORMATIONSCRIPTING_API QueryRegistry
 		QueryRegistry();
 
 		void registerDefaultQueries();
-		void registerDefaultScriptLocations();
 
 		Query* tryBuildQueryFromScript(const QString& name, QStringList args);
 
 		QHash<QString, QueryConstructor> constructors_;
-		QStringList scriptLocations_;
+		QString scriptLocation_{"scripts/"};
 };
 
 inline void QueryRegistry::registerQueryConstructor(const QString& command, QueryRegistry::QueryConstructor constructor)

--- a/InformationScripting/src/queries/QueryRegistry.h
+++ b/InformationScripting/src/queries/QueryRegistry.h
@@ -44,8 +44,6 @@ class INFORMATIONSCRIPTING_API QueryRegistry
 		using QueryConstructor = std::function<Query* (Model::Node*, QStringList)>;
 		void registerQueryConstructor(const QString& command, QueryConstructor constructor);
 
-		void registerScriptLocation(const QString& path);
-
 		Query* buildQuery(const QString& command, Model::Node* target, QStringList args);
 
 	private:

--- a/InformationScripting/src/queries/ScriptQuery.cpp
+++ b/InformationScripting/src/queries/ScriptQuery.cpp
@@ -32,8 +32,8 @@
 
 namespace InformationScripting {
 
-ScriptQuery::ScriptQuery(const QString& scriptPath)
-	: scriptPath_{scriptPath}
+ScriptQuery::ScriptQuery(const QString& scriptPath, const QStringList& args)
+	: scriptPath_{scriptPath}, arguments_{args}
 {}
 
 void ScriptQuery::initPythonEnvironment()
@@ -63,6 +63,7 @@ QList<TupleSet> ScriptQuery::execute(QList<TupleSet> input)
 		python::object sys = python::import("sys");
 
 		main_namespace["inputs"] = input;
+		main_namespace["args"] = arguments_;
 
 		exec_file(scriptPath_.toLatin1().data(), main_namespace, main_namespace);
 		// Workaround to get output

--- a/InformationScripting/src/queries/ScriptQuery.h
+++ b/InformationScripting/src/queries/ScriptQuery.h
@@ -35,7 +35,7 @@ namespace InformationScripting {
 class ScriptQuery : public Query
 {
 	public:
-		ScriptQuery(const QString& scriptPath);
+		ScriptQuery(const QString& scriptPath, const QStringList& args = {});
 
 		static void initPythonEnvironment();
 		static void unloadPythonEnvironment();
@@ -44,6 +44,8 @@ class ScriptQuery : public Query
 
 	private:
 		QString scriptPath_;
+		// Note since we only register QList<T> to python we don't use QStringList here:
+		QList<QString> arguments_;
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/SubstractNodesOperator.cpp
+++ b/InformationScripting/src/queries/SubstractNodesOperator.cpp
@@ -36,7 +36,7 @@ QList<TupleSet> SubstractNodesOperator::execute(QList<TupleSet> input)
 	auto setA = input[0];
 	auto setB = input[1];
 	// TODO: this is not the correct place to do this. But where is it??
-	setB.addAllPropertiesTo<Model::Node*>("ast");
+	setB.addPropertiesAsTuples<Model::Node*>("ast");
 	setA.remove(setB);
 	return {setA};
 }

--- a/InformationScripting/src/queries/SubstractNodesOperator.cpp
+++ b/InformationScripting/src/queries/SubstractNodesOperator.cpp
@@ -26,6 +26,8 @@
 
 #include "SubstractNodesOperator.h"
 
+#include "ModelBase/src/nodes/Node.h"
+
 namespace InformationScripting {
 
 QList<TupleSet> SubstractNodesOperator::execute(QList<TupleSet> input)
@@ -33,6 +35,8 @@ QList<TupleSet> SubstractNodesOperator::execute(QList<TupleSet> input)
 	Q_ASSERT(input.size() == 2);
 	auto setA = input[0];
 	auto setB = input[1];
+	// TODO: this is not the correct place to do this. But where is it??
+	setB.addAllPropertiesTo<Model::Node*>("ast");
 	setA.remove(setB);
 	return {setA};
 }

--- a/InformationScripting/src/queries/SubstractOperator.cpp
+++ b/InformationScripting/src/queries/SubstractOperator.cpp
@@ -24,18 +24,18 @@
 **
 ***********************************************************************************************************************/
 
-#pragma once
+#include "SubstractOperator.h"
 
-#include "../informationscripting_api.h"
-
-#include "Query.h"
+#include "ModelBase/src/nodes/Node.h"
 
 namespace InformationScripting {
 
-class INFORMATIONSCRIPTING_API SubstractNodesOperator : public Query
+QList<TupleSet> SubstractOperator::execute(QList<TupleSet> input)
 {
-	public:
-		virtual QList<TupleSet> execute(QList<TupleSet> input);
-};
+	Q_ASSERT(input.size() == 2);
+	auto setA = input[0];
+	setA.remove(input[1]);
+	return {setA};
+}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/SubstractOperator.h
+++ b/InformationScripting/src/queries/SubstractOperator.h
@@ -24,21 +24,18 @@
 **
 ***********************************************************************************************************************/
 
-#include "SubstractNodesOperator.h"
+#pragma once
 
-#include "ModelBase/src/nodes/Node.h"
+#include "../informationscripting_api.h"
+
+#include "Query.h"
 
 namespace InformationScripting {
 
-QList<TupleSet> SubstractNodesOperator::execute(QList<TupleSet> input)
+class INFORMATIONSCRIPTING_API SubstractOperator : public Query
 {
-	Q_ASSERT(input.size() == 2);
-	auto setA = input[0];
-	auto setB = input[1];
-	// TODO: this is not the correct place to do this. But where is it??
-	setB.addPropertiesAsTuples<Model::Node*>("ast");
-	setA.remove(setB);
-	return {setA};
-}
+	public:
+		virtual QList<TupleSet> execute(QList<TupleSet> input);
+};
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/wrappers/DataApi.cpp
+++ b/InformationScripting/src/wrappers/DataApi.cpp
@@ -38,17 +38,21 @@ object value(const NamedProperty& self) {
 }
 
 BOOST_PYTHON_MODULE(DataApi) {
-		class_<NamedProperty>("NamedProperty")
+		class_<NamedProperty>("NamedProperty", init<QString, QString>())
 				.def_readwrite("name", &NamedProperty::first)
 				.add_property("value", &value);
 
-		class_<Tuple>("Tuple");
+		class_<Tuple>("Tuple")
+				.def("add", &Tuple::add);
 
 
 		QSet<Tuple> (TupleSet::*tuples1)(const QString&) const = &TupleSet::tuples;
+		void (TupleSet::*removeTuple)(const Tuple&) = &TupleSet::remove;
 
 		class_<TupleSet>("TupleSet")
-				.def("tuples", tuples1);
+				.def("tuples", tuples1)
+				.def("remove", removeTuple)
+				.def("add", &TupleSet::add);
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/wrappers/DataApi.cpp
+++ b/InformationScripting/src/wrappers/DataApi.cpp
@@ -37,20 +37,27 @@ object value(const NamedProperty& self) {
 	return pythonObject(self.second);
 }
 
+object Tuple_getAttr(const Tuple& self, const QString& name) {
+	return pythonObject(self[name]);
+}
+
 BOOST_PYTHON_MODULE(DataApi) {
 		class_<NamedProperty>("NamedProperty", init<QString, QString>())
 				.def_readwrite("name", &NamedProperty::first)
 				.add_property("value", &value);
 
 		class_<Tuple>("Tuple")
-				.def("add", &Tuple::add);
-
+				.def("tag", &Tuple::tag)
+				.def("add", &Tuple::add)
+				.def("__getattr__", &Tuple_getAttr);
 
 		QSet<Tuple> (TupleSet::*tuples1)(const QString&) const = &TupleSet::tuples;
+		QSet<Tuple> (TupleSet::*take1)(const QString&) = &TupleSet::take;
 		void (TupleSet::*removeTuple)(const Tuple&) = &TupleSet::remove;
 
 		class_<TupleSet>("TupleSet")
 				.def("tuples", tuples1)
+				.def("take", take1)
 				.def("remove", removeTuple)
 				.def("add", &TupleSet::add);
 }

--- a/InformationScripting/test/scripts/color.py
+++ b/InformationScripting/test/scripts/color.py
@@ -1,0 +1,15 @@
+results = [];
+
+from DataApi import *
+
+color = "red"
+if (len(args)):
+    color = args[0]
+
+for ts in inputs:
+    tuples = ts.tuples("ast")
+    for tuple in tuples:
+        ts.remove(tuple)
+        tuple.add(NamedProperty("color", color))
+        ts.add(tuple)
+    results.append(ts)

--- a/InformationScripting/test/scripts/color.py
+++ b/InformationScripting/test/scripts/color.py
@@ -7,9 +7,8 @@ if (len(args)):
     color = args[0]
 
 for ts in inputs:
-    tuples = ts.tuples("ast")
+    tuples = ts.take("ast")
     for tuple in tuples:
-        ts.remove(tuple)
         tuple.add(NamedProperty("color", color))
         ts.add(tuple)
     results.append(ts)

--- a/InformationScripting/test/scripts/test.py
+++ b/InformationScripting/test/scripts/test.py
@@ -5,7 +5,6 @@ import AstApi
 for ts in inputs:
     tuples = ts.tuples("ast")
     for tuple in tuples:
-        asts = tuple.getAll("ast");
-        if type(asts[0].value) is AstApi.Class:
-            print(asts[0].value.constructKind)
+        if type(tuple.ast) is AstApi.Class:
+            print(tuple.ast.constructKind)
     results.append(ts)

--- a/InformationScripting/test/scripts/test.py
+++ b/InformationScripting/test/scripts/test.py
@@ -1,9 +1,11 @@
 results = [];
 
+import AstApi
 
 for ts in inputs:
     tuples = ts.tuples("ast")
     for tuple in tuples:
         asts = tuple.getAll("ast");
-        print(asts[0].value.constructKind)
+        if type(asts[0].value) is AstApi.Class:
+            print(asts[0].value.constructKind)
     results.append(ts)


### PR DESCRIPTION
Some more commits, so that you will not get bored next week :)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38788697%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38789367%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38790190%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38790438%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38790550%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38790644%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38790746%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38791172%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38792935%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38793164%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r39378490%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r39380331%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r39383850%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r39383876%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r39384124%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20778b5e60e4dc3272a27fe47294199c531969399b%20InformationScripting/src/queries/QueryRegistry.h%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38790644%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20have%20an%20idea%2C%20but%20I%27d%20like%20to%20hear%20from%20you%2C%20how%20exactly%20you%20imagine%20we%27ll%20use%20this%20registry.%22%2C%20%22created_at%22%3A%20%222015-09-04T20%3A25%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20it%20is%20used%20to%20get%20all%20known%20queries%20in%20the%20system.%20Or%20what%20do%20you%20mean%20how%20we%20will%20use%20it%3F%22%2C%20%22created_at%22%3A%20%222015-09-04T20%3A52%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/QueryRegistry.h%3AL1-70%22%7D%2C%20%22Pull%20778b5e60e4dc3272a27fe47294199c531969399b%20InformationScripting/src/queries/SubstractNodesOperator.cpp%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38791172%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20I%27m%20not%20entirely%20convinced%20what%27s%20the%20correct%20operation%20of%20the%20subtract%20operator.%20Strictly%20speaking%2C%20you%20shouldn%27t%20extend%20the%20B%20set%20before%20subtracting%20it%20from%20A.%20But%20on%20the%20other%20hand%2C%20it%20might%20be%20useful%2C%20in%20which%20case%20doing%20it%20here%20seems%20OK%2C%20why%20is%20it%20not%20OK%3F%20Maybe%20it%20should%20be%20an%20option.%20I%20can%20also%20imagine%20that%20there%20might%20be%20a%20more%20complex%20conditions%20that%20determines%20whether%20we%20should%20subtract%20something.%22%2C%20%22created_at%22%3A%20%222015-09-04T20%3A31%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/SubstractNodesOperator.cpp%3AL35-43%22%7D%2C%20%22Pull%20778b5e60e4dc3272a27fe47294199c531969399b%20InformationScripting/src/dataformat/TupleSet.h%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38789367%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20quite%20happy%20with%20the%20name%20of%20this%20method.%20Let%27s%20call%20it%20something%20more%20descriptive%2C%20such%20as%20%60addPropertiesAsTuples%60%20or%20some%20other%20better%20name.%22%2C%20%22created_at%22%3A%20%222015-09-04T20%3A08%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/dataformat/TupleSet.h%3AL55-67%22%7D%2C%20%22Pull%20888787134efffdbbabcc4c21dd0cc7479cb578d3%20InformationScripting/src/parsing/QueryBuilder.cpp%20139%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r39383850%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20past%20tense%20of%20split%20is%20split.%22%2C%20%22created_at%22%3A%20%222015-09-14T11%3A33%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/parsing/QueryBuilder.cpp%3AL1-210%22%7D%2C%20%22Pull%20778b5e60e4dc3272a27fe47294199c531969399b%20InformationScripting/src/parsing/QueryBuilder.cpp%20207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38790190%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22OK%2C%20I%27m%20not%20even%20going%20to%20pretend%20that%20I%20really%20tried%20to%20understand%20the%20parser.%20I%20looked%20at%20the%20code%20briefly%20and%20kept%20thinking%3A%20why%20is%20this%20so%20complicated%3F%20I%20must%20be%20missing%20something%20major%2C%20because%20I%20thought%20that%20our%20command%20expressions%20are%20so%20simple%2C%20we%20can%20literally%20use%20a%20few%20regular%20expressions%20to%20implement%20the%20parser.%20What%20are%20you%20thoughts%20on%20this%2C%20do%20we%20really%20need%20all%20the%20complex%20stuff%20above%3F%20If%20so%2C%20could%20you%20try%20to%20elaborate%20why%20that%20is%3F%22%2C%20%22created_at%22%3A%20%222015-09-04T20%3A19%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20have%20you%20looked%20at%20the%20grammar%20it%20should%20be%20able%20to%20parse%20in%20the%20header%20file%3F%20And%20after%20looking%20at%20it%20are%20you%20still%20sure%20we%20can%20solve%20it%20with%20regular%20expressions%3F%20If%20so%20I%20will%20be%20happy%20to%20redo%20it%20with%20regexes.%22%2C%20%22created_at%22%3A%20%222015-09-04T20%3A55%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20I%20think%20we%20should%20leave%20the%20current%20version%2C%20after%20our%20discussion.%22%2C%20%22created_at%22%3A%20%222015-09-14T11%3A33%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/parsing/QueryBuilder.cpp%3AL1-210%22%7D%2C%20%22Pull%20888787134efffdbbabcc4c21dd0cc7479cb578d3%20InformationScripting/src/queries/QueryRegistry.cpp%2063%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r39384124%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Move%20this%20to%20some%20AST%20source%20specific%20place.%22%2C%20%22created_at%22%3A%20%222015-09-14T11%3A37%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/QueryRegistry.cpp%3AL1-113%22%7D%2C%20%22Pull%20778b5e60e4dc3272a27fe47294199c531969399b%20InformationScripting/src/queries/QueryRegistry.cpp%2098%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38790550%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Preferably%2C%20just%20register%20%60%5C%22scripts%5C%22%60%20which%20will%20be%20a%20directory%20in%20DebugBuild.%20Then%20modify%20the%20.pro%20file%20to%20copy%20your%20scripts%20from%20the%20test%20directory%20to%20DebugBuild.%22%2C%20%22created_at%22%3A%20%222015-09-04T20%3A24%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20I%20can%20do%20that%2C%20but%20then%20it%20gets%20more%20tedious%20to%20edit%20the%20scripts.%20%28you%20have%20to%20move%20manually%20or%20rebuild%29%22%2C%20%22created_at%22%3A%20%222015-09-14T10%3A10%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20agree%20that%20things%20might%20require%20an%20extra%20step%2C%20but%20it%27s%20the%20correct%20thing%20to%20do.%20Imagine%20a%20release%2C%20binary-only%20distribution%20of%20Envision.%20Then%20there%20should%20be%20a%20directory%20outside%20of%20the%20source%20code%20that%20has%20the%20scripts.%5Cr%5Cn%5Cr%5CnTo%20ease%20debugging%2C%20you%20might%20on%20occasion%20directly%20modify%20the%20script%20in%20DebugBuild%20and%20once%20you%27re%20happy%20with%20it%2C%20just%20copy%20it%20back%20to%20the%20source%20directory.%22%2C%20%22created_at%22%3A%20%222015-09-14T10%3A38%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/QueryRegistry.cpp%3AL1-113%22%7D%2C%20%22Pull%20778b5e60e4dc3272a27fe47294199c531969399b%20InformationScripting/src/commands/CScript.cpp%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38788697%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Don%27t%20be%20lazy%2C%20add%20the%20%60%3E%200%60%20to%20make%20it%20easier%20to%20read.%22%2C%20%22created_at%22%3A%20%222015-09-04T19%3A58%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/commands/CScript.cpp%3AL67-204%22%7D%2C%20%22Pull%20778b5e60e4dc3272a27fe47294199c531969399b%20InformationScripting/src/queries/QueryRegistry.h%2047%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38790746%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20have%20declared%2C%20but%20not%20defined%20this%20method.%22%2C%20%22created_at%22%3A%20%222015-09-04T20%3A26%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/QueryRegistry.h%3AL1-70%22%7D%2C%20%22Pull%20778b5e60e4dc3272a27fe47294199c531969399b%20InformationScripting/src/queries/QueryRegistry.cpp%2065%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/143%23discussion_r38790438%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20is%20there%20double%20indentation%20here%3F%22%2C%20%22created_at%22%3A%20%222015-09-04T20%3A22%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/QueryRegistry.cpp%3AL1-113%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 778b5e60e4dc3272a27fe47294199c531969399b InformationScripting/src/commands/CScript.cpp 29'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/143#discussion_r38788697'>File: InformationScripting/src/commands/CScript.cpp:L67-204</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Don't be lazy, add the `> 0` to make it easier to read.
- [x] <a href='#crh-comment-Pull 778b5e60e4dc3272a27fe47294199c531969399b InformationScripting/src/dataformat/TupleSet.h 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/143#discussion_r38789367'>File: InformationScripting/src/dataformat/TupleSet.h:L55-67</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I'm not quite happy with the name of this method. Let's call it something more descriptive, such as `addPropertiesAsTuples` or some other better name.
- [x] <a href='#crh-comment-Pull 778b5e60e4dc3272a27fe47294199c531969399b InformationScripting/src/parsing/QueryBuilder.cpp 207'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/143#discussion_r38790190'>File: InformationScripting/src/parsing/QueryBuilder.cpp:L1-210</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> OK, I'm not even going to pretend that I really tried to understand the parser. I looked at the code briefly and kept thinking: why is this so complicated? I must be missing something major, because I thought that our command expressions are so simple, we can literally use a few regular expressions to implement the parser. What are you thoughts on this, do we really need all the complex stuff above? If so, could you try to elaborate why that is?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Hm have you looked at the grammar it should be able to parse in the header file? And after looking at it are you still sure we can solve it with regular expressions? If so I will be happy to redo it with regexes.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Ok, I think we should leave the current version, after our discussion.
- [x] <a href='#crh-comment-Pull 778b5e60e4dc3272a27fe47294199c531969399b InformationScripting/src/queries/QueryRegistry.cpp 65'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/143#discussion_r38790438'>File: InformationScripting/src/queries/QueryRegistry.cpp:L1-113</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why is there double indentation here?
- [x] <a href='#crh-comment-Pull 778b5e60e4dc3272a27fe47294199c531969399b InformationScripting/src/queries/QueryRegistry.cpp 98'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/143#discussion_r38790550'>File: InformationScripting/src/queries/QueryRegistry.cpp:L1-113</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Preferably, just register `"scripts"` which will be a directory in DebugBuild. Then modify the .pro file to copy your scripts from the test directory to DebugBuild.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Hm I can do that, but then it gets more tedious to edit the scripts. (you have to move manually or rebuild)
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I agree that things might require an extra step, but it's the correct thing to do. Imagine a release, binary-only distribution of Envision. Then there should be a directory outside of the source code that has the scripts.
  To ease debugging, you might on occasion directly modify the script in DebugBuild and once you're happy with it, just copy it back to the source directory.
- [x] <a href='#crh-comment-Pull 778b5e60e4dc3272a27fe47294199c531969399b InformationScripting/src/queries/QueryRegistry.h 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/143#discussion_r38790644'>File: InformationScripting/src/queries/QueryRegistry.h:L1-70</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I have an idea, but I'd like to hear from you, how exactly you imagine we'll use this registry.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Well it is used to get all known queries in the system. Or what do you mean how we will use it?
- [x] <a href='#crh-comment-Pull 778b5e60e4dc3272a27fe47294199c531969399b InformationScripting/src/queries/QueryRegistry.h 47'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/143#discussion_r38790746'>File: InformationScripting/src/queries/QueryRegistry.h:L1-70</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You have declared, but not defined this method.
- [x] <a href='#crh-comment-Pull 778b5e60e4dc3272a27fe47294199c531969399b InformationScripting/src/queries/SubstractNodesOperator.cpp 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/143#discussion_r38791172'>File: InformationScripting/src/queries/SubstractNodesOperator.cpp:L35-43</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, I'm not entirely convinced what's the correct operation of the subtract operator. Strictly speaking, you shouldn't extend the B set before subtracting it from A. But on the other hand, it might be useful, in which case doing it here seems OK, why is it not OK? Maybe it should be an option. I can also imagine that there might be a more complex conditions that determines whether we should subtract something.
- [x] <a href='#crh-comment-Pull 888787134efffdbbabcc4c21dd0cc7479cb578d3 InformationScripting/src/parsing/QueryBuilder.cpp 139'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/143#discussion_r39383850'>File: InformationScripting/src/parsing/QueryBuilder.cpp:L1-210</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> The past tense of split is split.
- [x] <a href='#crh-comment-Pull 888787134efffdbbabcc4c21dd0cc7479cb578d3 InformationScripting/src/queries/QueryRegistry.cpp 63'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/143#discussion_r39384124'>File: InformationScripting/src/queries/QueryRegistry.cpp:L1-113</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Move this to some AST source specific place.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/143?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/143?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/143'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
