### PR TITLE
Change CompositeNode::extension to return a unique_ptr

### DIFF
--- a/ContractsLibrary/test/SimpleTest.cpp
+++ b/ContractsLibrary/test/SimpleTest.cpp
@@ -65,7 +65,7 @@ static const bool DISABLE_FILTERS = false;
 Module* createContractsLibrary()
 {
 	Module* module = new Module("CodeContracts");
-	std::unique_ptr<Position>(module->extension<Position>())->set(1, 0);
+	module->extension<Position>()->set(1, 0);
 
 	Class* contract = new Class("Contract");
 	module->classes()->append(contract);
@@ -73,7 +73,7 @@ Module* createContractsLibrary()
 	Method* req = new Method("Requires", Modifier::Public | Modifier::Static);
 	contract->methods()->append(req);
 	req->arguments()->append( new FormalArgument("precondition", new PrimitiveTypeExpression(PrimitiveType::BOOLEAN)) );
-	std::unique_ptr<Position>(req->extension<Position>())->set(0, 0);
+	req->extension<Position>()->set(0, 0);
 
 	Method* ens = new Method("Ensures", Modifier::Public | Modifier::Static);
 	contract->methods()->append(ens);

--- a/ControlFlowVisualization/test/SimpleTest.cpp
+++ b/ControlFlowVisualization/test/SimpleTest.cpp
@@ -132,7 +132,7 @@ Method* addComplicated(Class* parent)
 	ReturnStatement* metReturn = new ReturnStatement();
 	metReturn->values()->append(new IntegerLiteral(42));
 	met->items()->append(metReturn);
-	std::unique_ptr<Position>(met->extension<Position>())->set(1, 0);
+	met->extension<Position>()->set(1, 0);
 
 	return met;
 }
@@ -222,7 +222,7 @@ Method* addDivBySix(Class* parent)
 	divbysixFinalReturn->values()->append(new ReferenceExpression("result"));
 	divbysix->items()->append(divbysixFinalReturn);
 
-	std::unique_ptr<Position>(divbysix->extension<Position>())->set(0, 0);
+	divbysix->extension<Position>()->set(0, 0);
 
 	return divbysix;
 }

--- a/CustomMethodCall/test/SimpleTest.cpp
+++ b/CustomMethodCall/test/SimpleTest.cpp
@@ -52,7 +52,7 @@ Class* addCollection(Project* parent)
 	Method* find = new Method();
 	col->methods()->append(find);
 	find->setName("find");
-	std::unique_ptr<Position>(find->extension<Position>())->set(0, 0);
+	find->extension<Position>()->set(0, 0);
 	FormalArgument* findArg = new FormalArgument();
 	find->arguments()->append(findArg);
 	findArg->setTypeExpression(new PrimitiveTypeExpression(PrimitiveTypeExpression::PrimitiveTypes::INT));
@@ -64,7 +64,7 @@ Class* addCollection(Project* parent)
 	Method* insert = new Method();
 	col->methods()->append(insert);
 	insert->setName("insert");
-	std::unique_ptr<Position>(insert->extension<Position>())->set(0, 1);
+	insert->extension<Position>()->set(0, 1);
 	FormalArgument* insertArg = new FormalArgument();
 	insert->arguments()->append(insertArg);
 	insertArg->setTypeExpression(new PrimitiveTypeExpression(PrimitiveTypeExpression::PrimitiveTypes::INT));
@@ -73,7 +73,7 @@ Class* addCollection(Project* parent)
 	Method* empty = new Method();
 	col->methods()->append(empty);
 	empty->setName("empty");
-	std::unique_ptr<Position>(empty->extension<Position>())->set(0, 2);
+	empty->extension<Position>()->set(0, 2);
 	FormalResult* emptyResult = new FormalResult();
 	emptyResult->setTypeExpression(new PrimitiveTypeExpression(PrimitiveTypeExpression::PrimitiveTypes::BOOLEAN));
 	empty->results()->append(emptyResult);
@@ -81,7 +81,7 @@ Class* addCollection(Project* parent)
 	Method* exists = new Method();
 	col->methods()->append(exists);
 	exists->setName(QChar(0x2203));
-	std::unique_ptr<Position>(exists->extension<Position>())->set(0, 3);
+	exists->extension<Position>()->set(0, 3);
 	FormalArgument* existsArg = new FormalArgument();
 	exists->arguments()->append(existsArg);
 	existsArg->setTypeExpression(new PrimitiveTypeExpression(PrimitiveTypeExpression::PrimitiveTypes::INT));
@@ -93,7 +93,7 @@ Class* addCollection(Project* parent)
 	Method* sum = new Method();
 	col->methods()->append(sum);
 	sum->setName("sum");
