### PR TITLE
Version control data source

### DIFF
--- a/FilePersistence/src/version_control/GitRepository.cpp
+++ b/FilePersistence/src/version_control/GitRepository.cpp
@@ -296,6 +296,7 @@ git_tree* GitRepository::getCommitTree(QString revision) const
 	auto gitCommit = parseCommit(revision);
 	auto errorCode = git_commit_tree(&gitTree, gitCommit);
 	checkError(errorCode);
+	git_commit_free(gitCommit);
 	return gitTree;
 }
 

--- a/FilePersistence/src/version_control/History.cpp
+++ b/FilePersistence/src/version_control/History.cpp
@@ -209,6 +209,7 @@ QSet<Model::NodeIdType> History::trackSubtree(QString revision, QString relative
 		Parser::load(startFile->content(), startFile->size_, false, tree->newPersistentUnit(relativePath));
 	}
 
+	tree->buildLookupHash();
 	GenericNode* subtreeRoot = tree->find(rootNodeId_);
 	if (!subtreeRoot)
 		return QSet<Model::NodeIdType>();

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -71,7 +71,8 @@ HEADERS += src/precompiled.h \
     src/visualization/VOperatorQueryNodeStyle.h \
     src/queries/LinearQuery.h \
     src/visualization/HighlightOverlay.h \
-    src/visualization/Heatmap.h
+    src/visualization/Heatmap.h \
+    src/queries/VersionControlQuery.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \
@@ -126,7 +127,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/visualization/VOperatorQueryNodeStyle.cpp \
     src/queries/LinearQuery.cpp \
     src/visualization/HighlightOverlay.cpp \
-    src/visualization/Heatmap.cpp
+    src/visualization/Heatmap.cpp \
+    src/queries/VersionControlQuery.cpp
 
 # Workaround to not have any pragma's in NodeApi.cpp
 # (because of unused local typedef in BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS):

--- a/InformationScripting/src/InformationScriptingPlugin.cpp
+++ b/InformationScripting/src/InformationScriptingPlugin.cpp
@@ -40,6 +40,7 @@
 #include "queries/AstNameFilter.h"
 #include "queries/AddASTPropertiesAsTuples.h"
 #include "queries/TagQuery.h"
+#include "queries/VersionControlQuery.h"
 #include "nodes/TagExtension.h"
 #include "visualization/Heatmap.h"
 #include "visualization/VCommandNode.h"
@@ -62,6 +63,7 @@ bool InformationScriptingPlugin::initialize(Core::EnvisionManager&)
 	AstNameFilter::registerDefaultQueries();
 	AddASTPropertiesAsTuples::registerDefaultQueries();
 	TagQuery::registerDefaultQueries();
+	VersionControlQuery::registerDefaultQueries();
 	Heatmap::registerDefaultQueries();
 	TagExtension::registerExtension();
 	Model::CompositeNode::registerNewExtension<TagExtension>();

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -55,9 +55,9 @@ TupleSet VersionControlQuery::executeLinear(TupleSet)
 	path.append(managerName);
 	// TODO user error later:
 	Q_ASSERT(GitRepository::repositoryExists(path));
-	auto repository = std::make_unique<GitRepository>(path);
+	GitRepository repository{path};
 
