### PR TITLE
Refactor: Use new features in HExpression

### DIFF
--- a/OOInteraction/src/handlers/HExpression.cpp
+++ b/OOInteraction/src/handlers/HExpression.cpp
@@ -51,11 +51,6 @@ using namespace Interaction;
 
 namespace OOInteraction {
 
-HExpression::HExpression()
-{
-
-}
-
 HExpression* HExpression::instance()
 {
 	static HExpression h;
@@ -119,23 +114,23 @@ void HExpression::keyPressEvent(Item *target, QKeyEvent *event)
 			if (topMostItem->node()->parent()
 					&& topMostItem->node()->parent()->typeId() == ExpressionStatement::typeIdStatic())
 			{
-				if ( auto list = dynamic_cast<StatementItemList*>(topMostItem->node()->parent()->parent()) )
+				if ( auto list = DCast<StatementItemList>(topMostItem->node()->parent()->parent()) )
 				{
 					int thisNodeListIndex = list->indexOf(topMostItem->node()->parent());
 					int nodeToDeletelistIndex = thisNodeListIndex + (key == Qt::Key_Backspace ? -1 : +1);
-					bool empty = dynamic_cast<EmptyExpression*>(topMostItem->node());
+					bool empty = DCast<EmptyExpression>(topMostItem->node());
 
 					// Get a parent which represents a list (of statements or statement items)
 					auto parent = topMostItem->parent();
 					VList* vlist = nullptr;
-					while (!(vlist = dynamic_cast<VList*>(parent)) && parent->parent())
+					while (!(vlist = DCast<VList>(parent)) && parent->parent())
 						parent = parent->parent();
 
 					if (nodeToDeletelistIndex >= 0 && nodeToDeletelistIndex < list->size())
 					{
 						// Delete the current or the previous or the next empty item
-						auto st = dynamic_cast<ExpressionStatement*>(list->at(nodeToDeletelistIndex));
-						if (st && dynamic_cast<EmptyExpression*>(st->expression()))
+						auto st = DCast<ExpressionStatement>(list->at(nodeToDeletelistIndex));
+						if (st && DCast<EmptyExpression>(st->expression()))
 						{
 							HList::instance()->removeNodeAndSetCursor(vlist,
 									empty ? thisNodeListIndex : nodeToDeletelistIndex, key == Qt::Key_Delete,
@@ -238,7 +233,7 @@ void HExpression::keyPressEvent(Item *target, QKeyEvent *event)
 
 								// Get a parent which represents a list (of statements or statement items)
 								auto parent = topMostItem->parent();
-								while (! dynamic_cast<VList*>(parent) && parent->parent()) parent = parent->parent();
+								while (! DCast<VList>(parent) && parent->parent()) parent = parent->parent();
 
 								target->scene()->addPostEventAction(new SetCursorEvent(parent, toFocus));
 								return;
@@ -257,7 +252,7 @@ void HExpression::keyPressEvent(Item *target, QKeyEvent *event)
 						|| trimmedText == "continue" || trimmedText == "break" || trimmedText == "return" ||
 						trimmedText == "do" || trimmedText == "//" || trimmedText == "switch" || trimmedText == "case"
 						|| trimmedText == "try" || trimmedText == "assert"|| trimmedText == "synchronized"))
-			replaceStatement = parentExpressionStatement(dynamic_cast<OOModel::Expression*>(target->node()));
+			replaceStatement = parentExpressionStatement(DCast<OOModel::Expression>(target->node()));
 
 		if (replaceStatement)
 		{
@@ -377,7 +372,7 @@ void HExpression::keyPressEvent(Item *target, QKeyEvent *event)
 
 			// Get a parent which represents a list (of statements or statement items)
 			auto parent = topMostItem->parent();
-			while (! dynamic_cast<VList*>(parent) && parent->parent()) parent = parent->parent();
+			while (! DCast<VList>(parent) && parent->parent()) parent = parent->parent();
 
 			target->scene()->addPostEventAction(new SetCursorEvent(parent, toFocus));
 			return;
@@ -386,10 +381,10 @@ void HExpression::keyPressEvent(Item *target, QKeyEvent *event)
 		// Insert a new line if enter is pressed at the boundary
 		if (enterPressed && (index == 0 || index == newText.size()))
 		{
-			auto expSt = parentExpressionStatement(dynamic_cast<OOModel::Expression*>(target->node()));
+			auto expSt = parentExpressionStatement(DCast<OOModel::Expression>(target->node()));
 			if (expSt)
 			{
-				auto stList = dynamic_cast<StatementItemList*>(expSt->parent());
+				auto stList = DCast<StatementItemList>(expSt->parent());
 				if (stList)
 				{
 					auto es = new ExpressionStatement(new EmptyExpression());
@@ -489,9 +484,9 @@ ExpressionStatement* HExpression::parentExpressionStatement(OOModel::Expression*
 {
 	// Is this expression part of an expression statement
 	auto ep = e->parent();
-	while (ep && !dynamic_cast<Statement*>(ep)) ep = ep->parent();
+	while (ep && !DCast<Statement>(ep)) ep = ep->parent();
 
-	return dynamic_cast<ExpressionStatement*>(ep);
+	return DCast<ExpressionStatement>(ep);
 }
 
 void HExpression::setNewExpression(Item* target, Item* topMostItem, const QString& text,
@@ -573,7 +568,7 @@ void HExpression::showAutoComplete(Item* target, bool showIfEmpty, bool showIfPr
 	SymbolProviderType* scopePrefix = nullptr;
 	bool afterDot = false;
 
-	if (auto ref = dynamic_cast<ReferenceExpression*>(target->node()))
+	if (auto ref = DCast<ReferenceExpression>(target->node()))
 	{
 		// If the auto complete is invoked somewhere in a reference expression after a '.' only look for members that
 		// match.
@@ -585,7 +580,7 @@ void HExpression::showAutoComplete(Item* target, bool showIfEmpty, bool showIfPr
 			if (!scopePrefix) SAFE_DELETE(t);
 		}
 	}
-	else if (auto unf = dynamic_cast<OOModel::UnfinishedOperator*>(target->node()))
+	else if (auto unf = DCast<OOModel::UnfinishedOperator>(target->node()))
 	{
 		// If the auto complete is invoked just after a '.' only look for members that match within the scope of the
 		// prefix.

--- a/OOInteraction/src/handlers/HExpression.h
+++ b/OOInteraction/src/handlers/HExpression.h
@@ -39,7 +39,7 @@ namespace OOInteraction {
 
 class OOINTERACTION_API HExpression : public Interaction::GenericHandler {
 	protected:
-		HExpression();
+		HExpression() = default;
 
 	public:
 		static HExpression* instance();


### PR DESCRIPTION
Use DCast instead of dynamic_cast (faster)
Use default constructor (less code)

Just some things I noticed while investigating the code

Actually that brought me to a nice query we should support:
Find all usages of dynamic_cast where the argument has a isSubtypeOf function and the template class a static typeIdStatic function
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/151%23issuecomment-141415365%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/151%23issuecomment-141428922%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/151%23issuecomment-141437599%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/151%23issuecomment-141439764%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/151%23issuecomment-141885597%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/151%23issuecomment-141904937%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/151%23issuecomment-141905009%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/151%23issuecomment-141415365%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20a%20lot%20Lukas.%20I%20actually%20quite%20like%20this%20new%20query%20you%20have%20in%20mind%2C%20especially%20since%20it%27s%20a%20real%20thing%20that%20we%20needed.%20Make%20sure%20to%20record%20it%20somewhere%20and%20we%20should%20try%20it%20out%20at%20some%20point.%20Does%20it%20work%20already%3F%22%2C%20%22created_at%22%3A%20%222015-09-18T10%3A41%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20that%20query%20is%20not%20that%20easy%3A%5Cr%5CnMaybe%20get%20all%20nodes%20which%20have%20a%20typeIdStatic%20function%20then%20combine%20with%20all%20castexpression%20and%20then%20use%20a%20script%20to%20check%20if%20the%20cast%20expression%20refers%20to%20any%20of%20the%20other%20nodes.%5Cr%5Cn%5Cr%5CnChecking%20if%20the%20argument%20has%20the%20function%20isSubTypeOf%2C%20sound%20even%20more%20complex..%20%28we%20need%20some%20function%20to%20get%20the%20type%20of%20a%20variable/field%29%20then%20we%20can%20do%20similar%20as%20above%5Cr%5Cn%5Cr%5CnIt%27s%20actually%20quite%20interesting%20since%20this%20example%20can%20show%20how%20good%20we%20are%20from%20a%20usability%20perspective%22%2C%20%22created_at%22%3A%20%222015-09-18T11%3A59%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oke%20here%20I%20have%20the%20command%20and%20script%20for%20the%20first%20part%3A%5Cr%5Cnhttp%3A//pastebin.com/0ddsqT5T%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-18T12%3A26%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20this%20could%20be%20simplified%20a%20lot.%5Cr%5Cn%5Cr%5CnWhat%20if%20the%20we%20support%20a%20generic%20%28ModelBase%29%20query%3A%20%60uses%60%20that%20just%20checks%20if%20the%20input%20ast%20node%20%28for%20each%20node%20in%20the%20input%29%20uses%20to%20a%20node%20with%20a%20specific%20name%20or%20type.%20E.g.%3A%5Cr%5Cn%5Cr%5Cn%60ast%20-s%3Dg%20-t%3DCastExpression%20%7C%20uses%20-t%3DClass%60%20or%20%60ast%20-s%3Dg%20-t%3DCastExpression%20%7C%20uses%20-name%3DNode%60.%5Cr%5CnSuch%20a%20query%20sounds%20very%20useful%20to%20me%20and%20is%20generic%20%28use%20%60ModelBase%3A%3ARefernce%3A%3Atarget%28%29%60%20instead%20of%20%60OOModel%3A%3AReferenceExression%3A%3Atarget%28%29%60%5Cr%5Cn%5Cr%5CnThis%20will%20essentially%20eliminate%20the%20loop%20in%20your%20python%20script%2C%20we%20might%20also%20find%20another%20way%20to%20abstract%20the%20class%20check%20function.%22%2C%20%22created_at%22%3A%20%222015-09-18T12%3A34%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20I%27m%20not%20sure%20if%20I%20get%20how%20you%20would%20implement%20the%20uses%20query%3F%20How%20do%20you%20check%20if%20any%20node%20uses%20another%20node%3F%22%2C%20%22created_at%22%3A%20%222015-09-21T06%3A19%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Check%20if%20the%20node%20has%20any%20direct%20or%20indirect%20children%20of%20type%20%60Reference%60%2C%20and%20if%20so%2C%20check%20if%20the%20%60target%28%29%60%20of%20the%20reference%20is%20the%20node%20you%20are%20interested%20in%20being%20used.%22%2C%20%22created_at%22%3A%20%222015-09-21T08%3A17%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Makes%20sense%20yes%22%2C%20%22created_at%22%3A%20%222015-09-21T08%3A18%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/151#issuecomment-141415365'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks a lot Lukas. I actually quite like this new query you have in mind, especially since it's a real thing that we needed. Make sure to record it somewhere and we should try it out at some point. Does it work already?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Hm that query is not that easy:
  Maybe get all nodes which have a typeIdStatic function then combine with all castexpression and then use a script to check if the cast expression refers to any of the other nodes.
  Checking if the argument has the function isSubTypeOf, sound even more complex.. (we need some function to get the type of a variable/field) then we can do similar as above
  It's actually quite interesting since this example can show how good we are from a usability perspective
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Oke here I have the command and script for the first part:
  http://pastebin.com/0ddsqT5T
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, this could be simplified a lot.
  What if the we support a generic (ModelBase) query: `uses` that just checks if the input ast node (for each node in the input) uses to a node with a specific name or type. E.g.:
  `ast -s=g -t=CastExpression | uses -t=Class` or `ast -s=g -t=CastExpression | uses -name=Node`.
  Such a query sounds very useful to me and is generic (use `ModelBase::Refernce::target()` instead of `OOModel::ReferenceExression::target()`
  This will essentially eliminate the loop in your python script, we might also find another way to abstract the class check function.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Hm I'm not sure if I get how you would implement the uses query? How do you check if any node uses another node?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Check if the node has any direct or indirect children of type `Reference`, and if so, check if the `target()` of the reference is the node you are interested in being used.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Makes sense yes

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/151?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/151?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/151'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
