### PR TITLE
Proposal how to deal with runtime errors in queries

### DIFF
--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -76,7 +76,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 		args.prepend(command);
 		auto q = QueryParser::buildQueryFrom(args.join(""), node);
 		QueryExecutor queryExecutor(q);
-		queryExecutor.execute();
+		return queryExecutor.execute();
 	}
 	else
 	{

--- a/InformationScripting/src/dataformat/TupleSet.cpp
+++ b/InformationScripting/src/dataformat/TupleSet.cpp
@@ -28,6 +28,11 @@
 
 namespace InformationScripting {
 
+TupleSet::TupleSet(const Tuple& t)
+{
+	add(t);
+}
+
 QSet<Tuple> TupleSet::tuples(const QString& tag) const
 {
 	return tuples_[tag];

--- a/InformationScripting/src/dataformat/TupleSet.h
+++ b/InformationScripting/src/dataformat/TupleSet.h
@@ -35,6 +35,12 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API TupleSet
 {
 	public:
+		TupleSet() = default;
+		TupleSet(const Tuple& t);
+
+		static TupleSet makeError(const QString& errorMessage);
+		static TupleSet makeWarning(const QString& warningMessage);
+
 		template<class Condition>
 		QSet<Tuple> tuples(Condition condition) const;
 		/**
@@ -64,6 +70,9 @@ class INFORMATIONSCRIPTING_API TupleSet
 	private:
 		QHash<QString, QSet<Tuple>> tuples_;
 };
+
+inline TupleSet TupleSet::makeError(const QString& errorMessage) { return {{{"error", errorMessage}}}; }
+inline TupleSet TupleSet::makeWarning(const QString& warningMessage) { return {{{"warning", warningMessage}}}; }
 
 template <class Condition>
 inline QSet<Tuple> TupleSet::tuples(Condition condition) const

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -79,7 +79,7 @@ class INFORMATIONSCRIPTING_API AstQuery : public ScopedArgumentQuery
 		void addNodesOfType(TupleSet& ts, const Model::SymbolMatcher& matcher, Model::Node* from = nullptr);
 		template <class Predicate>
 		void addNodesForWhich(TupleSet& ts, Predicate holds, Model::Node* from = nullptr);
-		void addCallInformation(TupleSet& ts, OOModel::Method* method, QList<OOModel::Method*> callees);
+		static void addCallInformation(TupleSet& ts, OOModel::Method* method, QList<OOModel::Method*> callees);
 
 		void adaptOutputForRelation(TupleSet& tupleSet, const QString& relationName, const QStringList& keepProperties);
 

--- a/InformationScripting/src/queries/QueryExecutor.h
+++ b/InformationScripting/src/queries/QueryExecutor.h
@@ -28,6 +28,10 @@
 
 #include "../informationscripting_api.h"
 
+namespace Interaction {
+	class CommandResult;
+}
+
 namespace InformationScripting {
 
 class Query;
@@ -38,7 +42,7 @@ class INFORMATIONSCRIPTING_API QueryExecutor
 		QueryExecutor(Query* q);
 		~QueryExecutor();
 
-		void execute();
+		Interaction::CommandResult* execute();
 
 	private:
 		Query* query_{};


### PR DESCRIPTION
This is quite a simple approach to runtime errors in queries. We just add an error/warning tuple. In the QueryExecutor we can check for errors/warnings in the result and show them to the user.

Please let me know if you like it, if so I will implement it consistently across all queries.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/172%23issuecomment-148328725%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/172%23issuecomment-148335391%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/172%23issuecomment-148336863%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/172%23issuecomment-148336885%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/172%23issuecomment-148415986%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/172%23issuecomment-148328725%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20I%20am%20not%20very%20fond%20of%20this%20approach.%20It%20confounds%20two%20totally%20unrelated%20things%3A%20tuples%20and%20errors.%20If%20errors%20are%20tuples%2C%20can%20we%20continue%20working%20on%20the%20pipeline%20by%20processing%20error%20tuples%20in%20subsequent%20query%20parts%3F%20I%20think%20the%20answer%20should%20be%20no%2C%20which%20means%20that%20whenever%20we%20encounter%20an%20error%20we%20stop%20the%20pipeline.%20So%20why%20should%20we%20stop%20the%20pipeline%20if%20errors%20are%20just%20tuples.%20It%27s%20all%20mixed%20up%20and%20I%20think%20we%20can%20do%20better.%5Cr%5Cn%5Cr%5CnIn%20the%20worst%20case%2C%20we%20can%20always%20introduce%20a%20separate%20place%20where%20we%20record%20the%20last%20error.%20If%20an%20error%20happens%2C%20we%20record%20it%2C%20then%20we%20break%20execution%20and%20the%20executor%20can%20check%20the%20error%20log%20and%20report%20that%20to%20the%20command%20infrastructure.%20It%27s%20a%20common%20pattern%20for%20handling%20errors%2C%20even%20if%20it%27s%20not%20the%20most%20elegant%20solution%2C%20though%20I%20think%20it%27s%20definitely%20better%20than%20using%20tuples.%22%2C%20%22created_at%22%3A%20%222015-10-15T09%3A23%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20you%20have%20%20a%20point%20there.%20I%20still%20have%20some%20points%20to%20cosider%3A%5Cr%5Cn%2A%20I%20don%27t%20fully%20agree%20that%20tuples%20and%20errors%20are%20unrelated%3A%20On%20a%20more%20abstract%20view%20a%20Tuple%20is%20just%20an%20information%20container%20and%20an%20error%20is%20a%20piece%20of%20information.%20%5Cr%5Cn%5Cr%5Cn%2A%20It%20probably%20makes%20sense%20to%20abort%20the%20pipeline%20in%20case%20of%20an%20error%2C%20on%20the%20other%20hand%20no%20query%20should%20make%20any%20assumptions%20about%20its%20input.%20I.e.%20if%20the%20query%20doesn%27t%20get%20any%20input%20it%20can%20use%20it%20ignores%20it%2C%20or%20adds%20a%20warning.%5Cr%5Cn%5Cr%5Cn%2A%20The%20tuples%20approach%20also%20integrates%20with%20no%20effort%20to%20scripts.%20%22%2C%20%22created_at%22%3A%20%222015-10-15T09%3A39%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22-%20You%20need%20to%20find%20the%20right%20level%20of%20abstraction.%20By%20your%20argument%20%28that%20both%20are%20pieces%20of%20information%29%2C%20tuples%2C%20and%20errors%2C%20and%20mp3%20files%20and%20pdfs%20are%20all%20the%20same%2C%20since%20they%20are%20pieces%20of%20information.%20We%20need%20to%20work%20at%20a%20much%20more%20fine%20grained%20level%20here.%20Tuples%20are%20small%20data%20bits%20that%20we%20keep%20propagating%20and%20altering%20through%20our%20pipeline.%20Errors%20are%20neither%20propagated%2C%20nor%20altered.%20The%20two%20are%20quite%20different%2C%20and%20the%20fact%20that%20we%20could%20encode%20errors%20as%20tuples%20is%20not%20enough.%5Cr%5Cn-%20Queries%20should%20be%20free%20to%20decided%20what%20assumptions%20they%20do%20or%20do%20not%20make.%20If%20a%20query%20needs%20input%2C%20but%20can%20work%20without%20it%20as%20well%2C%20it%27s%20free%20to%20do%20so.%20But%20if%20a%20query%20absolutely%20needs%20input%20and%20has%20no%20meaning%20without%20it%2C%20it%20should%20be%20able%20to%20break%20execution%20and%20report%20an%20error.%20So%20I%20don%27t%20agree%20that%20queries%20should%20make%20no%20assumptions%20for%20their%20input.%5Cr%5Cn-%20I%20agree%20that%20integrating%20dedicated%20error%20handling%20will%20be%20more%20work%20for%20scripts.%20But%20the%20amount%20of%20work%20we%20need%20to%20do%20now%20should%20not%20be%20the%20determining%20factor%20of%20what%20to%20implement.%22%2C%20%22created_at%22%3A%20%222015-10-15T09%3A48%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Let%27s%20discuss%20this%20in%20person.%22%2C%20%22created_at%22%3A%20%222015-10-15T09%3A48%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Closing%20in%20favor%20of%20a%20future%20optional%20return%20type%22%2C%20%22created_at%22%3A%20%222015-10-15T15%3A06%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/172#issuecomment-148328725'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, I am not very fond of this approach. It confounds two totally unrelated things: tuples and errors. If errors are tuples, can we continue working on the pipeline by processing error tuples in subsequent query parts? I think the answer should be no, which means that whenever we encounter an error we stop the pipeline. So why should we stop the pipeline if errors are just tuples. It's all mixed up and I think we can do better.
  In the worst case, we can always introduce a separate place where we record the last error. If an error happens, we record it, then we break execution and the executor can check the error log and report that to the command infrastructure. It's a common pattern for handling errors, even if it's not the most elegant solution, though I think it's definitely better than using tuples.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Hm you have  a point there. I still have some points to cosider:
- I don't fully agree that tuples and errors are unrelated: On a more abstract view a Tuple is just an information container and an error is a piece of information.
- It probably makes sense to abort the pipeline in case of an error, on the other hand no query should make any assumptions about its input. I.e. if the query doesn't get any input it can use it ignores it, or adds a warning.
- The tuples approach also integrates with no effort to scripts.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> - You need to find the right level of abstraction. By your argument (that both are pieces of information), tuples, and errors, and mp3 files and pdfs are all the same, since they are pieces of information. We need to work at a much more fine grained level here. Tuples are small data bits that we keep propagating and altering through our pipeline. Errors are neither propagated, nor altered. The two are quite different, and the fact that we could encode errors as tuples is not enough.
- Queries should be free to decided what assumptions they do or do not make. If a query needs input, but can work without it as well, it's free to do so. But if a query absolutely needs input and has no meaning without it, it should be able to break execution and report an error. So I don't agree that queries should make no assumptions for their input.
- I agree that integrating dedicated error handling will be more work for scripts. But the amount of work we need to do now should not be the determining factor of what to implement.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Let's discuss this in person.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Closing in favor of a future optional return type

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/172?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/172?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/172'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
