### PR TITLE
Add a LinearQuery to abstract Queries that only need single in-/output

### DIFF
--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -68,7 +68,8 @@ HEADERS += src/precompiled.h \
     src/visualization/VErrorQueryNodeStyle.h \
     src/visualization/VErrorQueryNode.h \
     src/visualization/VOperatorQueryNode.h \
-    src/visualization/VOperatorQueryNodeStyle.h
+    src/visualization/VOperatorQueryNodeStyle.h \
+    src/queries/LinearQuery.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -121,7 +122,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/visualization/VErrorQueryNode.cpp \
     src/visualization/VErrorQueryNodeStyle.cpp \
     src/visualization/VOperatorQueryNode.cpp \
-    src/visualization/VOperatorQueryNodeStyle.cpp
+    src/visualization/VOperatorQueryNodeStyle.cpp \
+    src/queries/LinearQuery.cpp
 
 # Workaround to not have any pragma's in NodeApi.cpp
 # (because of unused local typedef in BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS):

--- a/InformationScripting/src/queries/LinearQuery.cpp
+++ b/InformationScripting/src/queries/LinearQuery.cpp
@@ -24,57 +24,19 @@
 **
 ***********************************************************************************************************************/
 
-#pragma once
-
-#include "../informationscripting_api.h"
-
-#include "ScopedArgumentQuery.h"
-
-namespace Model {
-	class Node;
-	class SymbolMatcher;
-}
-
-namespace OOModel {
-	class Class;
-	class Method;
-}
+#include "LinearQuery.h"
 
 namespace InformationScripting {
 
-class INFORMATIONSCRIPTING_API AstQuery : public ScopedArgumentQuery
+QList<TupleSet> LinearQuery::execute(QList<TupleSet> input)
 {
-	public:
-		virtual TupleSet execute(TupleSet input) override;
+	QList<TupleSet> result;
+	// If we have no input just add one default input such that we execute at least once.
+	if (input.isEmpty()) input << TupleSet();
 
-		static void registerDefaultQueries();
-
-	private:
-
-		static const QStringList NODETYPE_ARGUMENT_NAMES;
-		static const QStringList NAME_ARGUMENT_NAMES;
-		static const QStringList ADD_AS_NAMES;
-
-		using ExecuteFunction = std::function<TupleSet (AstQuery*, TupleSet)>;
-		ExecuteFunction exec_{};
-
-		AstQuery(ExecuteFunction exec, Model::Node* target, QStringList args);
-
-		static void setTypeTo(QStringList& args, QString type);
-
-		TupleSet baseClassesQuery(TupleSet input);
-		TupleSet toParentType(TupleSet input);
-		TupleSet callGraph(TupleSet input);
-		TupleSet genericQuery(TupleSet input);
-		TupleSet typeQuery(TupleSet input, QString type);
-		TupleSet nameQuery(TupleSet input, QString name);
-		TupleSet usesQuery(TupleSet input);
-
-		void addBaseEdgesFor(OOModel::Class* childClass, NamedProperty& classNode, TupleSet& ts);
-		void addNodesOfType(TupleSet& ts, const Model::SymbolMatcher& matcher, Model::Node* from = nullptr);
-		void addCallInformation(TupleSet& ts, OOModel::Method* method, QList<OOModel::Method*> callees);
-
-		void adaptOutputForRelation(TupleSet& tupleSet, const QString& relationName, const QStringList& keepProperties);
-};
+	for (auto ts : input)
+		result.push_back(execute(ts));
+	return result;
+}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/LinearQuery.h
+++ b/InformationScripting/src/queries/LinearQuery.h
@@ -28,53 +28,15 @@
 
 #include "../informationscripting_api.h"
 