-	auto revisions = repository->revisions();
+	auto revisions = repository.revisions();
 	int commitIndexToTake = std::min(revisions.size() - 1, CHANGE_COUNT);
 	for (int i = commitIndexToTake; i > 0; --i)
 	{
@@ -65,7 +65,7 @@ TupleSet VersionControlQuery::executeLinear(TupleSet)
 		QString oldCommitId = revisions[i];
 		QString newCommitId = revisions[i - 1];
 
-		Diff diff = repository->diff(newCommitId, oldCommitId);
+		Diff diff = repository.diff(newCommitId, oldCommitId);
 		auto changes = diff.changes();
 
 		for (auto change : changes.values())

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -1,0 +1,112 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "VersionControlQuery.h"
+
+#include "QueryRegistry.h"
+
+#include "ModelBase/src/model/TreeManager.h"
+
+#include "FilePersistence/src/simple/SimpleTextFileStore.h"
+#include "FilePersistence/src/version_control/GitRepository.h"
+
+#include "ModelBase/src/nodes/Node.h"
+#include "OOModel/src/elements/StatementItem.h"
+
+using namespace FilePersistence;
+
+namespace InformationScripting {
+
+TupleSet VersionControlQuery::executeLinear(TupleSet)
+{
+	// FIXME use argument for this value:
+	const int CHANGE_COUNT{10};
+	QHash<Model::Node*, int> changeCount;
+
+	Model::TreeManager* treeManager = target()->manager();
+	QString managerName = treeManager->name();
+
+	// get GitRepository
+	QString path("projects/");
+	path.append(managerName);
+	// TODO user error later:
+	Q_ASSERT(GitRepository::repositoryExists(path));
+	auto repository = std::make_unique<GitRepository>(path);
+
+	auto revisions = repository->revisions();
+	int commitIndexToTake = std::min(revisions.size() - 1, CHANGE_COUNT);
+	for (int i = commitIndexToTake; i > 0; --i)
+	{
+		QSet<Model::Node*> changedNodes;
+		QString oldCommitId = revisions[i];
+		QString newCommitId = revisions[i - 1];
+
+		Diff diff = repository->diff(newCommitId, oldCommitId);
+		auto changes = diff.changes();
+
+		for (auto change : changes.values())
+		{
+			// We ignore stationary changes since a node with a stationary change, has a child which was deleted or added,
+			// and this child will appear in the final representation.
+			if (change->isFake() || change->type() == ChangeType::Stationary) continue;
+
+			auto id = change->nodeId();
+			// FIXME: here we just use the first StatementItem parent we should solve that better later.
+			if (auto node = const_cast<Model::Node*>(treeManager->nodeIdMap().node(id)))
+			{
+				if (auto statement = node->firstAncestorOfType<OOModel::StatementItem>())
+					changedNodes.insert(statement);
+				else if (auto statement = DCast<OOModel::StatementItem>(node))
+					changedNodes.insert(statement);
+				else // The node is hopefully higher up in the node hierarchy thus we take it as is.
+					changedNodes.insert(node);
+			}
+		}
+
+		for (auto changedNode : changedNodes)
+			if (changedNode) ++changeCount[changedNode];
+	}
+
+	TupleSet result;
+
+	for (auto it = changeCount.begin(); it != changeCount.end(); ++it)
+		result.add({{"count", it.value()}, {"ast", it.key()}});
+
+	return result;
+}
+
+void VersionControlQuery::registerDefaultQueries()
+{
+	QueryRegistry::instance().registerQueryConstructor("changes", [](Model::Node* target, QStringList args) {
+		return new VersionControlQuery(target, args);
+	});
+}
+
+VersionControlQuery::VersionControlQuery(Model::Node* target, QStringList args)
+	: ScopedArgumentQuery{target, {}, QStringList{"VersionControl"} + args}
+{}
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -70,9 +70,9 @@ TupleSet VersionControlQuery::executeLinear(TupleSet)
 
 		for (auto change : changes.values())
 		{
-			// We ignore stationary changes since a node with a stationary change, has a child which was deleted or added,
-			// and this child will appear in the final representation.
-			if (change->isFake() || change->type() == ChangeType::Stationary) continue;
+			// We ignore structure only changes since a node with a structure only change,
+			// has a child which was deleted or added or modified, and this child will appear in the final representation.
+			if (change->isFake() || change->onlyStructureChange()) continue;
 
 			auto id = change->nodeId();
 			// FIXME: here we just use the first StatementItem parent we should solve that better later.

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -40,10 +40,11 @@ using namespace FilePersistence;
 
 namespace InformationScripting {
 
+const QStringList VersionControlQuery::COUNT_ARGUMENT_NAMES{"c", "count"};
+
 TupleSet VersionControlQuery::executeLinear(TupleSet)
 {
-	// FIXME use argument for this value:
-	const int CHANGE_COUNT{10};
+	const int CHANGE_COUNT = argument(COUNT_ARGUMENT_NAMES[0]).toInt();
 	QHash<Model::Node*, int> changeCount;
 
 	Model::TreeManager* treeManager = target()->manager();
@@ -106,7 +107,9 @@ void VersionControlQuery::registerDefaultQueries()
 }
 
 VersionControlQuery::VersionControlQuery(Model::Node* target, QStringList args)
-	: ScopedArgumentQuery{target, {}, QStringList{"VersionControl"} + args}
+	: ScopedArgumentQuery{target, {
+		{COUNT_ARGUMENT_NAMES, "The amount of revision to look at", COUNT_ARGUMENT_NAMES[1], "10"}
+	}, QStringList{"VersionControl"} + args}
 {}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/VersionControlQuery.h
+++ b/InformationScripting/src/queries/VersionControlQuery.h
@@ -1,0 +1,45 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../informationscripting_api.h"
+
+#include "ScopedArgumentQuery.h"
+
+namespace InformationScripting {
+
+class INFORMATIONSCRIPTING_API VersionControlQuery : public ScopedArgumentQuery
+{
+	public:
+		virtual TupleSet executeLinear(TupleSet input) override;
+
+		static void registerDefaultQueries();
+	private:
+		VersionControlQuery(Model::Node* target, QStringList args);
+};
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/VersionControlQuery.h
+++ b/InformationScripting/src/queries/VersionControlQuery.h
@@ -39,6 +39,8 @@ class INFORMATIONSCRIPTING_API VersionControlQuery : public ScopedArgumentQuery
 
 		static void registerDefaultQueries();
 	private:
+		static const QStringList COUNT_ARGUMENT_NAMES;
+
 		VersionControlQuery(Model::Node* target, QStringList args);
 };
 

--- a/InformationScripting/src/visualization/Heatmap.cpp
+++ b/InformationScripting/src/visualization/Heatmap.cpp
@@ -79,6 +79,7 @@ QColor Heatmap::colorForValue(int value)
 	// First we need to calculate a index (i.e. factor) in the range. This we do with the following formula:
 	// minVal + colorFactor * range == value, thus colorFactor == (value - minVal) / range.
 	auto range = valueRange_.second - valueRange_.first;
+	if (range == 0) return {"red"};
 	double colorFactor = (double (value - valueRange_.first)) / range;
 	// The colorFactor can now be used to return a color based on the baseColor: (red + and green minus)
 	int red = baseColor_.red();

--- a/InformationScripting/src/visualization/HighlightOverlay.cpp
+++ b/InformationScripting/src/visualization/HighlightOverlay.cpp
@@ -30,6 +30,6 @@ namespace InformationScripting {
 
 ITEM_COMMON_DEFINITIONS(HighlightOverlay, "item")
 
-HighlightOverlay::HighlightOverlay(Item* selectedItem, const StyleType* style)  : Super{{selectedItem}, style} {}
+HighlightOverlay::HighlightOverlay(Item* selectedItem, const StyleType* style)  : Super{selectedItem, style} {}
 
 } /* namespace InformationScripting */


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/168%23discussion_r41978439%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/168%23discussion_r41978510%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/168%23discussion_r41978646%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/168%23issuecomment-148010761%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/168%23issuecomment-148011161%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/168%23discussion_r41979721%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/168%23discussion_r41980582%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/168%23issuecomment-148023298%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/168%23issuecomment-148010761%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Nice%2C%20only%20two%20minor%20issues.%20Look%20at%20those%20and%20I%27ll%20merge%20it.%22%2C%20%22created_at%22%3A%20%222015-10-14T10%3A45%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%27s%20also%20nice%20to%20see%20that%20this%20was%20rather%20straightforward%20to%20do.%20Among%20other%20things%2C%20this%20means%20that%20the%20queries%20system%20is%20well%20designed%20and%20easy%20to%20extend.%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-10-14T10%3A46%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20the%202%20small%20issues.%20User%20error%20feedback%20is%20definitely%20for%20later%20%28we%20already%20discussed%20a%20solution%20btw%29.%22%2C%20%22created_at%22%3A%20%222015-10-14T11%3A30%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%200b28104c39021620bb1615f62fb32672fdc6392c%20InformationScripting/src/queries/VersionControlQuery.cpp%2058%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/168%23discussion_r41978510%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20not%20simply%3A%20%60GitRepository%20repository%7Bpath%7D%60.%20Why%20do%20we%20need%20a%20unique%20pointer%3F%22%2C%20%22created_at%22%3A%20%222015-10-14T10%3A42%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/VersionControlQuery.cpp%3AL1-116%22%7D%2C%20%22Pull%200b28104c39021620bb1615f62fb32672fdc6392c%20InformationScripting/src/queries/VersionControlQuery.cpp%2056%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/168%23discussion_r41978439%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20at%20some%20point%20we%20should%20actually%20come%20up%20with%20a%20mechanism%20to%20report%20these%20errors.%22%2C%20%22created_at%22%3A%20%222015-10-14T10%3A41%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/VersionControlQuery.cpp%3AL1-116%22%7D%2C%20%22Pull%200b28104c39021620bb1615f62fb32672fdc6392c%20InformationScripting/src/queries/VersionControlQuery.cpp%2073%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/168%23discussion_r41978646%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Or%20modified.%20Renaming%20a%20class%20for%20example%20is%20a%20stationary%20change%2C%20but%20there%20are%20no%20added/deleted%20children.%22%2C%20%22created_at%22%3A%20%222015-10-14T10%3A44%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20problem%20here%20is%20a%20child%20change%20is%20detected%20as%20stationary%20change%20as%20well.%20%5Cr%5CnFor%20example%20if%20I%20change%20a%20statement%20in%20a%20StatementItemList%20the%20list%20will%20appear%20as%20a%20stationary%20change%2C%20which%20I%20don%27t%20like%20for%20this%20purpose.%22%2C%20%22created_at%22%3A%20%222015-10-14T10%3A58%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20there%20is%20a%20way%20to%20check%20for%20that%20specifically.%20use%20%60onlyStructureChange%60%20and%20discard%20changes%20where%20this%20is%20true.%22%2C%20%22created_at%22%3A%20%222015-10-14T11%3A09%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/VersionControlQuery.cpp%3AL1-116%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 0b28104c39021620bb1615f62fb32672fdc6392c InformationScripting/src/queries/VersionControlQuery.cpp 56'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/168#discussion_r41978439'>File: InformationScripting/src/queries/VersionControlQuery.cpp:L1-116</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, at some point we should actually come up with a mechanism to report these errors.
- [x] <a href='#crh-comment-Pull 0b28104c39021620bb1615f62fb32672fdc6392c InformationScripting/src/queries/VersionControlQuery.cpp 58'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/168#discussion_r41978510'>File: InformationScripting/src/queries/VersionControlQuery.cpp:L1-116</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why not simply: `GitRepository repository{path}`. Why do we need a unique pointer?
- [x] <a href='#crh-comment-Pull 0b28104c39021620bb1615f62fb32672fdc6392c InformationScripting/src/queries/VersionControlQuery.cpp 73'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/168#discussion_r41978646'>File: InformationScripting/src/queries/VersionControlQuery.cpp:L1-116</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Or modified. Renaming a class for example is a stationary change, but there are no added/deleted children.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> The problem here is a child change is detected as stationary change as well.
  For example if I change a statement in a StatementItemList the list will appear as a stationary change, which I don't like for this purpose.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> But there is a way to check for that specifically. use `onlyStructureChange` and discard changes where this is true.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/168#issuecomment-148010761'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Nice, only two minor issues. Look at those and I'll merge it.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> It's also nice to see that this was rather straightforward to do. Among other things, this means that the queries system is well designed and easy to extend. :)
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Fixed the 2 small issues. User error feedback is definitely for later (we already discussed a solution btw).

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/168?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/168?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/168'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