-	std::unique_ptr<Position>(sum->extension<Position>())->set(0, 4);
+	sum->extension<Position>()->set(0, 4);
 	FormalArgument* sumArgFrom = new FormalArgument();
 	sum->arguments()->append(sumArgFrom);
 	sumArgFrom->setTypeExpression(new PrimitiveTypeExpression(PrimitiveTypeExpression::PrimitiveTypes::INT));
@@ -109,7 +109,7 @@ Class* addCollection(Project* parent)
 	Method* test = new Method();
 	col->methods()->append(test);
 	test->setName("test");
-	std::unique_ptr<Position>(test->extension<Position>())->set(1, 0);
+	test->extension<Position>()->set(1, 0);
 
 	IfStatement* ifs = new IfStatement();
 	test->items()->append(ifs);

--- a/InteractionBase/src/handlers/HPositionLayout.cpp
+++ b/InteractionBase/src/handlers/HPositionLayout.cpp
@@ -64,7 +64,7 @@ void HPositionLayout::mousePressEvent(Visualization::Item *target, QGraphicsScen
 		if (itemToMove)
 		{
 			Model::CompositeNode* composite = static_cast<Model::CompositeNode*> (itemToMove->node());
-			Visualization::Position* pos = composite->extension<Visualization::Position>();
+			auto pos = composite->extension<Visualization::Position>();
 
 			target->scene()->clearSelection();
 			target->scene()->clearFocus();
@@ -73,7 +73,7 @@ void HPositionLayout::mousePressEvent(Visualization::Item *target, QGraphicsScen
 			originalX = pos->xNode() ? pos->x() : 0;
 			originalY = pos->yNode() ? pos->y() : 0;
 			currentItem = itemToMove;
-			currentItemPosition = pos;
+			currentItemPosition.swap(pos);
 		}
 		else event->ignore();
 	}

--- a/InteractionBase/src/handlers/HPositionLayout.h
+++ b/InteractionBase/src/handlers/HPositionLayout.h
@@ -52,7 +52,7 @@ class INTERACTIONBASE_API HPositionLayout : public GenericHandler
 		int originalX;
 		int originalY;
 		Visualization::Item* currentItem;
-		Visualization::Position* currentItemPosition;
+		std::unique_ptr<Visualization::Position> currentItemPosition;
 
 };
 

--- a/ModelBase/src/nodes/composite/CompositeNode.h
+++ b/ModelBase/src/nodes/composite/CompositeNode.h
@@ -132,7 +132,7 @@ class MODELBASE_API CompositeNode: public Super<Node>
 
 		static int registerExtensionId();
 
-		template <class T> T* extension();
+		template <class ExtensionType> std::unique_ptr<ExtensionType> extension();
 
 		const AttributeChain& meta();
 
@@ -175,10 +175,11 @@ inline Node* CompositeNode::get(const CompositeIndex &attributeIndex) const
 
 inline int CompositeNode::registerExtensionId() { return nextExtensionId_++; }
 
-template <class T> T* CompositeNode::extension()
+template <class ExtensionType> std::unique_ptr<ExtensionType> CompositeNode::extension()
 {
 	AttributeChain& topMeta = topLevelMeta();
-	if (topMeta.hasExtensionInHierarchy(T::extensionId())) return new T(this, topMeta.extension(T::extensionId()));
+	if (topMeta.hasExtensionInHierarchy(ExtensionType::extensionId()))
+		return std::make_unique<ExtensionType>(this, topMeta.extension(ExtensionType::extensionId()));
 	else return nullptr;
 }
 

--- a/ModelBase/test/NotificationsTest.cpp
+++ b/ModelBase/test/NotificationsTest.cpp
@@ -90,15 +90,13 @@ TEST(ModelBasePlugin, ModificationNotificationTests)
 	CHECK_CONDITION(nl.removedNodes.contains( left));
 	CHECK_CONDITION(nl.removedNodes.contains( left->name()));
 
-	TestNodes::PositionExtension* posLeft = left->extension<TestNodes::PositionExtension>();
+	auto posLeft = left->extension<TestNodes::PositionExtension>();
 	CHECK_CONDITION(nl.removedNodes.contains( posLeft->xNode()) );
 	CHECK_CONDITION(nl.removedNodes.contains( posLeft->yNode()) );
 
-	TestNodes::PositionExtension* posRight = right->extension<TestNodes::PositionExtension>();
+	auto posRight = right->extension<TestNodes::PositionExtension>();
 	CHECK_CONDITION(nl.removedNodes.contains( posRight->xNode()) );
 	CHECK_CONDITION(nl.removedNodes.contains( posRight->yNode()) );
-
-	SAFE_DELETE(posLeft);
 
 	nl.modifiedNodes.clear();
 	nl.removedNodes.clear();
