### PR TITLE
Ast query with names and types with regex support

### DIFF
--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -83,7 +83,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 		{
 			if (args.size() > 1)
 			{
-				// $"classes g" | "script test"$
+				// $<"<classes g>" | "<script test>">$
 				auto classesQuery = query("classes", node, QStringList("-s=g"));
 				// TODO we could be more fancy in script file name detection, e.g. if .py is already entered don't append it.
 				auto scriptQuery = query(args.takeFirst(), node, args);
@@ -96,21 +96,21 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 		}
 		else if (command == "methods")
 		{
-			// "methods"
+			// "<methods>"
 			auto methodsQuery = query("methods", node, args);
 			QueryExecutor queryExecutor(methodsQuery);
 			queryExecutor.execute();
 		}
 		else if (command == "bases")
 		{
-			// "bases"
+			// "<bases>"
 			auto basesQuery = query("bases", node, args);
 			QueryExecutor queryExecutor(basesQuery);
 			queryExecutor.execute();
 		}
 		else if (command == "pipe")
 		{
-			// $"methods" | "toClass"$
+			// $<"<methods>" | "<toClass>">$
 			auto methodQuery = query("methods", node, args);
 			auto toBaseQuery = query("toClass", node, args);
 			auto compositeQuery = new CompositeQuery();
@@ -124,7 +124,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 			// Find all classes for which the name contains X and which have a method named Y
 			// 5 queries seems like a lot for this :S
 
-			// $"classes -s=g" | "filter *Matcher*" | "methods -s=of" | "filter matches" | "toClass"$
+			// $<"<classes -s=g>" | "<filter *Matcher*>" | "<methods -s=of>" | "<filter matches>" | "<toClass>">$
 			auto classesQuery = query("classes", node, QStringList("-s=g"));
 			auto filterQuery = query("filter", node, QStringList("*Matcher*"));
 			auto methodsOfQuery = query("methods", node, QStringList("-s=of"));
@@ -141,7 +141,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 		}
 		else if (command == "callgraph")
 		{
-			// "callgraph"
+			// "<callgraph>"
 			auto callgraph = query("callgraph", node, args);
 			auto compositeQuery = new CompositeQuery();
 			compositeQuery->connectToOutput(callgraph);
@@ -152,9 +152,9 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 		{
 			// Find all methods that are not called transitively from the TARGET method.
 
-			// $"methods -s=g" - {$"callgraph" | "addASTProperties"$}$
+			// $<"<methods -s=g>" - {<$<"<callgraph>" | "<addASTProperties>">$>}>$
 			// or:
-			// ${"methods -s=g", $"callgraph" | "addASTProperties"$}-$
+			// $<{<"<methods -s=g>", $<"<callgraph>" | "<addASTProperties>">$>}->$
 			auto allMethodsQuery = query("methods", node, QStringList("-s=g"));
 			auto callGraphQuery = query("callgraph", node, args);
 			auto astAdder = new AddASTPropertiesAsTuples();
@@ -169,7 +169,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 		}
 		else if (command == "color")
 		{
-			// $"methods" | {$"filter *quotes*" | "color = blue"$, $"filter *brackets*" | "color = green"$} U$
+			// $<"<methods>" | {<$<"<filter *quotes*>" | "<color = blue>">$, $<"<filter *brackets*>" | "<color = green>">$>} U>$
 			auto colorQuotes = new NodePropertyAdder("color", QString("blue"));
 			auto colorBrackets = new NodePropertyAdder("color", QString("green"));
 

--- a/InformationScripting/src/parsing/QueryBuilder.cpp
+++ b/InformationScripting/src/parsing/QueryBuilder.cpp
@@ -36,8 +36,8 @@
 
 namespace InformationScripting {
 
-static const QStringList OPEN_SCOPE_SYMBOL{"$", "\"", "{"};
-static const QStringList CLOSE_SCOPE_SYMBOL{"$", "\"", "}"};
+static const QStringList OPEN_SCOPE_SYMBOL{"$<", "\"<", "{<"};
+static const QStringList CLOSE_SCOPE_SYMBOL{">$", ">\"", ">}"};
 
 QueryBuilder& QueryBuilder::instance()
 {
@@ -71,7 +71,7 @@ Query* QueryBuilder::buildQueryFrom(const QString& text, Model::Node* target)
 
 QueryBuilder::Type QueryBuilder::typeOf(const QString& text)
 {
-	int index = OPEN_SCOPE_SYMBOL.indexOf(text[0]);
+	int index = OPEN_SCOPE_SYMBOL.indexOf(text.mid(0, 2));
 	Q_ASSERT(index >= 0);
 	return static_cast<Type>(index);
 }
@@ -81,12 +81,13 @@ QPair<QStringList, QList<QChar>> QueryBuilder::split(const QString& text, const 
 	QPair<QStringList, QList<QChar>> result;
 	QString currentString;
 	QVector<int> openScopes(3, 0);
-	for (int i = 1; i < text.size() - 1; ++i)
+	for (int i = 2; i < text.size() - 2; ++i)
 	{
 		QChar currentChar = text.at(i);
-		int openIndex = OPEN_SCOPE_SYMBOL.indexOf(currentChar);
+		QString scopeSymbol = text.mid(i, 2);
+		int openIndex = OPEN_SCOPE_SYMBOL.indexOf(scopeSymbol);
 		if (openIndex >= 0) ++openScopes[openIndex];
-		int closeIndex = CLOSE_SCOPE_SYMBOL.indexOf(currentChar);
+		int closeIndex = CLOSE_SCOPE_SYMBOL.indexOf(scopeSymbol);
 		if (closeIndex >= 0) --openScopes[closeIndex];
 		bool isInScope = std::all_of(openScopes.begin(), openScopes.end(), [](int i) { return i == 0;});
 		if (isInScope && splitChars.contains(currentChar))
@@ -106,7 +107,7 @@ QPair<QStringList, QList<QChar>> QueryBuilder::split(const QString& text, const 
 Query* QueryBuilder::parseQuery(const QString& text)
 {
 	Q_ASSERT(typeOf(text) == Type::Query);
-	QStringList data = text.mid(1, text.size()-2).split(" ", QString::SkipEmptyParts);
+	QStringList data = text.mid(2, text.size()-4).split(" ", QString::SkipEmptyParts);
 	Q_ASSERT(data.size());
 	QString command = data.takeFirst();
 	auto q = QueryRegistry::instance().buildQuery(command, target_, data);

--- a/InformationScripting/src/parsing/QueryBuilder.cpp
+++ b/InformationScripting/src/parsing/QueryBuilder.cpp
@@ -36,8 +36,8 @@
 
 namespace InformationScripting {
 
-static const QStringList OPEN_SCOPE_SYMBOL{"$<", "\"<", "{<"};
-static const QStringList CLOSE_SCOPE_SYMBOL{">$", ">\"", ">}"};
+const QStringList QueryBuilder::OPEN_SCOPE_SYMBOL{"$<", "\"<", "{<"};
+const QStringList QueryBuilder::CLOSE_SCOPE_SYMBOL{">$", ">\"", ">}"};
 
 QueryBuilder& QueryBuilder::instance()
 {
@@ -71,7 +71,7 @@ Query* QueryBuilder::buildQueryFrom(const QString& text, Model::Node* target)
 
 QueryBuilder::Type QueryBuilder::typeOf(const QString& text)
 {
-	int index = OPEN_SCOPE_SYMBOL.indexOf(text.mid(0, 2));
+	int index = OPEN_SCOPE_SYMBOL.indexOf(text.mid(0, SCOPE_SYMBOL_LENGTH_));
 	Q_ASSERT(index >= 0);
 	return static_cast<Type>(index);
 }
@@ -80,11 +80,11 @@ QPair<QStringList, QList<QChar>> QueryBuilder::split(const QString& text, const 
 {
 	QPair<QStringList, QList<QChar>> result;
 	QString currentString;
-	QVector<int> openScopes(3, 0);
-	for (int i = 2; i < text.size() - 2; ++i)
+	QVector<int> openScopes(OPEN_SCOPE_SYMBOL.length(), 0);
+	for (int i = SCOPE_SYMBOL_LENGTH_; i < text.size() - SCOPE_SYMBOL_LENGTH_; ++i)
 	{
 		QChar currentChar = text.at(i);
-		QString scopeSymbol = text.mid(i, 2);
+		QString scopeSymbol = text.mid(i, SCOPE_SYMBOL_LENGTH_);
 		int openIndex = OPEN_SCOPE_SYMBOL.indexOf(scopeSymbol);
 		if (openIndex >= 0) ++openScopes[openIndex];
 		int closeIndex = CLOSE_SCOPE_SYMBOL.indexOf(scopeSymbol);
@@ -107,7 +107,8 @@ QPair<QStringList, QList<QChar>> QueryBuilder::split(const QString& text, const 
 Query* QueryBuilder::parseQuery(const QString& text)
 {
 	Q_ASSERT(typeOf(text) == Type::Query);
-	QStringList data = text.mid(2, text.size()-4).split(" ", QString::SkipEmptyParts);
+	QStringList data = text.mid(SCOPE_SYMBOL_LENGTH_,
+										 text.size() - 2 * SCOPE_SYMBOL_LENGTH_).split(" ", QString::SkipEmptyParts);
 	Q_ASSERT(data.size());
 	QString command = data.takeFirst();
 	auto q = QueryRegistry::instance().buildQuery(command, target_, data);

--- a/InformationScripting/src/parsing/QueryBuilder.h
+++ b/InformationScripting/src/parsing/QueryBuilder.h
@@ -70,6 +70,10 @@ class INFORMATIONSCRIPTING_API QueryBuilder
 										Query* connectionQuery, Query* outputQuery = nullptr);
 
 		Model::Node* target_{};
+
+		static constexpr int SCOPE_SYMBOL_LENGTH_{2};
+		static const QStringList OPEN_SCOPE_SYMBOL;
+		static const QStringList CLOSE_SCOPE_SYMBOL;
 };
 
 } /* namespace InformationScripting  */

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -269,9 +269,9 @@ TupleSet AstQuery::nameQuery(QList<TupleSet> input, QString name)
 	// If we have a type argument filter the results:
 	const QString type = argParser_.value(NODETYPE_ARGUMENT_NAMES[0]);
 	Model::SymbolMatcher matcher = matcherFor(type);
-	for (auto result : matchingNodes)
-		if (type.isEmpty() || matcher.matches(result.second->typeName()))
-			tuples.add({{"ast", result.second}});
+	for (auto matchingNode : matchingNodes)
+		if (type.isEmpty() || matcher.matches(matchingNode.second->typeName()))
+			tuples.add({{"ast", matchingNode.second}});
 
 	return tuples;
 }

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -28,6 +28,8 @@
 
 #include "../informationscripting_api.h"
 
+#include "ModelBase/src/util/SymbolMatcher.h"
+
 #include "Query.h"
 
 namespace Model {
@@ -77,9 +79,11 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 
 		void addBaseEdgesFor(OOModel::Class* childClass, NamedProperty& classNode, TupleSet& ts);
 
-		void addNodesOfType(TupleSet& ts, const QString& typeName, Model::Node* from = nullptr);
+		void addNodesOfType(TupleSet& ts, const Model::SymbolMatcher& matcher, Model::Node* from = nullptr);
 
 		void addCallInformation(TupleSet& ts, OOModel::Method* method, QList<OOModel::Method*> callees);
+
+		Model::SymbolMatcher matcherFor(const QString& text);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -73,6 +73,7 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 		TupleSet callGraph(QList<TupleSet> input);
 		TupleSet genericQuery(QList<TupleSet> input);
 		TupleSet typeQuery(QList<TupleSet> input, QString type);
+		TupleSet nameQuery(QList<TupleSet> input, QString name);
 
 		void addBaseEdgesFor(OOModel::Class* childClass, NamedProperty& classNode, TupleSet& ts);
 

--- a/InformationScripting/src/visitors/AllNodesOfType.cpp
+++ b/InformationScripting/src/visitors/AllNodesOfType.cpp
@@ -27,10 +27,11 @@
 #include "AllNodesOfType.h"
 
 #include "ModelBase/src/nodes/Node.h"
+#include "ModelBase/src/util/SymbolMatcher.h"
 
 namespace InformationScripting {
 
-QList<Model::Node*> AllNodesOfType::allNodesOfType(Model::Node* from, const QString& typeName)
+QList<Model::Node*> AllNodesOfType::allNodesOfType(Model::Node* from, const Model::SymbolMatcher& matcher)
 {
 	QList<Model::Node*> result;
 	QList<Model::Node*> workStack{from};
@@ -38,7 +39,7 @@ QList<Model::Node*> AllNodesOfType::allNodesOfType(Model::Node* from, const QStr
 	while (!workStack.empty())
 	{
 		auto node = workStack.takeLast();
-		if (node->typeName() == typeName) result.push_back(node);
+		if (matcher.matches(node->typeName())) result.push_back(node);
 		workStack << node->children();
 	}
 	return result;

--- a/InformationScripting/src/visitors/AllNodesOfType.h
+++ b/InformationScripting/src/visitors/AllNodesOfType.h
@@ -30,6 +30,7 @@
 
 namespace Model {
 	class Node;
+	class SymbolMatcher;
 }
 
 namespace InformationScripting {
@@ -37,7 +38,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API AllNodesOfType
 {
 	public:
-		static QList<Model::Node*> allNodesOfType(Model::Node* from, const QString& typeName);
+		static QList<Model::Node*> allNodesOfType(Model::Node* from, const Model::SymbolMatcher& matcher);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/visualization/DefaultVisualizer.cpp
+++ b/InformationScripting/src/visualization/DefaultVisualizer.cpp
@@ -104,12 +104,17 @@ void DefaultVisualizer::visualize(const TupleSet& ts)
 		for (auto it = colors.begin(); it != colors.end(); ++it)
 		{
 			Model::Node* node = it.key();
+			Q_ASSERT(node);
 			auto nodeVisualization = Visualization::Item::nodeItemsMap().find(node);
-			Q_ASSERT(nodeVisualization != Visualization::Item::nodeItemsMap().end());
-			auto item = *nodeVisualization;
-			auto overlay = new Visualization::SelectionOverlay(
-						item, Visualization::SelectionOverlay::itemStyles().get(it.value() + "Highlight"));
-			item->addOverlay(overlay, HIGHLIGHT_OVERLAY_GROUP);
+			if (nodeVisualization != Visualization::Item::nodeItemsMap().end())
+			{
+				auto item = *nodeVisualization;
+				auto overlay = new Visualization::SelectionOverlay(
+							item, Visualization::SelectionOverlay::itemStyles().get(it.value() + "Highlight"));
+				item->addOverlay(overlay, HIGHLIGHT_OVERLAY_GROUP);
+			}
+			else
+				qWarning() << "no visualization for" << node->typeName();
 		}
 	}
 }

--- a/InformationScripting/src/visualization/DefaultVisualizer.cpp
+++ b/InformationScripting/src/visualization/DefaultVisualizer.cpp
@@ -105,16 +105,16 @@ void DefaultVisualizer::visualize(const TupleSet& ts)
 		{
 			Model::Node* node = it.key();
 			Q_ASSERT(node);
-			auto nodeVisualization = Visualization::Item::nodeItemsMap().find(node);
-			if (nodeVisualization != Visualization::Item::nodeItemsMap().end())
+			auto nodeVisualizationIt = Visualization::Item::nodeItemsMap().find(node);
+			if (nodeVisualizationIt == Visualization::Item::nodeItemsMap().end())
+				qWarning() << "no visualization for" << node->typeName();
+			while (nodeVisualizationIt != Visualization::Item::nodeItemsMap().end())
 			{
-				auto item = *nodeVisualization;
+				auto item = *nodeVisualizationIt++;
 				auto overlay = new Visualization::SelectionOverlay(
 							item, Visualization::SelectionOverlay::itemStyles().get(it.value() + "Highlight"));
 				item->addOverlay(overlay, HIGHLIGHT_OVERLAY_GROUP);
 			}
-			else
-				qWarning() << "no visualization for" << node->typeName();
 		}
 	}
 }

--- a/ModelBase/src/util/NameResolver.cpp
+++ b/ModelBase/src/util/NameResolver.cpp
@@ -39,8 +39,12 @@ QList<QPair<QString, Node*>> NameResolver::mostLikelyMatches(const QString& node
 	for (auto part : parts) pattern += part + '*';
 	auto matcher = SymbolMatcher(new QRegExp(pattern, Qt::CaseInsensitive, QRegExp::Wildcard));
 
-	for (auto manager : AllTreeManagers::instance().loadedManagers())
-		matches.append(findAllMatches(matcher, "", root ? root : manager->root()));
+	if (root) matches.append(findAllMatches(matcher, "", root));
+	else
+	{
+		for (auto manager : AllTreeManagers::instance().loadedManagers())
+			matches.append(findAllMatches(matcher, "", manager->root()));
+	}
 
 	//Shorter names usually have less parts to the fully qualified name -> suggest them first
 	std::sort(matches.begin(), matches.end(), [](QPair<QString, Node*> first, QPair<QString, Node*> second)

--- a/ModelBase/src/util/NameResolver.cpp
+++ b/ModelBase/src/util/NameResolver.cpp
@@ -31,7 +31,7 @@
 
 namespace Model {
 
-QList<QPair<QString, Node*>> NameResolver::mostLikelyMatches(const QString& nodeName, int matchLimit)
+QList<QPair<QString, Node*>> NameResolver::mostLikelyMatches(const QString& nodeName, int matchLimit, Node* root)
 {
 	QList<QPair<QString, Node*>> matches;
 	auto parts = nodeName.split(".");
@@ -40,7 +40,7 @@ QList<QPair<QString, Node*>> NameResolver::mostLikelyMatches(const QString& node
 	auto matcher = SymbolMatcher(new QRegExp(pattern, Qt::CaseInsensitive, QRegExp::Wildcard));
 
 	for (auto manager : AllTreeManagers::instance().loadedManagers())
-		matches.append(findAllMatches(matcher, "", manager->root()));
+		matches.append(findAllMatches(matcher, "", root ? root : manager->root()));
 
 	//Shorter names usually have less parts to the fully qualified name -> suggest them first
 	std::sort(matches.begin(), matches.end(), [](QPair<QString, Node*> first, QPair<QString, Node*> second)

--- a/ModelBase/src/util/NameResolver.h
+++ b/ModelBase/src/util/NameResolver.h
@@ -37,7 +37,7 @@ class MODELBASE_API NameResolver {
 
 	public:
 		static QList<QPair<QString, Node*>> findAllMatches(const SymbolMatcher& matcher, QString nameSoFar, Node* root);
-		static QList<QPair<QString, Node*>> mostLikelyMatches(const QString& nodeName, int matchLimit);
+		static QList<QPair<QString, Node*>> mostLikelyMatches(const QString& nodeName, int matchLimit, Node* root = nullptr);
 
 	private:
 		static bool isSuggestable(Node::SymbolTypes symbolType);


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39754947%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39754971%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39754997%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39755698%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39756186%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39756198%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39756422%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39756438%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39756603%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39756924%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39757064%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23issuecomment-141380300%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23issuecomment-141380300%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20fixed%20the%20things%20you%20mentioned%20except%20for%20the%20Regex%20stuff%2C%20which%20I%20noted%20for%20later%2C%20as%20I%27m%20not%20yet%20sure%20what%27s%20the%20best%20way%20for%20this.%22%2C%20%22created_at%22%3A%20%222015-09-18T08%3A27%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a9f9ec26c1c459e43721533c671ce3158566a0d8%20InformationScripting/src/parsing/QueryBuilder.cpp%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39754971%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22magic%202%22%2C%20%22created_at%22%3A%20%222015-09-17T14%3A55%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/parsing/QueryBuilder.cpp%3AL81-94%22%7D%2C%20%22Pull%20a9f9ec26c1c459e43721533c671ce3158566a0d8%20ModelBase/src/util/NameResolver.cpp%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39756603%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22A%20node%20can%20only%20ever%20belong%20to%20one%20manager.%20Thus%20if%20%60root%60%20is%20provided%2C%20you%20should%20not%20loop%20over%20all%20managers.%22%2C%20%22created_at%22%3A%20%222015-09-17T15%3A07%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ModelBase/src/util/NameResolver.cpp%3AL40-47%22%7D%2C%20%22Pull%20a9f9ec26c1c459e43721533c671ce3158566a0d8%20InformationScripting/src/parsing/QueryBuilder.cpp%2025%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39754947%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%20are%20a%20lot%20of%20magical%20numbers%20here.%202%20should%20be%20inferred%20somehow%2C%20from%20the%20OPEN/CLOSE_SCOPE_SYMBOL%2C%20not%20a%20hardcoded%20constant.%22%2C%20%22created_at%22%3A%20%222015-09-17T14%3A55%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20should%20be%20a%20class%20invariant%20that%20OPEN/CLOSE_SCOPE_SYMBOL%20have%20this%20length.%20Not%20sure%20how%20to%20implement%20this%20nicely.%5Cr%5Cn%5Cr%5CnFix%20a%20constant%20and%20iterate%20at%20construction%20over%20the%20symbols%20and%20check%20their%20length%3F%22%2C%20%22created_at%22%3A%20%222015-09-17T15%3A03%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22At%20the%20very%20least%2C%20define%20a%20static%20global%20constant%20at%20the%20beginning%20of%20this%20file%20%3D%202%20and%20use%20that%20throughout.%22%2C%20%22created_at%22%3A%20%222015-09-17T15%3A09%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/parsing/QueryBuilder.cpp%3AL81-94%22%7D%2C%20%22Pull%20a9f9ec26c1c459e43721533c671ce3158566a0d8%20InformationScripting/src/queries/AstQuery.cpp%20117%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39756198%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20at%20some%20point%20we%20should%20control%20the%20type%20of%20matcher%20based%20on%20command%20arguments.%20E.g.%20no%20argument%20-%3E%20simple%20substring%20matcher%20%28%2Atext%2A%29.%20Otherwise%20a%20fullblown%20regex%20matcher.%20But%20maybe%20some%20other%20smart%20option%20that%20detects%20the%20type%20of%20pattern%20is%20also%20fine.%20What%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222015-09-17T15%3A04%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Maybe%20some%20special%20prefix.%20How%20is%20this%20in%20bash%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-17T15%3A05%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22not%20sure%2C%20but%20I%27ve%20definitely%20seen%20it%20for%20some%20commands%20%28e.g.%20%60sed%60%20uses%20%60-r%60%29%22%2C%20%22created_at%22%3A%20%222015-09-17T15%3A10%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstQuery.cpp%3AL300-318%22%7D%2C%20%22Pull%20a9f9ec26c1c459e43721533c671ce3158566a0d8%20InformationScripting/src/queries/AstQuery.cpp%2093%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39755698%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Don%27t%20use%20the%20name%20%60result%60%20for%20something%20that%20is%20not%20the%20result%20of%20the%20method.%20It%20can%20be%20confusing.%22%2C%20%22created_at%22%3A%20%222015-09-17T15%3A00%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstQuery.cpp%3AL242-282%22%7D%2C%20%22Pull%20a9f9ec26c1c459e43721533c671ce3158566a0d8%20InformationScripting/src/parsing/QueryBuilder.cpp%2042%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39754997%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Magic%202/4%22%2C%20%22created_at%22%3A%20%222015-09-17T14%3A55%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/parsing/QueryBuilder.cpp%3AL107-114%22%7D%2C%20%22Pull%20a9f9ec26c1c459e43721533c671ce3158566a0d8%20InformationScripting/src/visualization/DefaultVisualizer.cpp%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/150%23discussion_r39756438%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20we%20add%20an%20overlay%20to%20%2Aall%2A%20visualizations%20of%20an%20item%2C%20not%20just%20the%20first%20one%3F%22%2C%20%22created_at%22%3A%20%222015-09-17T15%3A05%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/visualization/DefaultVisualizer.cpp%3AL104-121%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull a9f9ec26c1c459e43721533c671ce3158566a0d8 InformationScripting/src/parsing/QueryBuilder.cpp 25'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/150#discussion_r39754947'>File: InformationScripting/src/parsing/QueryBuilder.cpp:L81-94</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> There are a lot of magical numbers here. 2 should be inferred somehow, from the OPEN/CLOSE_SCOPE_SYMBOL, not a hardcoded constant.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> It should be a class invariant that OPEN/CLOSE_SCOPE_SYMBOL have this length. Not sure how to implement this nicely.
  Fix a constant and iterate at construction over the symbols and check their length?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> At the very least, define a static global constant at the beginning of this file = 2 and use that throughout.
- [x] <a href='#crh-comment-Pull a9f9ec26c1c459e43721533c671ce3158566a0d8 InformationScripting/src/parsing/QueryBuilder.cpp 29'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/150#discussion_r39754971'>File: InformationScripting/src/parsing/QueryBuilder.cpp:L81-94</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> magic 2
- [x] <a href='#crh-comment-Pull a9f9ec26c1c459e43721533c671ce3158566a0d8 InformationScripting/src/parsing/QueryBuilder.cpp 42'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/150#discussion_r39754997'>File: InformationScripting/src/parsing/QueryBuilder.cpp:L107-114</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Magic 2/4
- [x] <a href='#crh-comment-Pull a9f9ec26c1c459e43721533c671ce3158566a0d8 InformationScripting/src/queries/AstQuery.cpp 93'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/150#discussion_r39755698'>File: InformationScripting/src/queries/AstQuery.cpp:L242-282</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Don't use the name `result` for something that is not the result of the method. It can be confusing.
- [x] <a href='#crh-comment-Pull a9f9ec26c1c459e43721533c671ce3158566a0d8 InformationScripting/src/queries/AstQuery.cpp 117'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/150#discussion_r39756198'>File: InformationScripting/src/queries/AstQuery.cpp:L300-318</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I think at some point we should control the type of matcher based on command arguments. E.g. no argument -> simple substring matcher (_text_). Otherwise a fullblown regex matcher. But maybe some other smart option that detects the type of pattern is also fine. What do you think?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Maybe some special prefix. How is this in bash ?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> not sure, but I've definitely seen it for some commands (e.g. `sed` uses `-r`)
- [x] <a href='#crh-comment-Pull a9f9ec26c1c459e43721533c671ce3158566a0d8 InformationScripting/src/visualization/DefaultVisualizer.cpp 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/150#discussion_r39756438'>File: InformationScripting/src/visualization/DefaultVisualizer.cpp:L104-121</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Shouldn't we add an overlay to _all_ visualizations of an item, not just the first one?
- [x] <a href='#crh-comment-Pull a9f9ec26c1c459e43721533c671ce3158566a0d8 ModelBase/src/util/NameResolver.cpp 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/150#discussion_r39756603'>File: ModelBase/src/util/NameResolver.cpp:L40-47</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> A node can only ever belong to one manager. Thus if `root` is provided, you should not loop over all managers.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/150#issuecomment-141380300'>General Comment</a></b>
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> I fixed the things you mentioned except for the Regex stuff, which I noted for later, as I'm not yet sure what's the best way for this.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/150?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/150?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/150'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
