### PR TITLE
Tags

### DIFF
--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -41,7 +41,8 @@ HEADERS += src/precompiled.h \
     src/queries/SubstractOperator.h \
     src/queries/AddASTPropertiesAsTuples.h \
     src/nodes/TagExtension.h \
-    src/queries/TagQuery.h
+    src/queries/TagQuery.h \
+    src/queries/ScopedArgumentQuery.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -67,7 +68,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/queries/SubstractOperator.cpp \
     src/queries/AddASTPropertiesAsTuples.cpp \
     src/nodes/TagExtension.cpp \
-    src/queries/TagQuery.cpp
+    src/queries/TagQuery.cpp \
+    src/queries/ScopedArgumentQuery.cpp
 
 # Workaround to not have any pragma's in NodeApi.cpp
 # (because of unused local typedef in BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS):

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -40,7 +40,8 @@ HEADERS += src/precompiled.h \
     src/queries/QueryRegistry.h \
     src/queries/SubstractOperator.h \
     src/queries/AddASTPropertiesAsTuples.h \
-    src/nodes/TagExtension.h
+    src/nodes/TagExtension.h \
+    src/queries/TagQuery.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -65,7 +66,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/queries/QueryRegistry.cpp \
     src/queries/SubstractOperator.cpp \
     src/queries/AddASTPropertiesAsTuples.cpp \
-    src/nodes/TagExtension.cpp
+    src/nodes/TagExtension.cpp \
+    src/queries/TagQuery.cpp
 
 # Workaround to not have any pragma's in NodeApi.cpp
 # (because of unused local typedef in BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS):

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -42,7 +42,8 @@ HEADERS += src/precompiled.h \
     src/queries/AddASTPropertiesAsTuples.h \
     src/nodes/TagExtension.h \
     src/queries/TagQuery.h \
-    src/queries/ScopedArgumentQuery.h
+    src/queries/ScopedArgumentQuery.h \
+    src/nodes/TagNode.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -69,7 +70,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/queries/AddASTPropertiesAsTuples.cpp \
     src/nodes/TagExtension.cpp \
     src/queries/TagQuery.cpp \
-    src/queries/ScopedArgumentQuery.cpp
+    src/queries/ScopedArgumentQuery.cpp \
+    src/nodes/TagNode.cpp
 
 # Workaround to not have any pragma's in NodeApi.cpp
 # (because of unused local typedef in BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS):

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -39,7 +39,8 @@ HEADERS += src/precompiled.h \
     src/wrappers/DataApi.h \
     src/queries/QueryRegistry.h \
     src/queries/SubstractOperator.h \
-    src/queries/AddASTPropertiesAsTuples.h
+    src/queries/AddASTPropertiesAsTuples.h \
+    src/nodes/TagExtension.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -63,7 +64,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/helpers/PythonSet.cpp \
     src/queries/QueryRegistry.cpp \
     src/queries/SubstractOperator.cpp \
-    src/queries/AddASTPropertiesAsTuples.cpp
+    src/queries/AddASTPropertiesAsTuples.cpp \
+    src/nodes/TagExtension.cpp
 
 # Workaround to not have any pragma's in NodeApi.cpp
 # (because of unused local typedef in BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS):

--- a/InformationScripting/src/InformationScriptingPlugin.cpp
+++ b/InformationScripting/src/InformationScriptingPlugin.cpp
@@ -27,6 +27,8 @@
 #include "InformationScriptingPlugin.h"
 #include "SelfTest/src/SelfTestSuite.h"
 
+#include "ModelBase/src/nodes/composite/CompositeNode.h"
+
 #include "InteractionBase/src/handlers/HSceneHandlerItem.h"
 #include "OOModel/src/declarations/Method.h"
 #include "OOModel/src/declarations/Class.h"
@@ -37,6 +39,7 @@
 #include "queries/AstQuery.h"
 #include "queries/AstNameFilter.h"
 #include "queries/AddASTPropertiesAsTuples.h"
+#include "nodes/TagExtension.h"
 
 namespace InformationScripting {
 
@@ -48,6 +51,9 @@ bool InformationScriptingPlugin::initialize(Core::EnvisionManager&)
 	AstQuery::registerDefaultQueries();
 	AstNameFilter::registerDefaultQueries();
 	AddASTPropertiesAsTuples::registerDefaultQueries();
+
+	TagExtension::registerExtension();
+	Model::CompositeNode::registerNewExtension<TagExtension>();
 	return true;
 }
 

--- a/InformationScripting/src/InformationScriptingPlugin.cpp
+++ b/InformationScripting/src/InformationScriptingPlugin.cpp
@@ -39,6 +39,7 @@
 #include "queries/AstQuery.h"
 #include "queries/AstNameFilter.h"
 #include "queries/AddASTPropertiesAsTuples.h"
