### PR TITLE
Manipulating queries

### DIFF
--- a/InformationScripting/src/dataformat/TupleSet.cpp
+++ b/InformationScripting/src/dataformat/TupleSet.cpp
@@ -28,6 +28,11 @@
 
 namespace InformationScripting {
 
+TupleSet::TupleSet(const QList<Tuple>& initialTuples)
+{
+	for (const auto& t : initialTuples) add(t);
+}
+
 QSet<Tuple> TupleSet::tuples(const QString& tag) const
 {
 	return tuples_[tag];

--- a/InformationScripting/src/dataformat/TupleSet.h
+++ b/InformationScripting/src/dataformat/TupleSet.h
@@ -35,6 +35,9 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API TupleSet
 {
 	public:
+		TupleSet() = default;
+		TupleSet(const QList<Tuple>& initialTuples);
+
 		template<class Condition>
 		QSet<Tuple> tuples(Condition condition) const;
 		/**

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -75,6 +75,8 @@ class INFORMATIONSCRIPTING_API AstQuery : public ScopedArgumentQuery
 		TupleSet typeFilter(TupleSet input);
 		TupleSet attribute(TupleSet input);
 
+		TupleSet modify(TupleSet input);
+
 		void addBaseEdgesFor(OOModel::Class* childClass, NamedProperty& classNode, TupleSet& ts);
 		void addNodesOfType(TupleSet& ts, const Model::SymbolMatcher& matcher, Model::Node* from = nullptr);
 		template <class Predicate>

--- a/InformationScripting/src/wrappers/DataApi.cpp
+++ b/InformationScripting/src/wrappers/DataApi.cpp
@@ -57,7 +57,12 @@ NamedProperty tuple_getItem(Tuple &t, int index)
 
 std::shared_ptr<Tuple> makeTuple(list args) {
 	stl_input_iterator<NamedProperty> begin(args), end;
-	return std::shared_ptr<Tuple>{new Tuple{QList<NamedProperty>::fromStdList(std::list<NamedProperty>(begin, end))}};
+	return std::make_shared<Tuple>(QList<NamedProperty>::fromStdList(std::list<NamedProperty>(begin, end)));
+}
+
+std::shared_ptr<TupleSet> makeTupleSet(list args) {
+	stl_input_iterator<Tuple> begin(args), end;
+	return std::make_shared<TupleSet>(QList<Tuple>::fromStdList(std::list<Tuple>(begin, end)));
 }
 
 BOOST_PYTHON_MODULE(DataApi) {
@@ -89,7 +94,8 @@ BOOST_PYTHON_MODULE(DataApi) {
 		QSet<Tuple> (TupleSet::*take1)(const QString&) = &TupleSet::take;
 		void (TupleSet::*removeTuple)(const Tuple&) = &TupleSet::remove;
 
-		class_<TupleSet>("TupleSet")
+		class_<TupleSet>("TupleSet", init<>())
+				.def("__init__", make_constructor(makeTupleSet))
 				.def("tuples", tuplesAll)
 				.def("tuples", tuplesString)
 				.def("take", take1)

--- a/InformationScripting/test/scripts/filterCasts.py
+++ b/InformationScripting/test/scripts/filterCasts.py
@@ -17,5 +17,4 @@ for tuple in classUses[0].tuples("uses"):
         values = [NamedProperty("ast", tuple.user)]
         result.add(Tuple(values))
 
-results = Query.toParent(["-t=CastExpression"], [result]) 
-
+results = Query.toParent(["-t=CastExpression", "-addAs=node"], [result]) 

--- a/InformationScripting/test/scripts/replaceCasts.py
+++ b/InformationScripting/test/scripts/replaceCasts.py
@@ -1,0 +1,27 @@
+#script $<"<replaceCasts>" | "<modify>">$
+#script $<"<replaceCasts>" | "<debug>">$
+
+casts = Query.ast(["-t=CastExpression"] + args, [])
+castTypeAttributes = Query.attribute(["-at=castType", "-s=of"], casts)
+classUses = Query.uses(["-s=of", "-t=Class"], castTypeAttributes)
+
+def hasTypeIdMethod( cl ):
+    for method in cl.methods:
+        if method.name == "typeIdStatic":
+            return True
+    return False
+
+result = TupleSet()
+
+for tuple in classUses[0].tuples("uses"):
+    if hasTypeIdMethod(tuple.used):
+        ## Get parent of type CastExpression
+        castTuples = TupleSet([Tuple([NamedProperty("ast", tuple.user)])])
+        castTuples = Query.toParent(["-t=CastExpression", "-addAs=node"], [castTuples])[0]
+        for castTuple in castTuples.take("ast"):
+            cast = castTuple.ast
+            castTo = tuple.used.name
+            newExpr = 'DCast<{}>()'.format(castTo)
+            result.add(Tuple([NamedProperty("replace", cast), NamedProperty("with", newExpr), NamedProperty("keepAsarguments", "expr")]))
+
+results.append(result)


### PR DESCRIPTION
This is the current suggestion for how a modifying query could look like. It should serve as a base for discussion.

When considering more cases a more general format for the Tuple given to the modify method could make sense:
- if to while:<br>
  (modify, <ifNode>), (replaceWith, while), (keep, condition), (as, condition), (keep, thenBranch), (as, body)<br>
  however this format is not allowed since a key can only appear once, maybe a more condensed format could work:<br>
  (modify, <ifNode>), (replaceWith, while), (keepCondition, condition), (keepThenBranch, body)
- swap if else:<br>
  (modify, <ifNode>), (swapThenBranch, elseBranch)
- According to this new format the replace casts would be written as follows
  (modify, <castNode>), (replaceWith, DCast<...>()), (keepExpr, arguments)
- Extract method:<br>
  (modify, <nodes to extract>), (extractAsMethod, methodName)
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/171%23issuecomment-148335625%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/171%23issuecomment-148673711%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/171%23issuecomment-148690484%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/171%23issuecomment-148335625%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20I%20don%27t%20like%20specializing%20the%20tuples%20so%20much.%20In%20particular%20we%20shouldn%27t%20have%20things%20like%20keepCondition/keepThenBranch%20and%20especially%20no%20things%20like%20extractAsMethod%2C%20since%20this%20is%20too%20high-level.%20We%20want%20to%20empower%20developers%20to%20write%20something%20like%20extractAsMethod%2C%20not%20do%20it%20for%20them%20like%20all%20other%20tools%20out%20there.%5Cr%5Cn%5Cr%5CnHow%20does%20the%20replaceWith%20work%3F%20Does%20it%20take%20a%20node%20or%20a%20string%20or%20what%3F%5Cr%5Cn%5Cr%5CnAnd%20how%20does%20the%20last%20modify%20work%20%28with%20%3Cnodes%20to%20extract%3E%29.%20Is%20that%20a%20list%3F%20I%20thought%20modify%20takes%20a%20single%20ast%20node.%5Cr%5Cn%5Cr%5CnNow%20that%20I%20think%20about%20it%2C%20I%27m%20not%20sure%20that%20using%20tuples%20as%20modifications%20command%20is%20the%20best%20choice.%20Perhaps%20tuples%20can%20be%20used%20to%20inform%20a%20python%20script%20which%20does%20the%20modifications%2C%20using%20some%20other%2C%20more%20intuitive%20API.%22%2C%20%22created_at%22%3A%20%222015-10-15T09%3A41%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Do%20we%20need%20to%20keep%20this%20pull%20request%20alive%2C%20will%20you%20update%20this%20one%20or%20create%20a%20new%20one%20later%3F%22%2C%20%22created_at%22%3A%20%222015-10-16T10%3A05%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Closing.%20Will%20use%20a%20new%20PR%20for%20this%20feature.%22%2C%20%22created_at%22%3A%20%222015-10-16T11%3A31%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/171#issuecomment-148335625'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, I don't like specializing the tuples so much. In particular we shouldn't have things like keepCondition/keepThenBranch and especially no things like extractAsMethod, since this is too high-level. We want to empower developers to write something like extractAsMethod, not do it for them like all other tools out there.
  How does the replaceWith work? Does it take a node or a string or what?
  And how does the last modify work (with <nodes to extract>). Is that a list? I thought modify takes a single ast node.
  Now that I think about it, I'm not sure that using tuples as modifications command is the best choice. Perhaps tuples can be used to inform a python script which does the modifications, using some other, more intuitive API.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Do we need to keep this pull request alive, will you update this one or create a new one later?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Closing. Will use a new PR for this feature.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/171?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/171?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/171'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