@@ -118,8 +116,6 @@ TEST(ModelBasePlugin, ModificationNotificationTests)
 	CHECK_CONDITION(nl.removedNodes.contains( right->name()));
 	CHECK_CONDITION(nl.removedNodes.contains( posRight->xNode()) );
 	CHECK_CONDITION(nl.removedNodes.contains( posRight->yNode()) );
-
-	SAFE_DELETE(posRight);
 }
 
 }

--- a/ModelBase/test/PositionTests.cpp
+++ b/ModelBase/test/PositionTests.cpp
@@ -41,7 +41,7 @@ TEST(ModelBasePlugin, PositionExtension)
 	CHECK_CONDITION(root->hasAttribute("_ext_PositionExtension_x"));
 	CHECK_CONDITION(root->hasAttribute("_ext_PositionExtension_y"));
 
-	TestNodes::PositionExtension* pos = root->extension<TestNodes::PositionExtension>();
+	auto pos = root->extension<TestNodes::PositionExtension>();
 
 	CHECK_INT_EQUAL( 0, pos->x() );
 	CHECK_INT_EQUAL( 0, pos->y() );

--- a/OOVisualization/src/semantic_zoom/VDeclarationConstantSz.cpp
+++ b/OOVisualization/src/semantic_zoom/VDeclarationConstantSz.cpp
@@ -82,7 +82,7 @@ void VDeclarationConstantSz::initializeForms()
 
 void VDeclarationConstantSz::updateGeometry(int availableWidth, int availableHeight)
 {
-	FullDetailSize* fds = node()->extension<FullDetailSize>();
+	auto fds = node()->extension<FullDetailSize>();
 	if (fds && fds->widthNode() && fds->heightNode())
 	{
 		qreal totalWidth = fds->width();

--- a/OOVisualization/test/HelloWorldTest.cpp
+++ b/OOVisualization/test/HelloWorldTest.cpp
@@ -337,11 +337,11 @@ Module* addLambda()
 	le->body()->append(new ExpressionStatement(someOpCall));
 
 	// Positions
-	std::unique_ptr<Position>(mod->extension<Position>())->set(2, 0);
-	std::unique_ptr<Position>(iUnary->extension<Position>())->set(0, 0);
-	std::unique_ptr<Position>(iBinary->extension<Position>())->set(0, 1);
-	std::unique_ptr<Position>(iNoRet->extension<Position>())->set(0, 2);
-	std::unique_ptr<Position>(test->extension<Position>())->set(1, 0);
+	mod->extension<Position>()->set(2, 0);
+	iUnary->extension<Position>()->set(0, 0);
+	iBinary->extension<Position>()->set(0, 1);
+	iNoRet->extension<Position>()->set(0, 2);
+	test->extension<Position>()->set(1, 0);
 	return mod;
 }
 
@@ -387,10 +387,10 @@ Project* addJavaLibrary(Project* parent)
 	prefix->ref()->setName("io");
 
 	// Set positions
-	std::unique_ptr<Position>(java->extension<Position>())->set(2, 1);
-	std::unique_ptr<Position>(string->extension<Position>())->set(0, 0);
-	std::unique_ptr<Position>(system->extension<Position>())->set(0, 1);
-	std::unique_ptr<Position>(io->extension<Position>())->set(1, 0);
+	java->extension<Position>()->set(2, 1);
+	string->extension<Position>()->set(0, 0);
+	system->extension<Position>()->set(0, 1);
+	io->extension<Position>()->set(1, 0);
 
 	return java;
 }

