### PR TITLE
Fix wrong Git Exception message

### DIFF
--- a/FilePersistence/src/version_control/GitRepository.cpp
+++ b/FilePersistence/src/version_control/GitRepository.cpp
@@ -1144,7 +1144,7 @@ void GitRepository::checkError(int errorCode)
 	if (errorCode < 0)
 	{
 		const git_error* lastError = giterr_last();
-		throw FilePersistenceException(QString("Error %1/%2: %3").arg(errorCode, lastError->klass)
+		throw FilePersistenceException(QString("Error %1/%2: %3").arg(errorCode).arg(lastError->klass)
 												 .arg(lastError->message));
 	}
 }


### PR DESCRIPTION
I fixed this wrongly last time arg(int,int) is not the same as
arg(int).arg(int)
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/147?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/147'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
