### PR TITLE
Ast query

### DIFF
--- a/InformationScripting/src/InformationScriptingPlugin.cpp
+++ b/InformationScripting/src/InformationScriptingPlugin.cpp
@@ -27,7 +27,7 @@
 #include "InformationScriptingPlugin.h"
 #include "SelfTest/src/SelfTestSuite.h"
 
-#include "OOInteraction/src/handlers/HStatementItemList.h"
+#include "InteractionBase/src/handlers/HSceneHandlerItem.h"
 #include "OOModel/src/declarations/Method.h"
 #include "OOModel/src/declarations/Class.h"
 
@@ -43,7 +43,7 @@ namespace InformationScripting {
 bool InformationScriptingPlugin::initialize(Core::EnvisionManager&)
 {
 	BoostPythonHelpers::initializeConverters();
-	OOInteraction::HStatementItemList::instance()->addCommand(new CScript());
+	Interaction::HSceneHandlerItem::instance()->addCommand(new CScript());
 	ScriptQuery::initPythonEnvironment();
 	AstQuery::registerDefaultQueries();
 	AstNameFilter::registerDefaultQueries();

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -48,18 +48,18 @@ namespace InformationScripting {
 
 CScript::CScript() : Command{"script"} {}
 
-bool CScript::canInterpret(Visualization::Item*, Visualization::Item*, const QStringList& commandTokens,
+bool CScript::canInterpret(Visualization::Item* source, Visualization::Item*, const QStringList& commandTokens,
 									const std::unique_ptr<Visualization::Cursor>&)
 {
-	return commandTokens.size() > 1 && commandTokens.first() == "script";
+	return commandTokens.size() > 1 && commandTokens.first() == "script" && source->findAncestorWithNode();
 }
 
-Interaction::CommandResult* CScript::execute(Visualization::Item*, Visualization::Item* target,
+Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visualization::Item*,
 															const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>&)
 {
 	using namespace boost;
 
-	auto node = target->node();
+	auto node = source->findAncestorWithNode()->node();
 	Q_ASSERT(node);
 
 	QStringList args = commandTokens.mid(1);

--- a/InformationScripting/src/dataformat/TupleSet.h
+++ b/InformationScripting/src/dataformat/TupleSet.h
@@ -89,8 +89,6 @@ inline QSet<Tuple> TupleSet::take(Condition condition)
 {
 	QSet<Tuple> result;
 
-	if (!condition) return result;
-
 	for (auto hashIt = tuples_.begin(); hashIt != tuples_.end(); ++hashIt)
 	{
 		auto& set = hashIt.value();

--- a/InformationScripting/src/precompiled.h
+++ b/InformationScripting/src/precompiled.h
@@ -44,6 +44,7 @@
 
 // Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
 // and will be included in their precompiled headers
+#include <QtCore/QCommandLineParser>
 
 
 #if defined(INFORMATIONSCRIPTING_LIBRARY)

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -123,30 +123,12 @@ void AstQuery::registerDefaultQueries()
 
 TupleSet AstQuery::classesQuery(QList<TupleSet> input)
 {
-	TupleSet tuples;
-	if (scope_ == Scope::Local)
-	{
-		auto parentProject = target_->firstAncestorOfType<OOModel::Project>();
-		for (auto childClass : *parentProject->classes())
-			tuples.add({{"ast", childClass}});
-	}
-	else
-		tuples = typeQuery(input, "Class");
-	return tuples;
+	return typeQuery(input, "Class");
 }
 
 TupleSet AstQuery::methodsQuery(QList<TupleSet> input)
 {
-	TupleSet tuples;
-	if (scope_ == Scope::Local)
-	{
-		auto parentClass = target_->firstAncestorOfType<OOModel::Class>();
-		for (auto method : *parentClass->methods())
-			tuples.add({{"ast", method}});
-	}
-	else
-		tuples = typeQuery(input, "Method");
-	return tuples;
+	return typeQuery(input, "Method");
 }
 
 TupleSet AstQuery::baseClassesQuery(QList<TupleSet>)
@@ -240,13 +222,9 @@ TupleSet AstQuery::typeQuery(QList<TupleSet> input, QString type)
 	Q_ASSERT(!type.isEmpty());
 
 	if (scope_ == Scope::Local)
-	{
-		// TODO how to get the correct ancestor?
-	}
+		addNodesOfType(tuples, type, target_);
 	else if (scope_ == Scope::Global)
-	{
 		addNodesOfType(tuples, type);
-	}
 	else if (scope_ == Scope::Input)
 	{
 		Q_ASSERT(input.size());

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -266,7 +266,7 @@ void AstQuery::addCallInformation(TupleSet& ts, OOModel::Method* method, QList<O
 
 void AstQuery::addNodesOfType(TupleSet& ts, const QString& typeName, Model::Node* from)
 {
-	if (!from) from = target_->manager()->root();
+	if (!from) from = target_->root();
 	auto allNodeOfType =  AllNodesOfType::allNodesOfType(from, typeName);
 	for (auto node : allNodeOfType)
 		ts.add({{"ast", node}});

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -44,7 +44,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API AstQuery : public Query
 {
 	public:
-		enum class QueryType : int {Classes, Methods, BaseClasses, ToClass, CallGraph};
+		enum class QueryType : int {Classes, Methods, BaseClasses, ToClass, CallGraph, Generic};
 		enum class Scope : int {Local, Global, Input};
 
 		AstQuery(QueryType type, Model::Node* target, QStringList args);
@@ -57,16 +57,19 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 		Model::Node* target_{};
 		Scope scope_{};
 		QueryType type_{};
+		QStringList args_{};
 
 		TupleSet classesQuery(QList<TupleSet> input);
 		TupleSet methodsQuery(QList<TupleSet> input);
 		TupleSet baseClassesQuery(QList<TupleSet> input);
 		TupleSet toClassNode(QList<TupleSet> input);
 		TupleSet callGraph(QList<TupleSet> input);
+		TupleSet genericQuery(QList<TupleSet> input);
+		TupleSet typeQuery(QList<TupleSet> input, QString type);
 
 		void addBaseEdgesFor(OOModel::Class* childClass, NamedProperty& classNode, TupleSet& ts);
 
-		void addGlobalNodesOfType(TupleSet& ts, const QString& typeName);
+		void addNodesOfType(TupleSet& ts, const QString& typeName, Model::Node* from = nullptr);
 
 		void addCallInformation(TupleSet& ts, OOModel::Method* method, QList<OOModel::Method*> callees);
 };

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -44,11 +44,6 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API AstQuery : public Query
 {
 	public:
-		enum class QueryType : int {Classes, Methods, BaseClasses, ToClass, CallGraph, Generic, GenericToParent};
-		enum class Scope : int {Local, Global, Input};
-
-		AstQuery(QueryType type, Model::Node* target, QStringList args);
-
 		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
 
 		static void registerDefaultQueries();
@@ -58,10 +53,17 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 		static const QStringList NODETYPE_ARGUMENT_NAMES;
 		static const QStringList NAME_ARGUMENT_NAMES;
 
+		enum class QueryType : int {BaseClasses, ToClass, CallGraph, Generic, GenericToParent};
+		enum class Scope : int {Local, Global, Input};
+
 		Model::Node* target_{};
 		Scope scope_{};
 		QueryType type_{};
 		QCommandLineParser argParser_;
+
+		AstQuery(QueryType type, Model::Node* target, QStringList args);
+
+		static void setTypeTo(QStringList& args, QString type);
 
 		TupleSet classesQuery(QList<TupleSet> input);
 		TupleSet methodsQuery(QList<TupleSet> input);

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -54,10 +54,14 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 		static void registerDefaultQueries();
 
 	private:
+		static const QStringList SCOPE_ARGUMENT_NAMES;
+		static const QStringList NODETYPE_ARGUMENT_NAMES;
+		static const QStringList NAME_ARGUMENT_NAMES;
+
 		Model::Node* target_{};
 		Scope scope_{};
 		QueryType type_{};
-		QStringList args_{};
+		QCommandLineParser argParser_;
 
 		TupleSet classesQuery(QList<TupleSet> input);
 		TupleSet methodsQuery(QList<TupleSet> input);

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -44,7 +44,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API AstQuery : public Query
 {
 	public:
-		enum class QueryType : int {Classes, Methods, BaseClasses, ToClass, CallGraph, Generic};
+		enum class QueryType : int {Classes, Methods, BaseClasses, ToClass, CallGraph, Generic, GenericToParent};
 		enum class Scope : int {Local, Global, Input};
 
 		AstQuery(QueryType type, Model::Node* target, QStringList args);
@@ -63,6 +63,7 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 		TupleSet methodsQuery(QList<TupleSet> input);
 		TupleSet baseClassesQuery(QList<TupleSet> input);
 		TupleSet toClassNode(QList<TupleSet> input);
+		TupleSet toParentType(QList<TupleSet> input, const QString& type);
 		TupleSet callGraph(QList<TupleSet> input);
 		TupleSet genericQuery(QList<TupleSet> input);
 		TupleSet typeQuery(QList<TupleSet> input, QString type);

--- a/ModelBase/src/nodes/Node.cpp
+++ b/ModelBase/src/nodes/Node.cpp
@@ -144,10 +144,10 @@ bool Node::isAncestorOf(const Node* other) const
 	return p == this;
 }
 
-Node* Node::firstAncestorOfType(const QString& typeName) const
+Node* Node::firstAncestorOfType(const SymbolMatcher& typeMatch) const
 {
 	auto p = parent();
-	while (p && p->typeName() != typeName) p = p->parent();
+	while (p && !typeMatch.matches(p->typeName())) p = p->parent();
 	return p;
 }
 

--- a/ModelBase/src/nodes/Node.cpp
+++ b/ModelBase/src/nodes/Node.cpp
@@ -144,6 +144,13 @@ bool Node::isAncestorOf(const Node* other) const
 	return p == this;
 }
 
+Node* Node::firstAncestorOfType(const QString& typeName) const
+{
+	auto p = parent();
+	while (p && p->typeName() != typeName) p = p->parent();
+	return p;
+}
+
 Node* Node::childToSubnode(const Node* other) const
 {
 	if (other == nullptr) return nullptr;

--- a/ModelBase/src/nodes/Node.h
+++ b/ModelBase/src/nodes/Node.h
@@ -311,6 +311,11 @@ class MODELBASE_API Node
 		NodeType* firstAncestorOfType();
 
 		/**
+		 * Returns the first Ancestor for which typeName() is equal to \a typeName if there is one, otherwise null.
+		 */
+		Node* firstAncestorOfType(const QString& typeName) const;
+
+		/**
 		 * Returns the direct child node that is equal to \a other or is an ancestor of \a other.
 		 *
 		 * Returns null if this node is not an ancestor of \a other.

--- a/ModelBase/src/nodes/Node.h
+++ b/ModelBase/src/nodes/Node.h
@@ -311,9 +311,9 @@ class MODELBASE_API Node
 		NodeType* firstAncestorOfType();
 
 		/**
-		 * Returns the first Ancestor for which typeName() is equal to \a typeName if there is one, otherwise null.
+		 * Returns the first Ancestor for which typeName() matches with \a typeMatch, if there is one, otherwise null.
 		 */
-		Node* firstAncestorOfType(const QString& typeName) const;
+		Node* firstAncestorOfType(const SymbolMatcher& typeMatch) const;
 
 		/**
 		 * Returns the direct child node that is equal to \a other or is an ancestor of \a other.


### PR DESCRIPTION
Ready to review commits. The ast query is now quite generic. Name queries are still to do.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23discussion_r39656764%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23discussion_r39656925%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23discussion_r39658414%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23discussion_r39658618%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23issuecomment-140810804%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23issuecomment-140981171%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23discussion_r39717216%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23issuecomment-140991623%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20d8ebb4c051a867388b539b2fc16bea939252b4ff%20InformationScripting/src/precompiled.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23discussion_r39656925%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Does%20this%20have%20to%20appear%20in%20a%20header%20file%3F%20If%20not%2C%20move%20it%20to%20the%20lower%20section%20of%20%60precompiled.h%60%22%2C%20%22created_at%22%3A%20%222015-09-16T17%3A07%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/precompiled.h%3AL44-51%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23issuecomment-140810804%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20finished%20with%20the%20review.%20Very%20good%20stuff%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-09-16T17%3A21%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20review.%20I%20fixed%20the%20things%20you%20mentioned.%20It%27s%20probably%20easier%20for%20you%20to%20merge%20this%20one%20and%20we%20start%20with%20a%20fresh%20PR%20for%20the%20node%20by%20name%20stuff.%22%2C%20%22created_at%22%3A%20%222015-09-17T06%3A34%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%22%2C%20%22created_at%22%3A%20%222015-09-17T07%3A29%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%200fd44468d333e06c59beddd7c96f055019411d53%20ModelBase/src/nodes/Node.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23discussion_r39717216%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20just%20quickly%20fix%20this%20and%20I%27ll%20merge%20it.%22%2C%20%22created_at%22%3A%20%222015-09-17T07%3A24%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ModelBase/src/nodes/Node.h%3AL311-322%22%7D%2C%20%22Pull%20d8ebb4c051a867388b539b2fc16bea939252b4ff%20InformationScripting/src/commands/CScript.cpp%2043%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23discussion_r39656764%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22you%20can%20greatly%20reduce%20the%20code%20size%20of%20%60CScript%3A%3Aexecute%60%20by%20introducing%20a%20lambda%20at%20the%20beginning%20of%20the%20method%3A%5Cr%5Cn%20%20%20%20%5Cr%5Cn%20%20%20%20auto%20query%20%3D%20%5B%5D%28auto%20...args%29%7Breturn%20QueryRegistry%3A%3Ainstance%28%29.buildQuery%28args...%29%3B%7D%5Cr%5Cn%5Cr%5Cnand%20then%20using%20it%20here%20and%20everywhere%20else%20in%20this%20method.%22%2C%20%22created_at%22%3A%20%222015-09-16T17%3A06%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/commands/CScript.cpp%3AL82-91%22%7D%2C%20%22Pull%20d8ebb4c051a867388b539b2fc16bea939252b4ff%20ModelBase/src/nodes/Node.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23discussion_r39658618%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20generalize%20this%20function%20and%20use%20a%20Matcher%20instead%20of%20a%20QString.%20It%20will%20be%20equally%20fast%20in%20case%20the%20matcher%20is%20a%20direct%20string%20comparison%2C%20but%20will%20also%20allow%20the%20extra%20flexibility.%22%2C%20%22created_at%22%3A%20%222015-09-16T17%3A20%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ModelBase/src/nodes/Node.cpp%3AL144-157%22%7D%2C%20%22Pull%20d8ebb4c051a867388b539b2fc16bea939252b4ff%20InformationScripting/src/queries/AstQuery.cpp%20255%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/149%23discussion_r39658414%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22skip%20%60-%3Emanager%28%29%60%22%2C%20%22created_at%22%3A%20%222015-09-16T17%3A19%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstQuery.cpp%3AL264-274%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull d8ebb4c051a867388b539b2fc16bea939252b4ff InformationScripting/src/commands/CScript.cpp 43'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/149#discussion_r39656764'>File: InformationScripting/src/commands/CScript.cpp:L82-91</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> you can greatly reduce the code size of `CScript::execute` by introducing a lambda at the beginning of the method:
  auto query = [](auto ...args){return QueryRegistry::instance().buildQuery(args...);}
  and then using it here and everywhere else in this method.
- [x] <a href='#crh-comment-Pull d8ebb4c051a867388b539b2fc16bea939252b4ff InformationScripting/src/precompiled.h 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/149#discussion_r39656925'>File: InformationScripting/src/precompiled.h:L44-51</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Does this have to appear in a header file? If not, move it to the lower section of `precompiled.h`
- [x] <a href='#crh-comment-Pull d8ebb4c051a867388b539b2fc16bea939252b4ff InformationScripting/src/queries/AstQuery.cpp 255'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/149#discussion_r39658414'>File: InformationScripting/src/queries/AstQuery.cpp:L264-274</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> skip `->manager()`
- [x] <a href='#crh-comment-Pull d8ebb4c051a867388b539b2fc16bea939252b4ff ModelBase/src/nodes/Node.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/149#discussion_r39658618'>File: ModelBase/src/nodes/Node.cpp:L144-157</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I would generalize this function and use a Matcher instead of a QString. It will be equally fast in case the matcher is a direct string comparison, but will also allow the extra flexibility.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/149#issuecomment-140810804'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I finished with the review. Very good stuff :)
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Thanks for review. I fixed the things you mentioned. It's probably easier for you to merge this one and we start with a fresh PR for the node by name stuff.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks.
- [x] <a href='#crh-comment-Pull 0fd44468d333e06c59beddd7c96f055019411d53 ModelBase/src/nodes/Node.h 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/149#discussion_r39717216'>File: ModelBase/src/nodes/Node.h:L311-322</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Could you just quickly fix this and I'll merge it.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/149?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/149?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/149'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