+#include "queries/TagQuery.h"
 #include "nodes/TagExtension.h"
 
 namespace InformationScripting {
@@ -51,7 +52,7 @@ bool InformationScriptingPlugin::initialize(Core::EnvisionManager&)
 	AstQuery::registerDefaultQueries();
 	AstNameFilter::registerDefaultQueries();
 	AddASTPropertiesAsTuples::registerDefaultQueries();
-
+	TagQuery::registerDefaultQueries();
 	TagExtension::registerExtension();
 	Model::CompositeNode::registerNewExtension<TagExtension>();
 	return true;

--- a/InformationScripting/src/nodes/TagExtension.cpp
+++ b/InformationScripting/src/nodes/TagExtension.cpp
@@ -1,0 +1,35 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "TagExtension.h"
+
+namespace InformationScripting {
+
+DEFINE_EXTENSION(TagExtension)
+
+REGISTER_EXTENSION_ATTRIBUTE(TagExtension, tagName, Text, false, true, true)
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/nodes/TagExtension.h
+++ b/InformationScripting/src/nodes/TagExtension.h
@@ -32,13 +32,15 @@
 #include "ModelBase/src/nodes/Text.h"
 #include "ModelBase/src/nodes/nodeMacros.h"
 
+#include "TagNode.h"
+
 namespace InformationScripting {
 
 class INFORMATIONSCRIPTING_API TagExtension
 {
 	DECLARE_EXTENSION(TagExtension)
 
-	EXTENSION_ATTRIBUTE_VALUE(Model::Text, tagName, setTagName, QString)
+	EXTENSION_ATTRIBUTE(TagNode, tag, setTag)
 
 };
 

--- a/InformationScripting/src/nodes/TagExtension.h
+++ b/InformationScripting/src/nodes/TagExtension.h
@@ -1,0 +1,45 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../informationscripting_api.h"
+
+#include "ModelBase/src/nodes/composite/CompositeNode.h"
+#include "ModelBase/src/nodes/Text.h"
+#include "ModelBase/src/nodes/nodeMacros.h"
+
+namespace InformationScripting {
+
+class INFORMATIONSCRIPTING_API TagExtension
+{
+	DECLARE_EXTENSION(TagExtension)
+
+	EXTENSION_ATTRIBUTE_VALUE(Model::Text, tagName, setTagName, QString)
+
+};
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/nodes/TagExtension.h
+++ b/InformationScripting/src/nodes/TagExtension.h
@@ -29,7 +29,6 @@
 #include "../informationscripting_api.h"
 
 #include "ModelBase/src/nodes/composite/CompositeNode.h"
-#include "ModelBase/src/nodes/Text.h"
 #include "ModelBase/src/nodes/nodeMacros.h"
 
 #include "TagNode.h"

--- a/InformationScripting/src/nodes/TagNode.cpp
+++ b/InformationScripting/src/nodes/TagNode.cpp
@@ -24,12 +24,18 @@
 **
 ***********************************************************************************************************************/
 
-#include "TagExtension.h"
+#include "TagNode.h"
+
+#include "ModelBase/src/nodes/TypedListDefinition.h"
+DEFINE_TYPED_LIST(InformationScripting::TagNode)
 
 namespace InformationScripting {
 
-DEFINE_EXTENSION(TagExtension)
+COMPOSITENODE_DEFINE_EMPTY_CONSTRUCTORS(TagNode)
+COMPOSITENODE_DEFINE_TYPE_REGISTRATION_METHODS(TagNode)
 
-REGISTER_EXTENSION_ATTRIBUTE(TagExtension, tag, TagNode, false, true, true)
+TagNode::TagNode(const QString& name)
+	: Super(nullptr, TagNode::getMetaData()), name_{name}
+{}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/nodes/TagNode.cpp
+++ b/InformationScripting/src/nodes/TagNode.cpp
@@ -34,8 +34,12 @@ namespace InformationScripting {
 COMPOSITENODE_DEFINE_EMPTY_CONSTRUCTORS(TagNode)
 COMPOSITENODE_DEFINE_TYPE_REGISTRATION_METHODS(TagNode)
 
+REGISTER_ATTRIBUTE(TagNode, name, Text, false, false, true)
+
 TagNode::TagNode(const QString& name)
-	: Super(nullptr, TagNode::getMetaData()), name_{name}
-{}
+	: Super(nullptr, TagNode::getMetaData())
+{
+	setName(name);
+}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/nodes/TagNode.h
+++ b/InformationScripting/src/nodes/TagNode.h
@@ -29,22 +29,17 @@
 #include "../informationscripting_api.h"
 
 #include "ModelBase/src/nodes/composite/CompositeNode.h"
+#include "ModelBase/src/nodes/Text.h"
 
 namespace InformationScripting {
 
 class INFORMATIONSCRIPTING_API TagNode : public Super<Model::CompositeNode>
 {
 	COMPOSITENODE_DECLARE_STANDARD_METHODS(TagNode)
+	ATTRIBUTE_VALUE(Model::Text, name, setName, QString)
 
 	public:
 		TagNode(const QString& name);
-		QString name() const;
-
-	private:
-		QString name_;
-
 };
-
-inline QString TagNode::name() const { return name_; }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/nodes/TagNode.h
+++ b/InformationScripting/src/nodes/TagNode.h
@@ -24,12 +24,27 @@
 **
 ***********************************************************************************************************************/
 
-#include "TagExtension.h"
+#pragma once
+
+#include "../informationscripting_api.h"
+
+#include "ModelBase/src/nodes/composite/CompositeNode.h"
 
 namespace InformationScripting {
 
-DEFINE_EXTENSION(TagExtension)
+class INFORMATIONSCRIPTING_API TagNode : public Super<Model::CompositeNode>
+{
+	COMPOSITENODE_DECLARE_STANDARD_METHODS(TagNode)
 
-REGISTER_EXTENSION_ATTRIBUTE(TagExtension, tag, TagNode, false, true, true)
+	public:
+		TagNode(const QString& name);
+		QString name() const;
+
+	private:
+		QString name_;
+
+};
+
+inline QString TagNode::name() const { return name_; }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/precompiled.h
+++ b/InformationScripting/src/precompiled.h
@@ -44,8 +44,6 @@
 
 // Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
 // and will be included in their precompiled headers
-#include <QtCore/QCommandLineParser>
-
 
 #if defined(INFORMATIONSCRIPTING_LIBRARY)
 // Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
@@ -65,6 +63,7 @@
 #endif
 
 #include <QtCore/QQueue>
+#include <QtCore/QCommandLineParser>
 
 #endif
 

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -30,7 +30,7 @@
 
 #include "ModelBase/src/util/SymbolMatcher.h"
 
-#include "Query.h"
+#include "ScopedArgumentQuery.h"
 
 namespace Model {
 	class Node;
@@ -43,7 +43,7 @@ namespace OOModel {
 
 namespace InformationScripting {
 
-class INFORMATIONSCRIPTING_API AstQuery : public Query
+class INFORMATIONSCRIPTING_API AstQuery : public ScopedArgumentQuery
 {
 	public:
 		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
@@ -51,16 +51,11 @@ class INFORMATIONSCRIPTING_API AstQuery : public Query
 		static void registerDefaultQueries();
 
 	private:
-		static const QStringList SCOPE_ARGUMENT_NAMES;
+
 		static const QStringList NODETYPE_ARGUMENT_NAMES;
 		static const QStringList NAME_ARGUMENT_NAMES;
 		static const QStringList ADD_AS_NAMES;
 
-		enum class Scope : int {Local, Global, Input};
-
-		Model::Node* target_{};
-		Scope scope_{};
-		QCommandLineParser argParser_;
 		ExecuteFunction<AstQuery> exec_{};
 
 		AstQuery(ExecuteFunction<AstQuery> exec, Model::Node* target, QStringList args);

--- a/InformationScripting/src/queries/ScopedArgumentQuery.h
+++ b/InformationScripting/src/queries/ScopedArgumentQuery.h
@@ -53,7 +53,7 @@ class INFORMATIONSCRIPTING_API ScopedArgumentQuery : public Query
 
 	private:
 		std::unique_ptr<QCommandLineParser> argParser_{};
-		Model::Node* target_;
+		Model::Node* target_{};
 		Scope scope_{};
 		static const QStringList SCOPE_ARGUMENT_NAMES;
 };

--- a/InformationScripting/src/queries/ScopedArgumentQuery.h
+++ b/InformationScripting/src/queries/ScopedArgumentQuery.h
@@ -28,28 +28,37 @@
 
 #include "../informationscripting_api.h"
 
-#include "ModelBase/src/util/SymbolMatcher.h"
+#include "Query.h"
 
-#include "ScopedArgumentQuery.h"
+namespace Model {
+	class Node;
+}
+
+class QCommandLineParser;
+class QCommandLineOption;
 
 namespace InformationScripting {
 
-class INFORMATIONSCRIPTING_API TagQuery : public ScopedArgumentQuery
+class INFORMATIONSCRIPTING_API ScopedArgumentQuery : public Query
 {
-	public:
-		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
+	protected:
+		enum class Scope : int {Local, Global, Input};
 
-		static void registerDefaultQueries();
+		ScopedArgumentQuery(Model::Node* target, std::initializer_list<QCommandLineOption> options,
+								  const QStringList& args);
+		Model::Node* target() const;
+		Scope scope() const;
+
+		QString argument(const QString& argName) const;
 
 	private:
-		static const QStringList TAGTYPE_ARGUMENT_NAMES;
-		static const QStringList NAME_ARGUMENT_NAMES;
-
-		ExecuteFunction<TagQuery> exec_{};
-
-		TagQuery(ExecuteFunction<TagQuery> exec, Model::Node* target, QStringList args);
-		QList<TupleSet> queryTags(QList<TupleSet> input);
-		QList<TupleSet> addTags(QList<TupleSet> input);
+		std::unique_ptr<QCommandLineParser> argParser_{};
+		Model::Node* target_;
+		Scope scope_{};
+		static const QStringList SCOPE_ARGUMENT_NAMES;
 };
+
+inline Model::Node* ScopedArgumentQuery::target() const { return target_; }
+inline ScopedArgumentQuery::Scope ScopedArgumentQuery::scope() const { return scope_; }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/TagQuery.cpp
+++ b/InformationScripting/src/queries/TagQuery.cpp
@@ -80,7 +80,8 @@ QList<TupleSet> TagQuery::queryTags(QList<TupleSet> input)
 			if (auto astNode = DCast<Model::CompositeNode>(node))
 			{
 				auto tagExtension = astNode->extension<TagExtension>();
-				qDebug() << tagExtension->tagName();
+				if (tagExtension->tagNameNode())
+					qDebug() << tagExtension->tagName();
 			}
 		}
 		result << tupleSet;

--- a/InformationScripting/src/queries/TagQuery.cpp
+++ b/InformationScripting/src/queries/TagQuery.cpp
@@ -80,8 +80,8 @@ QList<TupleSet> TagQuery::queryTags(QList<TupleSet> input)
 			if (auto astNode = DCast<Model::CompositeNode>(node))
 			{
 				auto tagExtension = astNode->extension<TagExtension>();
-				if (tagExtension->tagNameNode())
-					qDebug() << tagExtension->tagName();
+				if (auto tagNode = tagExtension->tag())
+					qDebug() << tagNode->name();
 			}
 		}
 		result << tupleSet;
@@ -112,7 +112,7 @@ QList<TupleSet> TagQuery::addTags(QList<TupleSet> input)
 			{
 				auto tagExtension = astNode->extension<TagExtension>();
 				astNode->beginModification("addTag");
-				tagExtension->setTagName("foo");
+				tagExtension->setTag(new TagNode{"foo"});
 				astNode->endModification();
 			}
 		}

--- a/InformationScripting/src/queries/TagQuery.cpp
+++ b/InformationScripting/src/queries/TagQuery.cpp
@@ -1,0 +1,139 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "TagQuery.h"
+
+#include "QueryRegistry.h"
+#include "../nodes/TagExtension.h"
+
+#include "ModelBase/src/nodes/composite/CompositeNode.h"
+
+namespace InformationScripting {
+
+const QStringList TagQuery::SCOPE_ARGUMENT_NAMES{"s", "scope"};
+const QStringList TagQuery::NODETYPE_ARGUMENT_NAMES{"t", "type"};
+const QStringList TagQuery::NAME_ARGUMENT_NAMES{"n", "name"};
+
+QList<TupleSet> TagQuery::execute(QList<TupleSet> input)
+{
+	return exec_(this, input);
+}
+
+void TagQuery::registerDefaultQueries()
+{
+	QueryRegistry::instance().registerQueryConstructor("tags", [](Model::Node*, QStringList args) {
+		return new TagQuery(&TagQuery::queryTags, args);
+	});
+	QueryRegistry::instance().registerQueryConstructor("addTags", [](Model::Node*, QStringList args) {
+		return new TagQuery(&TagQuery::addTags, args);
+	});
+}
+
+TagQuery::TagQuery(ExecuteFunction<TagQuery> exec, QStringList args)
+	: exec_{exec}
+{
+	// TODO find how we can share the code with AstQuery instead of copying it.
+	args.prepend("TagQuery");
+	argParser_.addOptions(
+	{
+		 {SCOPE_ARGUMENT_NAMES, "Scope argument", SCOPE_ARGUMENT_NAMES[1]},
+		 {NODETYPE_ARGUMENT_NAMES, "AST Type argument", NODETYPE_ARGUMENT_NAMES[1]},
+		 {NAME_ARGUMENT_NAMES, "Name of a symbol", NAME_ARGUMENT_NAMES[1]}
+	});
+	// Since all our options require values we don't want -abc to be interpreted as -a -b -c but as --abc
+	argParser_.setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
+
+	if (!argParser_.parse(args))
+		qWarning() << "ASTQuery parse failure"; // TODO warn user
+
+	QString scope = argParser_.value(SCOPE_ARGUMENT_NAMES[0]);
+	if (scope == "g") scope_ = Scope::Global;
+	else if (scope == "of") scope_ = Scope::Input;
+}
+
+QList<TupleSet> TagQuery::queryTags(QList<TupleSet> input)
+{
+	QList<TupleSet> result;
+	if (scope_ == Scope::Local)
+	{
+
+	}
+	else if (scope_ == Scope::Global)
+	{
+
+	}
+	else if (scope_ == Scope::Input)
+	{
+		Q_ASSERT(input.size() > 0);
+		TupleSet tupleSet = input.takeFirst();
+		auto astTuples = tupleSet.tuples("ast");
+		for (auto tuple : astTuples)
+		{
+			Model::Node* node = tuple["ast"];
+			if (auto astNode = DCast<Model::CompositeNode>(node))
+			{
+				auto tagExtension = astNode->extension<TagExtension>();
+				qDebug() << tagExtension->tagName();
+			}
+		}
+		result << tupleSet;
+	}
+	return result;
+}
+
+QList<TupleSet> TagQuery::addTags(QList<TupleSet> input)
+{
+	QList<TupleSet> result;
+	if (scope_ == Scope::Local)
+	{
+
+	}
+	else if (scope_ == Scope::Global)
+	{
+
+	}
+	else if (scope_ == Scope::Input)
+	{
+		Q_ASSERT(input.size() > 0);
+		TupleSet tupleSet = input.takeFirst();
+		auto astTuples = tupleSet.tuples("ast");
+		for (auto tuple : astTuples)
+		{
+			Model::Node* node = tuple["ast"];
+			if (auto astNode = DCast<Model::CompositeNode>(node))
+			{
+				auto tagExtension = astNode->extension<TagExtension>();
+				astNode->beginModification("addTag");
+				tagExtension->setTagName("foo");
+				astNode->endModification();
+			}
+		}
+		result << tupleSet;
+	}
+	return result;
+}
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/TagQuery.cpp
+++ b/InformationScripting/src/queries/TagQuery.cpp
@@ -105,17 +105,20 @@ QList<TupleSet> TagQuery::addTags(QList<TupleSet> input)
 		Q_ASSERT(input.size() > 0);
 		TupleSet tupleSet = input.takeFirst();
 		auto astTuples = tupleSet.tuples("ast");
+
+		auto treeManager = target()->manager();
+		treeManager->beginModification(target(), "addTags");
 		for (auto tuple : astTuples)
 		{
 			Model::Node* node = tuple["ast"];
 			if (auto astNode = DCast<Model::CompositeNode>(node))
 			{
 				auto tagExtension = astNode->extension<TagExtension>();
-				astNode->beginModification("addTag");
+				treeManager->changeModificationTarget(astNode);
 				tagExtension->setTag(new TagNode{"foo"});
-				astNode->endModification();
 			}
 		}
+		treeManager->endModification();
 		result << tupleSet;
 	}
 	return result;

--- a/InformationScripting/src/queries/TagQuery.h
+++ b/InformationScripting/src/queries/TagQuery.h
@@ -1,0 +1,60 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../informationscripting_api.h"
+
+#include "ModelBase/src/util/SymbolMatcher.h"
+
+#include "Query.h"
+
+namespace InformationScripting {
+
+class INFORMATIONSCRIPTING_API TagQuery : public Query
+{
+	public:
+		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
+
+		static void registerDefaultQueries();
+
+	private:
+		static const QStringList SCOPE_ARGUMENT_NAMES;
+		static const QStringList NODETYPE_ARGUMENT_NAMES;
+		static const QStringList NAME_ARGUMENT_NAMES;
+
+		enum class Scope : int {Local, Global, Input};
+
+		Scope scope_{};
+		QCommandLineParser argParser_;
+		ExecuteFunction<TagQuery> exec_{};
+
+		TagQuery(ExecuteFunction<TagQuery> exec, QStringList args);
+		QList<TupleSet> queryTags(QList<TupleSet> input);
+		QList<TupleSet> addTags(QList<TupleSet> input);
+};
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/TagQuery.h
+++ b/InformationScripting/src/queries/TagQuery.h
@@ -34,6 +34,8 @@
 
 namespace InformationScripting {
 
+class TagNode;
+
 class INFORMATIONSCRIPTING_API TagQuery : public ScopedArgumentQuery
 {
 	public:
@@ -50,6 +52,8 @@ class INFORMATIONSCRIPTING_API TagQuery : public ScopedArgumentQuery
 		TagQuery(ExecuteFunction<TagQuery> exec, Model::Node* target, QStringList args);
 		QList<TupleSet> queryTags(QList<TupleSet> input);
 		QList<TupleSet> addTags(QList<TupleSet> input);
+
+		QList<TagNode*> allTags(Model::Node* target = nullptr);
 };
 
 } /* namespace InformationScripting */

--- a/ModelBase/src/nodes/composite/CompositeNode.h
+++ b/ModelBase/src/nodes/composite/CompositeNode.h
@@ -138,7 +138,6 @@ class MODELBASE_API CompositeNode: public Super<Node>
 
 		template <class Extension> static void registerNewExtension();
 
-		// FIXME this was protected but for registerNewExtension to work we need it public
 		static CompositeIndex registerNewAttribute(const Attribute& attribute);
 
 	protected:

--- a/ModelBase/src/nodes/composite/CompositeNode.h
+++ b/ModelBase/src/nodes/composite/CompositeNode.h
@@ -136,13 +136,16 @@ class MODELBASE_API CompositeNode: public Super<Node>
 
 		const AttributeChain& meta();
 
+		template <class Extension> static void registerNewExtension();
+
+		// FIXME this was protected but for registerNewExtension to work we need it public
+		static CompositeIndex registerNewAttribute(const Attribute& attribute);
+
 	protected:
 		static CompositeIndex registerNewAttribute(AttributeChain& metaData, const QString &attributeName,
 				const QString &attributeType, bool canBePartiallyLoaded, bool isOptional, bool isPersistent);
 
 		static CompositeIndex registerNewAttribute(AttributeChain& metaData, const Attribute& attribute);
-
-		static CompositeIndex registerNewAttribute(const Attribute& attribute);
 
 		virtual AttributeChain& topLevelMeta();
 
@@ -184,5 +187,12 @@ template <class ExtensionType> std::unique_ptr<ExtensionType> CompositeNode::ext
 }
 
 inline const AttributeChain& CompositeNode::meta() { return meta_; }
+
+template <class Extension>
+inline void CompositeNode::registerNewExtension()
+{
+	if (getMetaData().hasExtensionInHierarchy(Extension::extensionId()) == false)
+		Extension::template extendNode<CompositeNode>(getMetaData().addExtension(Extension::extensionId()));
+}
 
 }


### PR DESCRIPTION
This is still Work in progress but I would like to get Feedback about the general structure
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40246609%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40246730%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40247088%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40247200%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40247372%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40247483%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40247713%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40247799%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23issuecomment-142708292%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23issuecomment-142883647%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23issuecomment-142889508%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23issuecomment-142889872%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23issuecomment-142890369%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23issuecomment-142891460%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23issuecomment-142708292%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20like%20it.%20There%20is%20more%20to%20be%20done%20in%20terms%20of%20expanding%20the%20queries%2C%20but%20it%27s%20definitely%20going%20in%20the%20right%20direction.%20If%20possible%2C%20could%20you%20please%20fix%20all%20the%20tiny%20issues%20that%20I%20mention%20here%20and%20I%27ll%20accept%20the%20PR%2C%20even%20in%20this%20incomplete%20state.%20Then%20at%20least%20I%27d%20only%20have%20to%20look%20at%20the%20new%20changes%20that%20come%20afterwards.%5Cr%5Cn%5Cr%5CnWe%20should%20meet%20to%20discuss%20your%20idea%20about%20tags.%20Keep%20in%20mind%20that%20tags%2C%20in%20my%20mind%20will%20be%20primarily%20used%20with%20your%20queries%2C%20so%20we%20need%20to%20have%20convenient%20ways%20to%20query%20and%20edit%20them.%5Cr%5Cn%5Cr%5CnI%20might%20have%20some%20time%20to%20meet%20tomorrow%20%28Thursday%29%2C%20but%20I%20can%27t%20say%20for%20sure%20at%20the%20moment.%22%2C%20%22created_at%22%3A%20%222015-09-23T19%3A45%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20merged%20this%20but%20I%27m%20wondering%2C%20why%20do%20we%20need%20a%20tag%20node%3F%20If%20we%20decide%20in%20the%20end%20that%20tags%20are%20just%20a%20list%20of%20strings%2C%20we%20should%20directly%20register%20a%20List%20of%20Strings%20attribute%20as%20part%20of%20the%20extension%2C%20and%20not%20bother%20with%20having%20a%20separate%20node.%20This%20way%2C%20you%20can%20even%20make%20that%20a%20required%20attribute%2C%20and%20missing%20lists%20will%20be%20autmatically%20empty.%22%2C%20%22created_at%22%3A%20%222015-09-24T10%3A23%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20well%20previously%20the%20idea%20was%20to%20have%20a%20bit%20more%20structured%20data.%20But%20now%20you%20are%20right.%5Cr%5Cn%5Cr%5CnOn%20the%20other%20hand%20one%20thing%20we%20should%20definitely%20support%20is%20having%20multiple%20tags%20at%20one%20node.%20Maybe%20the%20extension%20is%20then%20just%20a%20list%20of%20TagNode%20or%20do%20you%20have%20a%20better%20approach%20to%20solve%20this%3F%22%2C%20%22created_at%22%3A%20%222015-09-24T10%3A46%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20isn%27t%20a%20List%20of%20String%20%28as%20opposed%20to%20a%20List%20of%20TagNode%29%20enough%3F%20If%20we%20decide%20that%20we%20don%27t%20need%20more%20structure%20than%20a%20string%2C%20then%20we%20can%20completely%20get%20rid%20of%20the%20TagNode%20type.%22%2C%20%22created_at%22%3A%20%222015-09-24T10%3A48%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Actually%20I%20think%20a%20set%20would%20make%20more%20sense%3F%22%2C%20%22created_at%22%3A%20%222015-09-24T10%3A51%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20yes%2C%20but%20we%20don%27t%20have%20set%20attributes.%20We%20can%20use%20a%20list%20and%20just%20ignore%20the%20order.%22%2C%20%22created_at%22%3A%20%222015-09-24T10%3A53%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a08c5e3947f975973d6d221fa0fea9e1b27dbf11%20InformationScripting/src/queries/TagQuery.cpp%2036%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40247372%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20already%20talk%20about%20types%20and%20names%20of%20tags%2C%20but%20I%20don%27t%20know%20what%20these%20are.%20We%20should%20talk%20about%20your%20design.%22%2C%20%22created_at%22%3A%20%222015-09-23T19%3A36%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/TagQuery.cpp%3AL1-125%22%7D%2C%20%22Pull%20a08c5e3947f975973d6d221fa0fea9e1b27dbf11%20InformationScripting/src/queries/ScopedArgumentQuery.h%2056%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40247088%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20default%20initializer%20here%20%60%7B%7D%60.%22%2C%20%22created_at%22%3A%20%222015-09-23T19%3A34%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/ScopedArgumentQuery.h%3AL1-65%22%7D%2C%20%22Pull%20a08c5e3947f975973d6d221fa0fea9e1b27dbf11%20InformationScripting/src/queries/TagQuery.cpp%20116%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40247799%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20more%20performant%20to%20call%20begin/end%20modification%20only%20once%20for%20the%20entire%20method%2C%20and%20for%20each%20individual%20node%20to%20just%20call%20%60manger%28%29-%3EchangeModificationTarget%28%29%60.%22%2C%20%22created_at%22%3A%20%222015-09-23T19%3A40%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/TagQuery.cpp%3AL1-125%22%7D%2C%20%22Pull%20a08c5e3947f975973d6d221fa0fea9e1b27dbf11%20InformationScripting/src/queries/TagQuery.cpp%2066%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40247483%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20are%20%60Local%60%20and%20%60Global%60%20empty%3F%20Doesn%27t%20it%20make%20sense%20to%20just%20get%20all%20the%20tags%2C%20of%20let%27s%20say%20the%20current%20selection%3F%22%2C%20%22created_at%22%3A%20%222015-09-23T19%3A38%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/TagQuery.cpp%3AL1-125%22%7D%2C%20%22Pull%20a08c5e3947f975973d6d221fa0fea9e1b27dbf11%20InformationScripting/src/nodes/TagNode.h%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40246730%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20be%20an%20attribute.%20Why%20isn%27t%20it%3F%22%2C%20%22created_at%22%3A%20%222015-09-23T19%3A31%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/nodes/TagNode.h%3AL1-51%22%7D%2C%20%22Pull%20a08c5e3947f975973d6d221fa0fea9e1b27dbf11%20InformationScripting/src/queries/TagQuery.cpp%20114%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40247713%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Brilliant.%20You%27ve%20just%20implemented%20your%20first%20query%20that%20does%20modifications.%20I%20like%20it.%20I%20like%20how%20natural%20it%20feels%20to%20add%20tags%20this%20way.%20There%20might%20be%20other%20ways%2C%20but%20this%20one%20feels%20very%20natural%2C%20especially%20for%20adding%20tags%20on%20mass.%22%2C%20%22created_at%22%3A%20%222015-09-23T19%3A39%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/TagQuery.cpp%3AL1-125%22%7D%2C%20%22Pull%20a08c5e3947f975973d6d221fa0fea9e1b27dbf11%20InformationScripting/src/nodes/TagExtension.h%2032%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40246609%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Do%20you%20need%20to%20include%20this%3F%20You%20don%27t%20seem%20to%20use%20%60Text%60%20anywhere.%22%2C%20%22created_at%22%3A%20%222015-09-23T19%3A29%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/nodes/TagExtension.h%3AL1-48%22%7D%2C%20%22Pull%20a08c5e3947f975973d6d221fa0fea9e1b27dbf11%20ModelBase/src/nodes/composite/CompositeNode.h%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/155%23discussion_r40247200%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%27s%20there%20to%20fix%3F%20We%20just%20leave%20it%20public.%20I%20think%20that%27s%20fine.%22%2C%20%22created_at%22%3A%20%222015-09-23T19%3A35%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ModelBase/src/nodes/composite/CompositeNode.h%3AL136-153%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull a08c5e3947f975973d6d221fa0fea9e1b27dbf11 InformationScripting/src/nodes/TagExtension.h 32'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/155#discussion_r40246609'>File: InformationScripting/src/nodes/TagExtension.h:L1-48</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Do you need to include this? You don't seem to use `Text` anywhere.
- [x] <a href='#crh-comment-Pull a08c5e3947f975973d6d221fa0fea9e1b27dbf11 InformationScripting/src/nodes/TagNode.h 40'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/155#discussion_r40246730'>File: InformationScripting/src/nodes/TagNode.h:L1-51</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This should be an attribute. Why isn't it?
- [x] <a href='#crh-comment-Pull a08c5e3947f975973d6d221fa0fea9e1b27dbf11 InformationScripting/src/queries/ScopedArgumentQuery.h 56'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/155#discussion_r40247088'>File: InformationScripting/src/queries/ScopedArgumentQuery.h:L1-65</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Use default initializer here `{}`.
- [x] <a href='#crh-comment-Pull a08c5e3947f975973d6d221fa0fea9e1b27dbf11 ModelBase/src/nodes/composite/CompositeNode.h 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/155#discussion_r40247200'>File: ModelBase/src/nodes/composite/CompositeNode.h:L136-153</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> What's there to fix? We just leave it public. I think that's fine.
- [ ] <a href='#crh-comment-Pull a08c5e3947f975973d6d221fa0fea9e1b27dbf11 InformationScripting/src/queries/TagQuery.cpp 36'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/155#discussion_r40247372'>File: InformationScripting/src/queries/TagQuery.cpp:L1-125</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You already talk about types and names of tags, but I don't know what these are. We should talk about your design.
- [x] <a href='#crh-comment-Pull a08c5e3947f975973d6d221fa0fea9e1b27dbf11 InformationScripting/src/queries/TagQuery.cpp 66'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/155#discussion_r40247483'>File: InformationScripting/src/queries/TagQuery.cpp:L1-125</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why are `Local` and `Global` empty? Doesn't it make sense to just get all the tags, of let's say the current selection?
- [x] <a href='#crh-comment-Pull a08c5e3947f975973d6d221fa0fea9e1b27dbf11 InformationScripting/src/queries/TagQuery.cpp 114'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/155#discussion_r40247713'>File: InformationScripting/src/queries/TagQuery.cpp:L1-125</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Brilliant. You've just implemented your first query that does modifications. I like it. I like how natural it feels to add tags this way. There might be other ways, but this one feels very natural, especially for adding tags on mass.
- [x] <a href='#crh-comment-Pull a08c5e3947f975973d6d221fa0fea9e1b27dbf11 InformationScripting/src/queries/TagQuery.cpp 116'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/155#discussion_r40247799'>File: InformationScripting/src/queries/TagQuery.cpp:L1-125</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> It's more performant to call begin/end modification only once for the entire method, and for each individual node to just call `manger()->changeModificationTarget()`.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/155#issuecomment-142708292'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I like it. There is more to be done in terms of expanding the queries, but it's definitely going in the right direction. If possible, could you please fix all the tiny issues that I mention here and I'll accept the PR, even in this incomplete state. Then at least I'd only have to look at the new changes that come afterwards.
  We should meet to discuss your idea about tags. Keep in mind that tags, in my mind will be primarily used with your queries, so we need to have convenient ways to query and edit them.
  I might have some time to meet tomorrow (Thursday), but I can't say for sure at the moment.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I merged this but I'm wondering, why do we need a tag node? If we decide in the end that tags are just a list of strings, we should directly register a List of Strings attribute as part of the extension, and not bother with having a separate node. This way, you can even make that a required attribute, and missing lists will be autmatically empty.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Hm well previously the idea was to have a bit more structured data. But now you are right.
  On the other hand one thing we should definitely support is having multiple tags at one node. Maybe the extension is then just a list of TagNode or do you have a better approach to solve this?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> But isn't a List of String (as opposed to a List of TagNode) enough? If we decide that we don't need more structure than a string, then we can completely get rid of the TagNode type.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Actually I think a set would make more sense?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Well yes, but we don't have set attributes. We can use a list and just ignore the order.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/155?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/155?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/155'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
