### PR TITLE
Scripting various improvements

### DIFF
--- a/InformationScripting/src/dataformat/Property.cpp
+++ b/InformationScripting/src/dataformat/Property.cpp
@@ -30,6 +30,7 @@ namespace InformationScripting {
 
 boost::python::object pythonObject(const Property& p)
 {
+	if (!p.data_) return boost::python::object();
 	return p.data_->pythonObject();
 }
 

--- a/InformationScripting/src/queries/AddASTPropertiesAsTuples.cpp
+++ b/InformationScripting/src/queries/AddASTPropertiesAsTuples.cpp
@@ -32,10 +32,9 @@
 
 namespace InformationScripting {
 
-QList<TupleSet> AddASTPropertiesAsTuples::execute(QList<TupleSet> input)
+TupleSet AddASTPropertiesAsTuples::executeLinear(TupleSet input)
 {
-	for (auto& ts : input)
-		ts.addPropertiesAsTuples<Model::Node*>("ast");
+	input.addPropertiesAsTuples<Model::Node*>("ast");
 	return input;
 }
 

--- a/InformationScripting/src/queries/AddASTPropertiesAsTuples.h
+++ b/InformationScripting/src/queries/AddASTPropertiesAsTuples.h
@@ -28,14 +28,14 @@
 
 #include "../informationscripting_api.h"
 
-#include "Query.h"
+#include "LinearQuery.h"
 
 namespace InformationScripting {
 
-class INFORMATIONSCRIPTING_API AddASTPropertiesAsTuples : public Query
+class INFORMATIONSCRIPTING_API AddASTPropertiesAsTuples : public LinearQuery
 {
 	public:
-		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
+		virtual TupleSet executeLinear(TupleSet input) override;
 
 		static void registerDefaultQueries();
 };

--- a/InformationScripting/src/queries/AstNameFilter.cpp
+++ b/InformationScripting/src/queries/AstNameFilter.cpp
@@ -40,14 +40,7 @@ AstNameFilter::AstNameFilter(Model::SymbolMatcher matcher)
 			if (it != t.end())
 			{
 				Model::Node* astNode = it->second;
-				if (auto compositeNode = DCast<Model::CompositeNode>(astNode))
-				{
-					if (compositeNode->hasAttribute("name"))
-					{
-						if (auto nameText = DCast<Model::Text>(compositeNode->get("name")))
-							return matcher.matches(nameText->get());
-					}
-				}
+				return !astNode->symbolName().isEmpty() && matcher.matches(astNode->symbolName());
 			}
 			return false;
 		}
@@ -57,14 +50,8 @@ AstNameFilter::AstNameFilter(Model::SymbolMatcher matcher)
 void AstNameFilter::registerDefaultQueries()
 {
 	QueryRegistry::instance().registerQueryConstructor("filter", [](Model::Node*, QStringList args) {
-		Q_ASSERT(args.size());
-		if (args[0].contains("*"))
-		{
-			QString regexString = args[0];
-			regexString.replace("*", "\\w*");
-			return new AstNameFilter(Model::SymbolMatcher(new QRegExp(regexString)));
-		}
-		return new AstNameFilter(Model::SymbolMatcher(args[0]));
+		Q_ASSERT(args.size() > 0);
+		return new AstNameFilter(Model::SymbolMatcher::guessMatcher(args[0]));
 	});
 }
 

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -69,40 +69,32 @@ TupleSet AstQuery::executeLinear(TupleSet input)
 
 void AstQuery::registerDefaultQueries()
 {
-	auto& registry = QueryRegistry::instance();
-	registry.registerQueryConstructor("classes", [](Model::Node* target, QStringList args) {
+	QueryRegistry::instance().registerQueryConstructor("classes", [](Model::Node* target, QStringList args) {
 		setTypeTo(args, "Class");
 		return new AstQuery(&AstQuery::genericQuery, target, args);
 	});
-	registry.registerQueryConstructor("methods", [](Model::Node* target, QStringList args) {
+	QueryRegistry::instance().registerQueryConstructor("methods", [](Model::Node* target, QStringList args) {
 		setTypeTo(args, "Method");
 		return new AstQuery(&AstQuery::genericQuery, target, args);
 	});
-	registry.registerQueryConstructor("bases", [](Model::Node* target, QStringList args) {
-		return new AstQuery(&AstQuery::baseClassesQuery, target, args);
-	});
-	registry.registerQueryConstructor("toClass", [](Model::Node* target, QStringList args) {
+	QueryRegistry::instance().registerQueryConstructor("toClass", [](Model::Node* target, QStringList args) {
 		setTypeTo(args, "Class");
 		return new AstQuery(&AstQuery::toParentType, target, args);
 	});
-	registry.registerQueryConstructor("callgraph", [](Model::Node* target, QStringList args) {
-		return new AstQuery(&AstQuery::callGraph, target, args);
-	});
-	registry.registerQueryConstructor("ast", [](Model::Node* target, QStringList args) {
-		return new AstQuery(&AstQuery::genericQuery, target, args);
-	});
-	registry.registerQueryConstructor("toParent", [](Model::Node* target, QStringList args) {
-		return new AstQuery(&AstQuery::toParentType, target, args);
-	});
-	registry.registerQueryConstructor("uses", [](Model::Node* target, QStringList args) {
-		return new AstQuery(&AstQuery::usesQuery, target, args);
-	});
-	registry.registerQueryConstructor("type", [](Model::Node* target, QStringList args) {
-		return new AstQuery(&AstQuery::typeFilter, target, args);
-	});
-	registry.registerQueryConstructor("attribute", [](Model::Node* target, QStringList args) {
-		return new AstQuery(&AstQuery::attribute, target, args);
-	});
+
+	auto registerQuery = [](const QString& name, auto methodToCall) {
+		QueryRegistry::instance().registerQueryConstructor(name, [methodToCall](Model::Node* target, QStringList args) {
+				return new AstQuery(methodToCall, target, args);
+		});
+	};
+
+	registerQuery("bases", &AstQuery::baseClassesQuery);
+	registerQuery("callgraph", &AstQuery::callGraph);
+	registerQuery("ast", &AstQuery::genericQuery);
+	registerQuery("toParent", &AstQuery::toParentType);
+	registerQuery("uses", &AstQuery::usesQuery);
+	registerQuery("type", &AstQuery::typeFilter);
+	registerQuery("attribute", &AstQuery::attribute);
 }
 
 void AstQuery::setTypeTo(QStringList& args, QString type)

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -56,6 +56,7 @@ class INFORMATIONSCRIPTING_API AstQuery : public ScopedArgumentQuery
 		static const QStringList NODETYPE_ARGUMENT_NAMES;
 		static const QStringList NAME_ARGUMENT_NAMES;
 		static const QStringList ADD_AS_NAMES;
+		static const QStringList ATTRIBUTE_NAME_NAMES;
 
 		using ExecuteFunction = std::function<TupleSet (AstQuery*, TupleSet)>;
 		ExecuteFunction exec_{};
@@ -72,6 +73,7 @@ class INFORMATIONSCRIPTING_API AstQuery : public ScopedArgumentQuery
 		TupleSet nameQuery(TupleSet input, QString name);
 		TupleSet usesQuery(TupleSet input);
 		TupleSet typeFilter(TupleSet input);
+		TupleSet attribute(TupleSet input);
 
 		void addBaseEdgesFor(OOModel::Class* childClass, NamedProperty& classNode, TupleSet& ts);
 		void addNodesOfType(TupleSet& ts, const Model::SymbolMatcher& matcher, Model::Node* from = nullptr);

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -85,6 +85,8 @@ class INFORMATIONSCRIPTING_API AstQuery : public ScopedArgumentQuery
 
 		static bool matchesExpectedType(Model::Node* node, Model::Node::SymbolType symbolType,
 										 const QString& expectedType, const QStringList& args);
+
+		static void registerQuery(const QString& name, ExecuteFunction methodToCall, const QString& setTypeTo = {});
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/GenericFilter.cpp
+++ b/InformationScripting/src/queries/GenericFilter.cpp
@@ -31,16 +31,11 @@ namespace InformationScripting {
 GenericFilter::GenericFilter(GenericFilter::KeepTuple f) : keepTuple_{f}
 {}
 
-QList<TupleSet> GenericFilter::execute(QList<TupleSet> input)
+TupleSet GenericFilter::executeLinear(TupleSet input)
 {
-	for (auto& t : input) applyFilter(t);
+	for (const auto& t : input.tuples())
+		if (!keepTuple_(t)) input.remove(t);
 	return input;
-}
-
-void GenericFilter::applyFilter(TupleSet& set)
-{
-	for (auto t : set.tuples())
-		if (!keepTuple_(t)) set.remove(t);
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/GenericFilter.h
+++ b/InformationScripting/src/queries/GenericFilter.h
@@ -28,24 +28,22 @@
 
 #include "../informationscripting_api.h"
 
-#include "Query.h"
+#include "LinearQuery.h"
 
 namespace InformationScripting {
 
 class InformationNode;
 
-class INFORMATIONSCRIPTING_API GenericFilter : public Query
+class INFORMATIONSCRIPTING_API GenericFilter : public LinearQuery
 {
 	public:
 		using KeepTuple = std::function<bool(const Tuple&)>;
 		GenericFilter(KeepTuple f);
 
-		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
+		virtual TupleSet executeLinear(TupleSet input) override;
 
 	private:
 		KeepTuple keepTuple_;
-
-		void applyFilter(TupleSet& set);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/test/scripts/filterCasts.py
+++ b/InformationScripting/test/scripts/filterCasts.py
@@ -1,19 +1,21 @@
-#$<"<ast -s=g -t=CastExpression>" | "<uses -s=of -t=Class>" | "<filterCasts>">$
-import AstApi
-from DataApi import Tuple, NamedProperty
+#script "<filterCasts>"
 
-def checkClass( cl ):
+casts = Query.ast(["-t=CastExpression"] + args, [])
+castTypeAttributes = Query.attribute(["-at=castType", "-s=of"], casts)
+classUses = Query.uses(["-s=of", "-t=Class"], castTypeAttributes)
+
+def hasTypeIdMethod( cl ):
     for method in cl.methods:
         if method.name == "typeIdStatic":
             return True
     return False
 
-results = [];
+result = TupleSet()
 
-for ts in inputs:
-    tuples = ts.tuples("uses")
-    for tuple in tuples:
-        if not checkClass(tuple.used):
-            removeTuple = Tuple([NamedProperty("ast", tuple.user)])
-            ts.remove(removeTuple)
-    results.append(ts) 
+for tuple in classUses[0].tuples("uses"):
+    if hasTypeIdMethod(tuple.used):
+        values = [NamedProperty("ast", tuple.user)]
+        result.add(Tuple(values))
+
+results = Query.toParent(["-t=CastExpression"], [result]) 
+


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/170%23discussion_r41979884%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/170%23discussion_r41979997%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/170%23discussion_r41980089%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/170%23issuecomment-148021579%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/170%23discussion_r41981761%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/170%23issuecomment-148021579%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Fix%20the%203%20comments%20you%20had%20with%20a%20small%20commit.%22%2C%20%22created_at%22%3A%20%222015-10-14T11%3A19%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ab4b27f259b36fd2da4e996b195fb4df1a577e55%20InformationScripting/src/queries/AstQuery.cpp%2078%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/170%23discussion_r41979997%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Move%20this%20right%20before%20the%20lambda%20definition.%22%2C%20%22created_at%22%3A%20%222015-10-14T11%3A01%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstQuery.cpp%3AL347-397%22%7D%2C%20%22Pull%2020ba845e9a2271dba22dd0e784e569432bc3fdac%20InformationScripting/src/queries/AstQuery.h%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/170%23discussion_r41981761%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22A%20null%20string%20is%20better.%20Use%20%60%7B%7D%60%20instead%20of%20%60%5C%22%5C%22%60.%20The%20in%20the%20implementation%20use%20%60isNull%60%20instead%20of%20%60isEmpty%60.%22%2C%20%22created_at%22%3A%20%222015-10-14T11%3A24%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstQuery.h%3AL85-93%22%7D%2C%20%22Pull%20ab4b27f259b36fd2da4e996b195fb4df1a577e55%20InformationScripting/src/queries/AstQuery.cpp%2077%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/170%23discussion_r41980089%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Move%20this%20right%20before%20the%20%60if%28scope%28%29...%60.%5Cr%5Cn%5Cr%5CnIn%20general%2C%20definitions%20should%20also%20be%20immediately%20after%20first%20use.%22%2C%20%22created_at%22%3A%20%222015-10-14T11%3A02%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstQuery.cpp%3AL347-397%22%7D%2C%20%22Pull%20ab4b27f259b36fd2da4e996b195fb4df1a577e55%20InformationScripting/src/queries/AstQuery.cpp%2055%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/170%23discussion_r41979884%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20put%20this%20lambda%20on%20top%2C%20and%20add%20another%20string%20argument%2C%20which%20if%20not%20null%20will%20be%20used%20in%20a%20call%20to%20%60setTypeTo%28args%2C%20argument%29%60.%20This%20way%20you%20can%20do%20all%20of%20the%20registrations%20using%20the%20lambda.%5Cr%5Cn%5Cr%5CnSince%20lambdas%20cannot%20have%20default%20arguments%2C%20you%20can%20consider%20also%20making%20a%20private%20static%20function%20instead%20and%20settings%20the%20last%20argument%20to%20be%20a%20null%20QString%20by%20default.%22%2C%20%22created_at%22%3A%20%222015-10-14T10%3A59%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/AstQuery.cpp%3AL69-101%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull ab4b27f259b36fd2da4e996b195fb4df1a577e55 InformationScripting/src/queries/AstQuery.cpp 55'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/170#discussion_r41979884'>File: InformationScripting/src/queries/AstQuery.cpp:L69-101</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I would put this lambda on top, and add another string argument, which if not null will be used in a call to `setTypeTo(args, argument)`. This way you can do all of the registrations using the lambda.
  Since lambdas cannot have default arguments, you can consider also making a private static function instead and settings the last argument to be a null QString by default.
- [x] <a href='#crh-comment-Pull ab4b27f259b36fd2da4e996b195fb4df1a577e55 InformationScripting/src/queries/AstQuery.cpp 78'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/170#discussion_r41979997'>File: InformationScripting/src/queries/AstQuery.cpp:L347-397</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Move this right before the lambda definition.
- [x] <a href='#crh-comment-Pull ab4b27f259b36fd2da4e996b195fb4df1a577e55 InformationScripting/src/queries/AstQuery.cpp 77'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/170#discussion_r41980089'>File: InformationScripting/src/queries/AstQuery.cpp:L347-397</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Move this right before the `if(scope()...`.
  In general, definitions should also be immediately after first use.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/170#issuecomment-148021579'>General Comment</a></b>
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Fix the 3 comments you had with a small commit.
- [x] <a href='#crh-comment-Pull 20ba845e9a2271dba22dd0e784e569432bc3fdac InformationScripting/src/queries/AstQuery.h 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/170#discussion_r41981761'>File: InformationScripting/src/queries/AstQuery.h:L85-93</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> A null string is better. Use `{}` instead of `""`. The in the implementation use `isNull` instead of `isEmpty`.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/170?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/170?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/170'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