-#include "ScopedArgumentQuery.h"
-
-namespace Model {
-	class Node;
-	class SymbolMatcher;
-}
-
-namespace OOModel {
-	class Class;
-	class Method;
-}
+#include "Query.h"
 
 namespace InformationScripting {
 
-class INFORMATIONSCRIPTING_API AstQuery : public ScopedArgumentQuery
+class INFORMATIONSCRIPTING_API LinearQuery : public Query
 {
 	public:
-		virtual TupleSet execute(TupleSet input) override;
-
-		static void registerDefaultQueries();
-
-	private:
-
-		static const QStringList NODETYPE_ARGUMENT_NAMES;
-		static const QStringList NAME_ARGUMENT_NAMES;
-		static const QStringList ADD_AS_NAMES;
-
-		using ExecuteFunction = std::function<TupleSet (AstQuery*, TupleSet)>;
-		ExecuteFunction exec_{};
-
-		AstQuery(ExecuteFunction exec, Model::Node* target, QStringList args);
-
-		static void setTypeTo(QStringList& args, QString type);
-
-		TupleSet baseClassesQuery(TupleSet input);
-		TupleSet toParentType(TupleSet input);
-		TupleSet callGraph(TupleSet input);
-		TupleSet genericQuery(TupleSet input);
-		TupleSet typeQuery(TupleSet input, QString type);
-		TupleSet nameQuery(TupleSet input, QString name);
-		TupleSet usesQuery(TupleSet input);
-
-		void addBaseEdgesFor(OOModel::Class* childClass, NamedProperty& classNode, TupleSet& ts);
-		void addNodesOfType(TupleSet& ts, const Model::SymbolMatcher& matcher, Model::Node* from = nullptr);
-		void addCallInformation(TupleSet& ts, OOModel::Method* method, QList<OOModel::Method*> callees);
-
-		void adaptOutputForRelation(TupleSet& tupleSet, const QString& relationName, const QStringList& keepProperties);
+		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
+		virtual TupleSet execute(TupleSet) = 0;
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/Query.h
+++ b/InformationScripting/src/queries/Query.h
@@ -37,10 +37,6 @@ class INFORMATIONSCRIPTING_API Query
 	public:
 		virtual ~Query() = default;
 		virtual QList<TupleSet> execute(QList<TupleSet>) = 0;
-
-	protected:
-		template <class QueryClass>
-		using ExecuteFunction = std::function<QList<TupleSet> (QueryClass*, QList<TupleSet>)>;
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/ScopedArgumentQuery.h
+++ b/InformationScripting/src/queries/ScopedArgumentQuery.h
@@ -28,7 +28,7 @@
 
 #include "../informationscripting_api.h"
 
-#include "Query.h"
+#include "LinearQuery.h"
 
 namespace Model {
 	class Node;
@@ -39,7 +39,7 @@ class QCommandLineOption;
 
 namespace InformationScripting {
 
-class INFORMATIONSCRIPTING_API ScopedArgumentQuery : public Query
+class INFORMATIONSCRIPTING_API ScopedArgumentQuery : public LinearQuery
 {
 	protected:
 		enum class Scope : int {Local, Global, Input};

--- a/InformationScripting/src/queries/TagQuery.h
+++ b/InformationScripting/src/queries/TagQuery.h
@@ -40,7 +40,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API TagQuery : public ScopedArgumentQuery
 {
 	public:
-		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
+		virtual TupleSet execute(TupleSet input) override;
 
 		static void registerDefaultQueries();
 
@@ -50,14 +50,15 @@ class INFORMATIONSCRIPTING_API TagQuery : public ScopedArgumentQuery
 		static const QStringList REMOVE_ARGUMENT_NAMES;
 		static const QStringList PERSISTENT_ARGUMENT_NAMES;
 
-		ExecuteFunction<TagQuery> exec_{};
+		using ExecuteFunction = std::function<TupleSet (TagQuery*, TupleSet)>;
+		ExecuteFunction exec_{};
 		bool persistent_{true};
 
-		TagQuery(ExecuteFunction<TagQuery> exec, Model::Node* target, QStringList args);
-		QList<TupleSet> tags(QList<TupleSet> input);
-		QList<TupleSet> queryTags(QList<TupleSet> input);
-		QList<TupleSet> addTags(QList<TupleSet> input);
-		QList<TupleSet> removeTags(QList<TupleSet> input);
+		TagQuery(ExecuteFunction exec, Model::Node* target, QStringList args);
+		TupleSet tags(TupleSet input);
+		TupleSet queryTags(TupleSet input);
+		TupleSet addTags(TupleSet input);
+		TupleSet removeTags(TupleSet input);
 
 		void insertFoundTags(TupleSet& tuples, const Model::SymbolMatcher& matcher, Model::Node* target = nullptr);
 };


### PR DESCRIPTION
Note that will conflict with #159 because of the pro file. I will resolve the one you merge later.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/160%23discussion_r41271141%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/160%23discussion_r41271276%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/160%23discussion_r41271350%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/160%23discussion_r41271909%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/160%23issuecomment-145876634%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/160%23discussion_r41312612%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/160%23discussion_r41360823%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/160%23issuecomment-146116738%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/160%23issuecomment-145876634%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22That%27s%20all%20my%20comments.%20I%20like%20the%20change%2C%20it%20cleans%20things%20up%20a%20little%20bit.%22%2C%20%22created_at%22%3A%20%222015-10-06T14%3A38%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Changed%20the%20things%20we%20discussed%20by%20amending%20the%20commit.%5Cr%5Cn%5Cr%5CnI%20removed%20ExecuteFunction%20and%20LinearExecuteFunction%20aliases%20from%20Query/LinearQuery%20and%20added%20the%20aliases%20in%20the%20using%20classes%20%28TagQuery/AstQuery%29%22%2C%20%22created_at%22%3A%20%222015-10-07T08%3A34%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2073b5cd58d0b2d1ebc148025fdf06e8db5fa594b2%20InformationScripting/src/queries/LinearQuery.h%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/160%23discussion_r41271141%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22No%20need%20to%20make%20this%20final.%20If%20someone%20wants%20to%20implement%20a%20%5C%22better%5C%22%20version%20for%20their%20particular%20query%2C%20let%20them.%22%2C%20%22created_at%22%3A%20%222015-10-06T14%3A30%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/LinearQuery.h%3AL1-48%22%7D%2C%20%22Pull%2073b5cd58d0b2d1ebc148025fdf06e8db5fa594b2%20InformationScripting/src/queries/LinearQuery.h%2043%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/160%23discussion_r41271276%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20declare%20this%2C%20but%20don%27t%20use%20it%20anywhere%20in%20this%20class.%20This%20usually%20indicates%20that%20you%20should%20move%20the%20declaration%20to%20a%20different%20place.%20Why%20have%20it%20here%3F%22%2C%20%22created_at%22%3A%20%222015-10-06T14%3A31%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22All%20subclasses%20can%20easily%20use%20it.%22%2C%20%22created_at%22%3A%20%222015-10-06T14%3A32%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20then%2C%20why%20not%20add%20a%20constructor%20to%20this%20generic%20level%2C%20that%20accepts%20a%20%60LinearExecuteFunction%60%20and%20instead%20of%20having%20a%20pure%20virtual%20%60execute%60%2C%20implement%20a%20default%20one%20that%20uses%20%60Q_ASSERT%60%20to%20make%20sure%20the%20%60LinearExecuteFunction%60%20has%20been%20set%20and%20calls%20it.%20Otherwise%2C%20the%20user%20should%20provide%20their%20own%20%60execute%60.%22%2C%20%22created_at%22%3A%20%222015-10-06T14%3A36%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20that%20doesn%27t%20really%20work%20that%20simple.%20We%20would%20need%20to%20template%20the%20whole%20class%2C%20where%20the%20template%20arguments%20is%20the%20specific%20implementing%20class.%20This%20also%20is%20a%20bit%20complicated%20if%20a%20class%20is%20not%20a%20direct%20child%20class%20%28e.g.%20AstQuery%20%3C%3A%20ScopedArgumentQuery%20%3C%3A%20LinearQuery%29.%5Cr%5Cn%5Cr%5CnThe%20problem%20is%20that%20the%20exec_%20function%20is%20just%20a%20std%3A%3Afunction%20wrapper%20to%20a%20private%20member%20function%20and%20at%20creation%20you%20can%27t%20bind%20the%20instance%20%28see%20AstQuery%3A%3AregisterDefaultQueries%29%5Cr%5Cn%5Cr%5CnAny%20suggestion%20on%20how%20to%20solve%20this%2C%20since%20in%20general%20I%20like%20the%20idea.%22%2C%20%22created_at%22%3A%20%222015-10-06T19%3A47%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20I%20looked%20and%20couldn%27t%20find%20a%20good%20way%20of%20doing%20this%2C%20although%20I%20have%20a%20strong%20feeling%20I%27m%20missing%20something%2C%20and%20there%20should%20be%20a%20better%20way.%20In%20any%20case%2C%20you%20can%20leave%20the%20mechanism%20as%20it%20is.%5Cr%5Cn%5Cr%5CnBut%20I%20still%20think%20you%20should%20move%20this%20declaration%20%28and%20create%20two%20copies%20of%20it%29%2C%20into%20the%20most-derived%20classes%20that%20use%20it.%20In%20a%20sense%20this%20declaration%20is%20an%20implementation%20detail%20of%20those%20classes.%20I%20might%20make%20a%20different%20class%20where%20I%20choose%20to%20work%20with%20a%20big%20switch%20statement%20in%20the%20%60execute%60%20function%2C%20or%20do%20something%20else%20entirely%2C%20and%20this%20declaration%20will%20be%20of%20no%20use%20to%20me.%20Even%20though%20you%20will%20create%20two%20copies%20of%20it%2C%20by%20moving%20it%20up%2C%20I%20think%20that%27s%20fine%2C%20since%20those%20two%20copies%20are%20in%20a%20sense%20accidental.%20We%20just%20happen%20to%20implement%20the%20two%20different%20sources%20in%20a%20similar%20way.%22%2C%20%22created_at%22%3A%20%222015-10-07T07%3A52%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/LinearQuery.h%3AL1-48%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 73b5cd58d0b2d1ebc148025fdf06e8db5fa594b2 InformationScripting/src/queries/LinearQuery.h 38'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/160#discussion_r41271141'>File: InformationScripting/src/queries/LinearQuery.h:L1-48</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> No need to make this final. If someone wants to implement a "better" version for their particular query, let them.
- [x] <a href='#crh-comment-Pull 73b5cd58d0b2d1ebc148025fdf06e8db5fa594b2 InformationScripting/src/queries/LinearQuery.h 43'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/160#discussion_r41271276'>File: InformationScripting/src/queries/LinearQuery.h:L1-48</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You declare this, but don't use it anywhere in this class. This usually indicates that you should move the declaration to a different place. Why have it here?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> All subclasses can easily use it.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> But then, why not add a constructor to this generic level, that accepts a `LinearExecuteFunction` and instead of having a pure virtual `execute`, implement a default one that uses `Q_ASSERT` to make sure the `LinearExecuteFunction` has been set and calls it. Otherwise, the user should provide their own `execute`.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Hm that doesn't really work that simple. We would need to template the whole class, where the template arguments is the specific implementing class. This also is a bit complicated if a class is not a direct child class (e.g. AstQuery <: ScopedArgumentQuery <: LinearQuery).
  The problem is that the exec_ function is just a std::function wrapper to a private member function and at creation you can't bind the instance (see AstQuery::registerDefaultQueries)
  Any suggestion on how to solve this, since in general I like the idea.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> OK, I looked and couldn't find a good way of doing this, although I have a strong feeling I'm missing something, and there should be a better way. In any case, you can leave the mechanism as it is.
  But I still think you should move this declaration (and create two copies of it), into the most-derived classes that use it. In a sense this declaration is an implementation detail of those classes. I might make a different class where I choose to work with a big switch statement in the `execute` function, or do something else entirely, and this declaration will be of no use to me. Even though you will create two copies of it, by moving it up, I think that's fine, since those two copies are in a sense accidental. We just happen to implement the two different sources in a similar way.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/160#issuecomment-145876634'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> That's all my comments. I like the change, it cleans things up a little bit.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Changed the things we discussed by amending the commit.
  I removed ExecuteFunction and LinearExecuteFunction aliases from Query/LinearQuery and added the aliases in the using classes (TagQuery/AstQuery)

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/160?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/160?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/160'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