--- a/VisualizationBase/src/declarative/GridLayouter.cpp
+++ b/VisualizationBase/src/declarative/GridLayouter.cpp
@@ -71,7 +71,7 @@ QVector< QVector<Model::Node*>> GridLayouter::arrange(QVector<Model::Node*> node
 	{
 		auto composite = DCast<Model::CompositeNode>(node);
 		Q_ASSERT(composite);
-		auto position = std::unique_ptr<Position>(composite->extension<Position>());
+		auto position = composite->extension<Position>();
 		Q_ASSERT(position);
 
 		if ( position->xNode() && position->yNode() )
@@ -108,7 +108,7 @@ void GridLayouter::setPositionInGrid(QVector<Model::Node*> nodes, int x, int y, 
 
 	auto composite = DCast<Model::CompositeNode>(node);
 	Q_ASSERT(composite);
-	auto position = std::unique_ptr<Position>(composite->extension<Position>());
+	auto position = composite->extension<Position>();
 	Q_ASSERT(position);
 	position->set(std::max(x, 0), std::max(y, 0));
 }
@@ -119,7 +119,7 @@ void GridLayouter::removeFromGrid(QVector<Model::Node*> nodes, Model::Node* node
 
 	auto composite = DCast<Model::CompositeNode>(node);
 	Q_ASSERT(composite);
-	auto position = std::unique_ptr<Position>(composite->extension<Position>());
+	auto position = composite->extension<Position>();
 	Q_ASSERT(position);
 	if ( position->xNode()  == nullptr && position->yNode() == nullptr) return;
 
@@ -137,7 +137,7 @@ void GridLayouter::pushNodes(QVector<Model::Node*> nodes, int x, int y, int push
 	{
 		auto composite = DCast<Model::CompositeNode>(existingNode);
 		Q_ASSERT(composite);
-		auto position = std::unique_ptr<Position>(composite->extension<Position>());
+		auto position = composite->extension<Position>();
 		Q_ASSERT(position);
 
 		if ( position->xNode() && position->yNode() )
@@ -169,7 +169,7 @@ void GridLayouter::normalizeGridIndices(QVector<Model::Node*> nodes, MajorAxis m
 		{
 			auto composite = DCast<Model::CompositeNode>(normalized[major][minor]);
 			Q_ASSERT(composite);
-			auto position = std::unique_ptr<Position>(composite->extension<Position>());
+			auto position = composite->extension<Position>();
 			Q_ASSERT(position);
 
 			int normalizedX = majorAxis == ColumnMajor ? major : minor;

--- a/VisualizationBase/src/layouts/PositionLayout.cpp
+++ b/VisualizationBase/src/layouts/PositionLayout.cpp
@@ -125,7 +125,7 @@ void PositionLayout::synchronizeWithNodes(const QList<Model::Node*>& nodes)
 	if (allNodesLackPositionInfo)
 		for (auto node : nodes)
 			if (auto extNode = DCast<Model::CompositeNode> (node))
-				if (auto pos = std::unique_ptr<Position>(extNode->extension<Position>()))
+				if (auto pos = extNode->extension<Position>())
 					if (pos->xNode() || pos->yNode())
 					{
 						allNodesLackPositionInfo = false;

--- a/VisualizationBase/src/layouts/PositionLayout.h
+++ b/VisualizationBase/src/layouts/PositionLayout.h
@@ -95,7 +95,7 @@ class VISUALIZATIONBASE_API PositionLayout : public Super<Layout>
 template <class T> T* PositionLayout::at(int index) { return static_cast<T*> (items[index]); }
 template <class T> T* PositionLayout::at(int index) const { return static_cast<T*> (items[index]); }
 inline std::unique_ptr<Position> PositionLayout::positionOf(Item* item)
-{ return std::unique_ptr<Position>((static_cast<Model::CompositeNode*>(item->node()))->extension<Position>());	}
+{ return (static_cast<Model::CompositeNode*>(item->node()))->extension<Position>();	}
 
 inline void PositionLayout::ensureItemHasCompositeNode(const Item* item)
 {


### PR DESCRIPTION
That makes much more sense than a pointer since the return pointer is in
most cases deleted after usage. In most cases it was even used as
unique_ptr already and in other cases the pointer leaked.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/154%23discussion_r40182486%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/154%23issuecomment-142534747%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/154%23discussion_r40182581%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/154%23discussion_r40182630%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/154%23issuecomment-142537562%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20234b105b9faa5da4c1a663661b28659a2ffe553e%20ModelBase/test/NotificationsTest.cpp%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/154%23discussion_r40182486%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20can%20even%20remove%20this%20line%2C%20it%20doesn%27t%20seem%20to%20be%20needed%20now%20%28it%20was%20used%20for%20deletion%20before%29.%22%2C%20%22created_at%22%3A%20%222015-09-23T09%3A00%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20I%20thought%20the%20test%20depends%20on%20deletion%20at%20this%20point%22%2C%20%22created_at%22%3A%20%222015-09-23T09%3A01%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Remove%20it%20and%20run%20the%20test%20to%20make%20sure.%22%2C%20%22created_at%22%3A%20%222015-09-23T09%3A02%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ModelBase/test/NotificationsTest.cpp%3AL90-105%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/154%23issuecomment-142534747%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20looks%20great.%20Thanks%20for%20helping%20out.%22%2C%20%22created_at%22%3A%20%222015-09-23T09%3A01%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20comment%20by%20amending%22%2C%20%22created_at%22%3A%20%222015-09-23T09%3A16%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 234b105b9faa5da4c1a663661b28659a2ffe553e ModelBase/test/NotificationsTest.cpp 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/154#discussion_r40182486'>File: ModelBase/test/NotificationsTest.cpp:L90-105</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You can even remove this line, it doesn't seem to be needed now (it was used for deletion before).
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Ah I thought the test depends on deletion at this point
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Remove it and run the test to make sure.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/154#issuecomment-142534747'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This looks great. Thanks for helping out.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Fixed comment by amending

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/154?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/154?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/154'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
