### PR TITLE
Optional returnvalue

### DIFF
--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -75,7 +75,8 @@ HEADERS += src/precompiled.h \
     src/queries/VersionControlQuery.h \
     src/interaction/SimpleQueryParser.h \
     src/visualization/VCompositeQueryNode.h \
-    src/visualization/VCompositeQueryNodeStyle.h
+    src/visualization/VCompositeQueryNodeStyle.h \
+    src/misc/Optional.h
 SOURCES += src/InformationScriptingException.cpp \
 	src/InformationScriptingPlugin.cpp \
 	test/SimpleTest.cpp \

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -76,7 +76,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 		args.prepend(command);
 		auto q = QueryParser::buildQueryFrom(args.join(""), node);
 		QueryExecutor queryExecutor(q);
-		queryExecutor.execute();
+		return queryExecutor.execute();
 	}
 	else
 	{

--- a/InformationScripting/src/misc/Optional.h
+++ b/InformationScripting/src/misc/Optional.h
@@ -39,26 +39,26 @@ class INFORMATIONSCRIPTING_API Optional
 		// Since the error constructor takes a QString we disallow usage with QString.
 		static_assert(!std::is_same<ValueType, QString>(), "QString is not allowed as paremeter for Optional");
 	public:
-		constexpr Optional(const ValueType& v, const QString& warning = {});
-		constexpr Optional(ValueType&& v, const QString& warning = {});
-		constexpr Optional(const QString& errorMessage);
-		constexpr Optional(QString&& errorMessage);
+		Optional(const ValueType& v, const QString& warning = {});
+		Optional(ValueType&& v, const QString& warning = {});
+		Optional(const QString& errorMessage);
+		Optional(QString&& errorMessage);
 
 		Optional(const Optional& other);
 		Optional(Optional&& other);
 
-		constexpr explicit operator bool() const;
+		explicit operator bool() const;
 
-		constexpr const ValueType& value() const &;
-		constexpr ValueType& value() &;
+		const ValueType& value() const &;
+		ValueType& value() &;
 
-		constexpr ValueType&& value() &&;
-		constexpr const ValueType&& value() const &&;
+		ValueType&& value() &&;
+		const ValueType&& value() const &&;
 
-		constexpr bool hasError() const;
+		bool hasError() const;
 		QString error() const;
 
-		constexpr bool hasWarning() const;
+		bool hasWarning() const;
 		QString warning() const;
 	private:
 		enum class Type : int {Value, Warning, Error};
@@ -68,25 +68,25 @@ class INFORMATIONSCRIPTING_API Optional
 };
 
 template <class ValueType>
-inline constexpr Optional<ValueType>::Optional(const ValueType& v, const QString& warning)
+inline Optional<ValueType>::Optional(const ValueType& v, const QString& warning)
 	: value_{v}, message_{warning}
 {
 	if (!warning.isNull()) type_ = Type::Warning;
 }
 
 template <class ValueType>
-inline constexpr Optional<ValueType>::Optional(ValueType&& v, const QString& warning)
+inline Optional<ValueType>::Optional(ValueType&& v, const QString& warning)
 	: value_{std::move(v)}, message_{warning}
 {
 	if (!warning.isNull()) type_ = Type::Warning;
 }
 
 template <class ValueType>
-inline constexpr Optional<ValueType>::Optional(const QString& errorMessage)
+inline Optional<ValueType>::Optional(const QString& errorMessage)
 	: message_{errorMessage}, type_{Type::Error} {}
 
 template <class ValueType>
-inline constexpr Optional<ValueType>::Optional(QString&& errorMessage)
+inline Optional<ValueType>::Optional(QString&& errorMessage)
 	: message_{std::move(errorMessage)}, type_{Type::Error} {}
 
 template <class ValueType>
@@ -98,24 +98,24 @@ inline Optional<ValueType>::Optional(Optional&& other)
 	: value_{std::move(other.value_)}, message_{std::move(other.message_)}, type_{std::move(other.type_)} {}
 
 template <class ValueType>
-inline constexpr Optional<ValueType>::operator bool() const { return type_ != Type::Error;}
+inline Optional<ValueType>::operator bool() const { return type_ != Type::Error;}
 
 template <class ValueType>
-inline constexpr const ValueType& Optional<ValueType>::value() const & { Q_ASSERT(bool(*this)); return value_; }
+inline const ValueType& Optional<ValueType>::value() const & { Q_ASSERT(bool(*this)); return value_; }
 
 template <class ValueType>
-inline constexpr ValueType& Optional<ValueType>::value() & { Q_ASSERT(bool(*this)); return value_; }
+inline ValueType& Optional<ValueType>::value() & { Q_ASSERT(bool(*this)); return value_; }
 
 template <class ValueType>
-inline constexpr ValueType&& Optional<ValueType>::value() && { Q_ASSERT(bool(*this)); return std::move(value_); }
+inline ValueType&& Optional<ValueType>::value() && { Q_ASSERT(bool(*this)); return std::move(value_); }
 
 template <class ValueType>
-inline constexpr bool Optional<ValueType>::hasError() const { return type_ == Type::Error; }
+inline bool Optional<ValueType>::hasError() const { return type_ == Type::Error; }
 template <class ValueType>
 inline QString Optional<ValueType>::error() const { Q_ASSERT(type_ == Type::Error); return message_; }
 
 template <class ValueType>
-inline constexpr bool Optional<ValueType>::hasWarning() const { return type_ == Type::Warning; }
+inline bool Optional<ValueType>::hasWarning() const { return type_ == Type::Warning; }
 template <class ValueType>
 inline QString Optional<ValueType>::warning() const { Q_ASSERT(type_ == Type::Warning); return message_; }
 

--- a/InformationScripting/src/misc/Optional.h
+++ b/InformationScripting/src/misc/Optional.h
@@ -47,6 +47,9 @@ class INFORMATIONSCRIPTING_API Optional
 		Optional(const Optional& other);
 		Optional(Optional&& other);
 
+		Optional& operator=(const Optional& other);
+		Optional& operator=(Optional&& other);
+
 		explicit operator bool() const;
 
 		const ValueType& value() const &;
@@ -60,6 +63,7 @@ class INFORMATIONSCRIPTING_API Optional
 
 		bool hasWarnings() const;
 		QStringList warnings() const;
+		void addWarnings(const QStringList& warnings);
 	private:
 		enum class Type : int {Value, Warning, Error};
 		Q_DECLARE_FLAGS(Types, Type)
@@ -115,6 +119,26 @@ inline Optional<ValueType>::Optional(Optional&& other)
 	  errors_{std::move(other.errors_)}, type_{std::move(other.type_)} {}
 
 template <class ValueType>
+Optional<ValueType>& Optional<ValueType>::operator=(const Optional& other)
+{
+	value_ = other.value_;
+	warnings_ = other.warnings_;
+	errors_ = other.errors_;
+	type_ = other.type_;
+	return *this;
+}
+
+template <class ValueType>
+Optional<ValueType>& Optional<ValueType>::operator=(Optional&& other)
+{
+	value_ = std::move(other.value_);
+	warnings_ = std::move(other.warnings_);
+	errors_ = std::move(other.errors_);
+	type_ = std::move(other.type_);
+	return *this;
+}
+
+template <class ValueType>
 inline Optional<ValueType>::operator bool() const { return !type_.testFlag(Type::Error);}
 
 template <class ValueType>
@@ -135,5 +159,14 @@ template <class ValueType>
 inline bool Optional<ValueType>::hasWarnings() const { return type_.testFlag(Type::Warning); }
 template <class ValueType>
 inline QStringList Optional<ValueType>::warnings() const { Q_ASSERT(hasWarnings()); return warnings_; }
+template <class ValueType>
+inline void Optional<ValueType>::addWarnings(const QStringList& warnings)
+{
+	if (!warnings.isEmpty())
+	{
+		type_ |= Type::Warning;
+		warnings_ << warnings;
+	}
+}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/misc/Optional.h
+++ b/InformationScripting/src/misc/Optional.h
@@ -1,0 +1,122 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../informationscripting_api.h"
+
+namespace InformationScripting {
+
+/**
+ * Class inspired by std::experimental::optional, but it additionally contains an error/warning message.
+ */
+template <class ValueType>
+class INFORMATIONSCRIPTING_API Optional
+{
+		// Since the error constructor takes a QString we disallow usage with QString.
+		static_assert(!std::is_same<ValueType, QString>(), "QString is not allowed as paremeter for Optional");
+	public:
+		constexpr Optional(const ValueType& v, const QString& warning = {});
+		constexpr Optional(ValueType&& v, const QString& warning = {});
+		constexpr Optional(const QString& errorMessage);
+		constexpr Optional(QString&& errorMessage);
+
+		Optional(const Optional& other);
+		Optional(Optional&& other);
+
+		constexpr explicit operator bool() const;
+
+		constexpr const ValueType& value() const &;
+		constexpr ValueType& value() &;
+
+		constexpr ValueType&& value() &&;
+		constexpr const ValueType&& value() const &&;
+
+		constexpr bool hasError() const;
+		QString error() const;
+
+		constexpr bool hasWarning() const;
+		QString warning() const;
+	private:
+		enum class Type : int {Value, Warning, Error};
+		ValueType value_{};
+		QString message_;
+		Type type_{Type::Value};
+};
+
+template <class ValueType>
+inline constexpr Optional<ValueType>::Optional(const ValueType& v, const QString& warning)
+	: value_{v}, message_{warning}
+{
+	if (!warning.isNull()) type_ = Type::Warning;
+}
+
+template <class ValueType>
+inline constexpr Optional<ValueType>::Optional(ValueType&& v, const QString& warning)
+	: value_{std::move(v)}, message_{warning}
+{
+	if (!warning.isNull()) type_ = Type::Warning;
+}
+
+template <class ValueType>
+inline constexpr Optional<ValueType>::Optional(const QString& errorMessage)
+	: message_{errorMessage}, type_{Type::Error} {}
+
+template <class ValueType>
+inline constexpr Optional<ValueType>::Optional(QString&& errorMessage)
+	: message_{std::move(errorMessage)}, type_{Type::Error} {}
+
+template <class ValueType>
+inline Optional<ValueType>::Optional(const Optional& other)
+	: value_{other.value_}, message_{other.message_}, type_{other.type_} {}
+
+template <class ValueType>
+inline Optional<ValueType>::Optional(Optional&& other)
+	: value_{std::move(other.value_)}, message_{std::move(other.message_)}, type_{std::move(other.type_)} {}
+
+template <class ValueType>
+inline constexpr Optional<ValueType>::operator bool() const { return type_ != Type::Error;}
+
+template <class ValueType>
+inline constexpr const ValueType& Optional<ValueType>::value() const & { Q_ASSERT(bool(*this)); return value_; }
+
+template <class ValueType>
+inline constexpr ValueType& Optional<ValueType>::value() & { Q_ASSERT(bool(*this)); return value_; }
+
+template <class ValueType>
+inline constexpr ValueType&& Optional<ValueType>::value() && { Q_ASSERT(bool(*this)); return std::move(value_); }
+
+template <class ValueType>
+inline constexpr bool Optional<ValueType>::hasError() const { return type_ == Type::Error; }
+template <class ValueType>
+inline QString Optional<ValueType>::error() const { Q_ASSERT(type_ == Type::Error); return message_; }
+
+template <class ValueType>
+inline constexpr bool Optional<ValueType>::hasWarning() const { return type_ == Type::Warning; }
+template <class ValueType>
+inline QString Optional<ValueType>::warning() const { Q_ASSERT(type_ == Type::Warning); return message_; }
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/AddASTPropertiesAsTuples.cpp
+++ b/InformationScripting/src/queries/AddASTPropertiesAsTuples.cpp
@@ -32,7 +32,7 @@
 
 namespace InformationScripting {
 
-TupleSet AddASTPropertiesAsTuples::executeLinear(TupleSet input)
+Optional<TupleSet> AddASTPropertiesAsTuples::executeLinear(TupleSet input)
 {
 	input.addPropertiesAsTuples<Model::Node*>("ast");
 	return input;

--- a/InformationScripting/src/queries/AddASTPropertiesAsTuples.h
+++ b/InformationScripting/src/queries/AddASTPropertiesAsTuples.h
@@ -35,7 +35,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API AddASTPropertiesAsTuples : public LinearQuery
 {
 	public:
-		virtual TupleSet executeLinear(TupleSet input) override;
+		virtual Optional<TupleSet> executeLinear(TupleSet input) override;
 
 		static void registerDefaultQueries();
 };

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -121,8 +121,9 @@ Optional<TupleSet> AstQuery::baseClassesQuery(TupleSet)
 
 Optional<TupleSet> AstQuery::toParentType(TupleSet input)
 {
+	// TODO require argument
 	QString type = argument(NODETYPE_ARGUMENT_NAMES[0]);
-	Q_ASSERT(type.size() > 0); // TODO should be a warning for the user.
+	Q_ASSERT(type.size() > 0);
 
 	auto ts = input;
 	Model::SymbolMatcher matcher = Model::SymbolMatcher::guessMatcher(type);
@@ -137,6 +138,8 @@ Optional<TupleSet> AstQuery::toParentType(TupleSet input)
 		return false;
 	};
 	auto tuples = ts.tuples(haveMatchingParent);
+	if (tuples.isEmpty()) return {ts, "No input nodes found which have a parent of type: " + type};
+
 	for (auto tuple : tuples)
 	{
 		Model::Node* astNode = tuple["ast"];
@@ -197,10 +200,12 @@ Optional<TupleSet> AstQuery::callGraph(TupleSet input)
 
 Optional<TupleSet> AstQuery::genericQuery(TupleSet input)
 {
+	// TODO require one argument!
 	QString typeArgument = argument(NODETYPE_ARGUMENT_NAMES[0]);
 	QString nameArgument = argument(NAME_ARGUMENT_NAMES[0]);
 	if (nameArgument.size() > 0) return nameQuery(input, nameArgument);
 	else if (typeArgument.size() > 0) return typeQuery(input, typeArgument);
+	Q_ASSERT(false);
 	return {"Generic Error"};
 }
 
@@ -228,6 +233,8 @@ Optional<TupleSet> AstQuery::typeQuery(TupleSet input, QString type)
 
 Optional<TupleSet> AstQuery::nameQuery(TupleSet input, QString name)
 {
+	Q_ASSERT(!name.isEmpty());
+
 	TupleSet tuples;
 
 	QList<QPair<QString, Model::Node*>> matchingNodes;
@@ -274,6 +281,7 @@ Optional<TupleSet> AstQuery::usesQuery(TupleSet input)
 		result = tuples;
 	}
 
+	// TODO require one argument!
 	auto typeMatcher = Model::SymbolMatcher::guessMatcher(argument(NODETYPE_ARGUMENT_NAMES[0]));
 	auto nameMatcher = Model::SymbolMatcher::guessMatcher(argument(NAME_ARGUMENT_NAMES[0]));
 
@@ -309,6 +317,7 @@ Optional<TupleSet> AstQuery::typeFilter(TupleSet input)
 	QStringList arguments;
 	TupleSet result;
 
+	// TODO require argument!
 	// NOTE: To use spaces in this argument use quotes!
 	// QCommandLineParser removes the entered spaces automatically
 	// NOTE: here the type argument has a different meaning than in the other queries:
@@ -468,6 +477,7 @@ bool AstQuery::matchesExpectedType(Model::Node* node, Model::Node::SymbolType sy
 		{
 			if (args.size() != methodDecl->arguments()->size()) return false;
 			// TODO: here we support only one return value:
+			Q_ASSERT(methodDecl->results()->size() <= 1);
 			if ((methodDecl->results()->size() == 0 && (expectedType.isEmpty() || expectedType == "void"))
 				 || (methodDecl->results()->size() > 0 &&
 					  StringComponents::stringForNode(methodDecl->results()->at(0)->typeExpression()) == expectedType)

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -147,30 +147,52 @@ Optional<TupleSet> AstQuery::toParentType(TupleSet input)
 	return ts;
 }
 
-Optional<TupleSet> AstQuery::callGraph(TupleSet)
+Optional<TupleSet> AstQuery::callGraph(TupleSet input)
 {
-	TupleSet ts;
+	TupleSet result;
+
+	auto addCallgraphFor = [&result](std::vector<OOModel::Method*> methods)
+	{
+		for (auto method : methods)
+		{
+			Q_ASSERT(method);
+			QSet<OOModel::Method*> seenMethods{method};
+			auto callees = method->callees().toList();
+			addCallInformation(result, method, callees);
+			while (!callees.empty())
+			{
+				auto currentMethod = callees.takeLast();
+				if (seenMethods.contains(currentMethod)) continue;
+				seenMethods.insert(currentMethod);
+				auto newCallees = currentMethod->callees().toList();
+				addCallInformation(result, currentMethod, newCallees);
+				callees << newCallees;
+			}
+		}
+	};
+
 	if (scope() == Scope::Local)
 	{
-		auto methodTarget = target()->firstAncestorOfType<OOModel::Method>();
-		Q_ASSERT(methodTarget);
-		QSet<OOModel::Method*> seenMethods{methodTarget};
-		auto methods = methodTarget->callees().toList();
-		addCallInformation(ts, methodTarget, methods);
-		while (!methods.empty())
-		{
-			auto currentMethod = methods.takeLast();
-			if (seenMethods.contains(currentMethod)) continue;
-			seenMethods.insert(currentMethod);
-			auto newCallees = currentMethod->callees().toList();
-			addCallInformation(ts, currentMethod, newCallees);
-			methods << newCallees;
-		}
-
-		adaptOutputForRelation(ts, "calls", {"caller", "callee"});
+		if (auto method = DCast<OOModel::Method>(target())) addCallgraphFor({method});
+		else return {"Callgraph does only work on method nodes"};
 	}
-	// TODO handle other cases, global propably doesn't make sense.
-	return ts;
+	else if (scope() == Scope::Global)
+		return {"Callgraph does not work globally"};
+	else if (scope() == Scope::Input)
+	{
+		// Keep input nodes
+		result = input;
+		std::vector<OOModel::Method*> methodsInInput;
+		for (const auto& astTuple : input.tuples("ast"))
+		{
+			Model::Node* astNode = astTuple["ast"];
+			if (auto method = DCast<OOModel::Method>(astNode)) methodsInInput.push_back(method);
+		}
+		if (methodsInInput.size() == 0) return {result, "Called callgraph without methods in input"};
+		else addCallgraphFor(std::move(methodsInInput));
+	}
+	adaptOutputForRelation(result, "calls", {"caller", "callee"});
+	return result;
 }
 
 Optional<TupleSet> AstQuery::genericQuery(TupleSet input)

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -62,7 +62,7 @@ AstQuery::AstQuery(ExecuteFunction exec, Model::Node* target, QStringList args)
 		}, QStringList("AstQuery") + args}, exec_{exec}
 {}
 
-TupleSet AstQuery::executeLinear(TupleSet input)
+Optional<TupleSet> AstQuery::executeLinear(TupleSet input)
 {
 	return exec_(this, input);
 }
@@ -96,7 +96,7 @@ void AstQuery::setTypeTo(QStringList& args, QString type)
 		args.append(QString("-%1=%2").arg(NODETYPE_ARGUMENT_NAMES[0], type));
 }
 
-TupleSet AstQuery::baseClassesQuery(TupleSet)
+Optional<TupleSet> AstQuery::baseClassesQuery(TupleSet)
 {
 	// TODO handle input
 	TupleSet ts;
@@ -119,7 +119,7 @@ TupleSet AstQuery::baseClassesQuery(TupleSet)
 	return ts;
 }
 
-TupleSet AstQuery::toParentType(TupleSet input)
+Optional<TupleSet> AstQuery::toParentType(TupleSet input)
 {
 	QString type = argument(NODETYPE_ARGUMENT_NAMES[0]);
 	Q_ASSERT(type.size() > 0); // TODO should be a warning for the user.
@@ -147,7 +147,7 @@ TupleSet AstQuery::toParentType(TupleSet input)
 	return ts;
 }
 
-TupleSet AstQuery::callGraph(TupleSet)
+Optional<TupleSet> AstQuery::callGraph(TupleSet)
 {
 	TupleSet ts;
 	if (scope() == Scope::Local)
@@ -173,16 +173,16 @@ TupleSet AstQuery::callGraph(TupleSet)
 	return ts;
 }
 
-TupleSet AstQuery::genericQuery(TupleSet input)
+Optional<TupleSet> AstQuery::genericQuery(TupleSet input)
 {
 	QString typeArgument = argument(NODETYPE_ARGUMENT_NAMES[0]);
 	QString nameArgument = argument(NAME_ARGUMENT_NAMES[0]);
 	if (nameArgument.size() > 0) return nameQuery(input, nameArgument);
 	else if (typeArgument.size() > 0) return typeQuery(input, typeArgument);
-	return {};
+	return {"Generic Error"};
 }
 
-TupleSet AstQuery::typeQuery(TupleSet input, QString type)
+Optional<TupleSet> AstQuery::typeQuery(TupleSet input, QString type)
 {
 	TupleSet tuples;
 
@@ -204,7 +204,7 @@ TupleSet AstQuery::typeQuery(TupleSet input, QString type)
 	return tuples;
 }
 
-TupleSet AstQuery::nameQuery(TupleSet input, QString name)
+Optional<TupleSet> AstQuery::nameQuery(TupleSet input, QString name)
 {
 	TupleSet tuples;
 
@@ -232,7 +232,7 @@ TupleSet AstQuery::nameQuery(TupleSet input, QString name)
 	return tuples;
 }
 
-TupleSet AstQuery::usesQuery(TupleSet input)
+Optional<TupleSet> AstQuery::usesQuery(TupleSet input)
 {
 	TupleSet result;
 	QHash<Model::Node*, QList<Model::Reference*>> references;
@@ -278,7 +278,7 @@ TupleSet AstQuery::usesQuery(TupleSet input)
 	return result;
 }
 
-TupleSet AstQuery::typeFilter(TupleSet input)
+Optional<TupleSet> AstQuery::typeFilter(TupleSet input)
 {
 	using SymbolType = Model::Node::SymbolType;
 
@@ -329,7 +329,7 @@ TupleSet AstQuery::typeFilter(TupleSet input)
 	return result;
 }
 
-TupleSet AstQuery::attribute(TupleSet input)
+Optional<TupleSet> AstQuery::attribute(TupleSet input)
 {
 	const QString attributeName = argument(ATTRIBUTE_NAME_NAMES[1]);
 	Q_ASSERT(!attributeName.isEmpty());

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -47,7 +47,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API AstQuery : public ScopedArgumentQuery
 {
 	public:
-		virtual TupleSet executeLinear(TupleSet input) override;
+		virtual Optional<TupleSet> executeLinear(TupleSet input) override;
 
 		static void registerDefaultQueries();
 
@@ -58,22 +58,22 @@ class INFORMATIONSCRIPTING_API AstQuery : public ScopedArgumentQuery
 		static const QStringList ADD_AS_NAMES;
 		static const QStringList ATTRIBUTE_NAME_NAMES;
 
-		using ExecuteFunction = std::function<TupleSet (AstQuery*, TupleSet)>;
+		using ExecuteFunction = std::function<Optional<TupleSet> (AstQuery*, TupleSet)>;
 		ExecuteFunction exec_{};
 
 		AstQuery(ExecuteFunction exec, Model::Node* target, QStringList args);
 
 		static void setTypeTo(QStringList& args, QString type);
 
-		TupleSet baseClassesQuery(TupleSet input);
-		TupleSet toParentType(TupleSet input);
-		TupleSet callGraph(TupleSet input);
-		TupleSet genericQuery(TupleSet input);
-		TupleSet typeQuery(TupleSet input, QString type);
-		TupleSet nameQuery(TupleSet input, QString name);
-		TupleSet usesQuery(TupleSet input);
-		TupleSet typeFilter(TupleSet input);
-		TupleSet attribute(TupleSet input);
+		Optional<TupleSet> baseClassesQuery(TupleSet input);
+		Optional<TupleSet> toParentType(TupleSet input);
+		Optional<TupleSet> callGraph(TupleSet input);
+		Optional<TupleSet> genericQuery(TupleSet input);
+		Optional<TupleSet> typeQuery(TupleSet input, QString type);
+		Optional<TupleSet> nameQuery(TupleSet input, QString name);
+		Optional<TupleSet> usesQuery(TupleSet input);
+		Optional<TupleSet> typeFilter(TupleSet input);
+		Optional<TupleSet> attribute(TupleSet input);
 
 		void addBaseEdgesFor(OOModel::Class* childClass, NamedProperty& classNode, TupleSet& ts);
 		void addNodesOfType(TupleSet& ts, const Model::SymbolMatcher& matcher, Model::Node* from = nullptr);

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -79,7 +79,7 @@ class INFORMATIONSCRIPTING_API AstQuery : public ScopedArgumentQuery
 		void addNodesOfType(TupleSet& ts, const Model::SymbolMatcher& matcher, Model::Node* from = nullptr);
 		template <class Predicate>
 		void addNodesForWhich(TupleSet& ts, Predicate holds, Model::Node* from = nullptr);
-		void addCallInformation(TupleSet& ts, OOModel::Method* method, QList<OOModel::Method*> callees);
+		static void addCallInformation(TupleSet& ts, OOModel::Method* method, QList<OOModel::Method*> callees);
 
 		void adaptOutputForRelation(TupleSet& tupleSet, const QString& relationName, const QStringList& keepProperties);
 

--- a/InformationScripting/src/queries/CompositeQuery.cpp
+++ b/InformationScripting/src/queries/CompositeQuery.cpp
@@ -32,7 +32,7 @@ CompositeQuery::~CompositeQuery()
 {
 	SAFE_DELETE(inNode_);
 	for (auto node : nodes_) SAFE_DELETE(node);
-	// Don't delete the outNode_ as that we delete all Graphs which we returned in the execute methods.
+	SAFE_DELETE(outNode_);
 }
 
 QList<Optional<TupleSet> > CompositeQuery::execute(QList<TupleSet> input)

--- a/InformationScripting/src/queries/CompositeQuery.cpp
+++ b/InformationScripting/src/queries/CompositeQuery.cpp
@@ -82,7 +82,7 @@ QList<Optional<TupleSet> > CompositeQuery::execute(QList<TupleSet> input)
 				{
 					// early abort in case of error:
 					if (currentNode->calculatedOutputs_[outIndex]) output = currentNode->calculatedOutputs_[outIndex].value();
-					else return { currentNode->calculatedOutputs_[outIndex].error() };
+					else return {currentNode->calculatedOutputs_[outIndex]};
 				}
 
 				receiver->addCalculatedInput(std::distance(receiver->inputMap_.begin(), inputIt), output);

--- a/InformationScripting/src/queries/CompositeQuery.cpp
+++ b/InformationScripting/src/queries/CompositeQuery.cpp
@@ -77,7 +77,13 @@ QList<Optional<TupleSet> > CompositeQuery::execute(QList<TupleSet> input)
 					return m.outputFrom_ == currentNode && m.outputIndex_ == outIndex;
 				});
 				Q_ASSERT(inputIt != receiver->inputMap_.end());
-				auto output = hasOutput ? currentNode->calculatedOutputs_[outIndex].value() : TupleSet();
+				TupleSet output;
+				if (hasOutput)
+				{
+					// early abort in case of error:
+					if (currentNode->calculatedOutputs_[outIndex]) output = currentNode->calculatedOutputs_[outIndex].value();
+					else return { currentNode->calculatedOutputs_[outIndex].error() };
+				}
 
 				receiver->addCalculatedInput(std::distance(receiver->inputMap_.begin(), inputIt), output);
 

--- a/InformationScripting/src/queries/CompositeQuery.h
+++ b/InformationScripting/src/queries/CompositeQuery.h
@@ -37,7 +37,7 @@ class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 	public:
 		virtual ~CompositeQuery() override;
 
-		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
+		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;
 
 		/**
 		 * Connects output 0 from Query \a from to input 0 of Query \a to.
@@ -82,7 +82,7 @@ class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 				QVector<QSet<QueryNode*>> outputMap_;
 
 				QList<TupleSet> calculatedInputs_;
-				QList<TupleSet> calculatedOutputs_;
+				QList<Optional<TupleSet>> calculatedOutputs_;
 
 				void addCalculatedInput(int index, TupleSet g);
 				bool canExecute() const;

--- a/InformationScripting/src/queries/CompositeQuery.h
+++ b/InformationScripting/src/queries/CompositeQuery.h
@@ -81,10 +81,10 @@ class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 				 */
 				QVector<QSet<QueryNode*>> outputMap_;
 
-				QList<TupleSet> calculatedInputs_;
+				QList<Optional<TupleSet>> calculatedInputs_;
 				QList<Optional<TupleSet>> calculatedOutputs_;
 
-				void addCalculatedInput(int index, TupleSet g);
+				void addCalculatedInput(int index, Optional<TupleSet> g);
 				bool canExecute() const;
 				void execute();
 

--- a/InformationScripting/src/queries/GenericFilter.cpp
+++ b/InformationScripting/src/queries/GenericFilter.cpp
@@ -31,7 +31,7 @@ namespace InformationScripting {
 GenericFilter::GenericFilter(GenericFilter::KeepTuple f) : keepTuple_{f}
 {}
 
-TupleSet GenericFilter::executeLinear(TupleSet input)
+Optional<TupleSet> GenericFilter::executeLinear(TupleSet input)
 {
 	for (const auto& t : input.tuples())
 		if (!keepTuple_(t)) input.remove(t);

--- a/InformationScripting/src/queries/GenericFilter.h
+++ b/InformationScripting/src/queries/GenericFilter.h
@@ -40,7 +40,7 @@ class INFORMATIONSCRIPTING_API GenericFilter : public LinearQuery
 		using KeepTuple = std::function<bool(const Tuple&)>;
 		GenericFilter(KeepTuple f);
 
-		virtual TupleSet executeLinear(TupleSet input) override;
+		virtual Optional<TupleSet> executeLinear(TupleSet input) override;
 
 	private:
 		KeepTuple keepTuple_;

--- a/InformationScripting/src/queries/LinearQuery.cpp
+++ b/InformationScripting/src/queries/LinearQuery.cpp
@@ -28,9 +28,9 @@
 
 namespace InformationScripting {
 
-QList<TupleSet> LinearQuery::execute(QList<TupleSet> input)
+QList<Optional<TupleSet> > LinearQuery::execute(QList<TupleSet> input)
 {
-	QList<TupleSet> result;
+	QList<Optional<TupleSet>> result;
 	// If we have no input just add one default input such that we execute at least once.
 	if (input.isEmpty()) input << TupleSet();
 

--- a/InformationScripting/src/queries/LinearQuery.h
+++ b/InformationScripting/src/queries/LinearQuery.h
@@ -35,8 +35,8 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API LinearQuery : public Query
 {
 	public:
-		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
-		virtual TupleSet executeLinear(TupleSet) = 0;
+		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;
+		virtual Optional<TupleSet> executeLinear(TupleSet) = 0;
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/NodePropertyAdder.cpp
+++ b/InformationScripting/src/queries/NodePropertyAdder.cpp
@@ -32,7 +32,7 @@ NodePropertyAdder::NodePropertyAdder(const QString& propertyName, Property value
  : name_{propertyName}, value_{value}
 {}
 
-QList<TupleSet> NodePropertyAdder::execute(QList<TupleSet> input)
+QList<Optional<TupleSet>> NodePropertyAdder::execute(QList<TupleSet> input)
 {
 	for (auto& ts : input)
 	{
@@ -42,7 +42,9 @@ QList<TupleSet> NodePropertyAdder::execute(QList<TupleSet> input)
 			ts.add(node);
 		}
 	}
-	return input;
+	QList<Optional<TupleSet>> result;
+	for (auto&& t : input) result.push_back(t);
+	return result;
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/NodePropertyAdder.h
+++ b/InformationScripting/src/queries/NodePropertyAdder.h
@@ -36,7 +36,7 @@ class INFORMATIONSCRIPTING_API NodePropertyAdder : public Query
 {
 	public:
 		NodePropertyAdder(const QString& propertyName, Property value);
-		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
+		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;
 
 	private:
 		QString name_;

--- a/InformationScripting/src/queries/Query.h
+++ b/InformationScripting/src/queries/Query.h
@@ -30,13 +30,15 @@
 
 #include "../dataformat/TupleSet.h"
 
+#include "../misc/Optional.h"
+
 namespace InformationScripting {
 
 class INFORMATIONSCRIPTING_API Query
 {
 	public:
 		virtual ~Query() = default;
-		virtual QList<TupleSet> execute(QList<TupleSet>) = 0;
+		virtual QList<Optional<TupleSet>> execute(QList<TupleSet>) = 0;
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/QueryExecutor.cpp
+++ b/InformationScripting/src/queries/QueryExecutor.cpp
@@ -52,7 +52,7 @@ void QueryExecutor::execute()
 		}
 		else
 		{
-			qWarning() << results[0].error();
+			qWarning() << results[0].errors();
 		}
 	}
 }

--- a/InformationScripting/src/queries/QueryExecutor.cpp
+++ b/InformationScripting/src/queries/QueryExecutor.cpp
@@ -30,6 +30,8 @@
 
 #include "visualization/DefaultVisualizer.h"
 
+#include "InteractionBase/src/commands/CommandResult.h"
+
 namespace InformationScripting {
 
 QueryExecutor::QueryExecutor(Query* q) : query_{q} {}
@@ -39,11 +41,14 @@ QueryExecutor::~QueryExecutor()
 	SAFE_DELETE(query_);
 }
 
-void QueryExecutor::execute()
+Interaction::CommandResult* QueryExecutor::execute()
 {
 	auto results = query_->execute({});
 	if (results.size())
 	{
+		// TODO how to handle warnings? CommandResult has no warnings?
+		if (results[0].hasWarnings())
+			qWarning() << results[0].warnings();
 		if (results[0])
 		{
 			auto val = results[0].value();
@@ -52,9 +57,11 @@ void QueryExecutor::execute()
 		}
 		else
 		{
-			qWarning() << results[0].errors();
+			return new Interaction::CommandResult(new Interaction::CommandError(results[0].errors()[0]));
 		}
 	}
+
+	return new Interaction::CommandResult();
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/QueryExecutor.cpp
+++ b/InformationScripting/src/queries/QueryExecutor.cpp
@@ -44,8 +44,16 @@ void QueryExecutor::execute()
 	auto results = query_->execute({});
 	if (results.size())
 	{
-		DefaultVisualizer::instance().visualize(results[0]);
-		results.clear();
+		if (results[0])
+		{
+			auto val = results[0].value();
+			DefaultVisualizer::instance().visualize(val);
+			results.clear();
+		}
+		else
+		{
+			qWarning() << results[0].error();
+		}
 	}
 }
 

--- a/InformationScripting/src/queries/QueryExecutor.h
+++ b/InformationScripting/src/queries/QueryExecutor.h
@@ -28,6 +28,10 @@
 
 #include "../informationscripting_api.h"
 
+namespace Interaction {
+	class CommandResult;
+}
+
 namespace InformationScripting {
 
 class Query;
@@ -38,7 +42,7 @@ class INFORMATIONSCRIPTING_API QueryExecutor
 		QueryExecutor(Query* q);
 		~QueryExecutor();
 
-		void execute();
+		Interaction::CommandResult* execute();
 
 	private:
 		Query* query_{};

--- a/InformationScripting/src/queries/ScriptQuery.cpp
+++ b/InformationScripting/src/queries/ScriptQuery.cpp
@@ -97,7 +97,7 @@ QList<Optional<TupleSet> > ScriptQuery::execute(QList<TupleSet> input)
 			auto queryMethod = std::bind(&ScriptQuery::queryExecutor, this, query, std::placeholders::_1,
 												  std::placeholders::_2);
 			auto call_policies = python::default_call_policies();
-			typedef boost::mpl::vector<QList<Optional<TupleSet>>, python::list, python::list> func_sig;
+			using func_sig = boost::mpl::vector<QList<Optional<TupleSet>>, python::list, python::list>;
 			queriesDict[query] = python::make_function(queryMethod, call_policies, func_sig());
 		}
 

--- a/InformationScripting/src/queries/ScriptQuery.cpp
+++ b/InformationScripting/src/queries/ScriptQuery.cpp
@@ -56,11 +56,11 @@ void ScriptQuery::unloadPythonEnvironment()
 	Py_Finalize();
 }
 
-QList<TupleSet> ScriptQuery::execute(QList<TupleSet> input)
+QList<Optional<TupleSet> > ScriptQuery::execute(QList<TupleSet> input)
 {
 	using namespace boost;
 
-	QList<TupleSet> result;
+	QList<Optional<TupleSet>> result;
 
 	try {
 		python::object main_module = python::import("__main__");
@@ -97,7 +97,7 @@ QList<TupleSet> ScriptQuery::execute(QList<TupleSet> input)
 			auto queryMethod = std::bind(&ScriptQuery::queryExecutor, this, query, std::placeholders::_1,
 												  std::placeholders::_2);
 			auto call_policies = python::default_call_policies();
-			typedef boost::mpl::vector<QList<TupleSet>, python::list, python::list> func_sig;
+			typedef boost::mpl::vector<QList<Optional<TupleSet>>, python::list, python::list> func_sig;
 			queriesDict[query] = python::make_function(queryMethod, call_policies, func_sig());
 		}
 
@@ -107,7 +107,7 @@ QList<TupleSet> ScriptQuery::execute(QList<TupleSet> input)
 
 		python::list results = python::extract<python::list>(main_namespace["results"]);
 		python::stl_input_iterator<TupleSet> begin(results), end;
-		result = QList<TupleSet>::fromStdList(std::list<TupleSet>(begin, end));
+		result = QList<Optional<TupleSet>>::fromStdList(std::list<Optional<TupleSet>>(begin, end));
 	} catch (python::error_already_set ) {
 		qDebug() << "Error in Python: " << BoostPythonHelpers::parsePythonException();
 	}
@@ -128,7 +128,7 @@ void ScriptQuery::importStar(boost::python::dict& main_namespace, boost::python:
 	}
 }
 
-QList<TupleSet> ScriptQuery::queryExecutor(QString name, boost::python::list args, boost::python::list input)
+QList<Optional<TupleSet>> ScriptQuery::queryExecutor(QString name, boost::python::list args, boost::python::list input)
 {
 	boost::python::stl_input_iterator<QString> argsBegin(args), argsEnd;
 	QStringList argsConverted = QStringList::fromStdList(std::list<QString>(argsBegin, argsEnd));

--- a/InformationScripting/src/queries/ScriptQuery.h
+++ b/InformationScripting/src/queries/ScriptQuery.h
@@ -44,7 +44,7 @@ class ScriptQuery : public Query
 		static void initPythonEnvironment();
 		static void unloadPythonEnvironment();
 
-		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
+		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;
 
 	private:
 		QString scriptPath_;
@@ -54,7 +54,7 @@ class ScriptQuery : public Query
 
 		void importStar(boost::python::dict& main_namespace, boost::python::object apiObject);
 
-		QList<TupleSet> queryExecutor(QString name, boost::python::list args, boost::python::list input);
+		QList<Optional<TupleSet>> queryExecutor(QString name, boost::python::list args, boost::python::list input);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/SubstractOperator.cpp
+++ b/InformationScripting/src/queries/SubstractOperator.cpp
@@ -30,7 +30,7 @@
 
 namespace InformationScripting {
 
-QList<TupleSet> SubstractOperator::execute(QList<TupleSet> input)
+QList<Optional<TupleSet> > SubstractOperator::execute(QList<TupleSet> input)
 {
 	Q_ASSERT(input.size() == 2);
 	auto setA = input[0];

--- a/InformationScripting/src/queries/SubstractOperator.h
+++ b/InformationScripting/src/queries/SubstractOperator.h
@@ -35,7 +35,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API SubstractOperator : public Query
 {
 	public:
-		virtual QList<TupleSet> execute(QList<TupleSet> input);
+		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/TagQuery.cpp
+++ b/InformationScripting/src/queries/TagQuery.cpp
@@ -74,9 +74,10 @@ TagQuery::TagQuery(ExecuteFunction exec, Model::Node* target, QStringList args)
 
 Optional<TupleSet> TagQuery::tags(TupleSet input)
 {
+	// TODO require at most one argument
 	bool addSet = isArgumentSet(ADD_ARGUMENT_NAMES[0]);
 	bool removeSet = isArgumentSet(REMOVE_ARGUMENT_NAMES[0]);
-	Q_ASSERT(!(addSet && removeSet)); // TODO should be user warning
+	Q_ASSERT(!(addSet && removeSet));
 	if (addSet)
 		return addTags(input);
 	else if (removeSet)
@@ -87,8 +88,9 @@ Optional<TupleSet> TagQuery::tags(TupleSet input)
 
 Optional<TupleSet> TagQuery::queryTags(TupleSet input)
 {
+	// TODO require argument
 	QString tagText = argument(NAME_ARGUMENT_NAMES[0]);
-	Q_ASSERT(tagText.size() > 0); // TODO should be user warning
+	Q_ASSERT(tagText.size() > 0);
 	// Keep stuff in the input
 	TupleSet result = input;
 
@@ -116,15 +118,16 @@ Optional<TupleSet> TagQuery::addTags(TupleSet input)
 	TupleSet result = input;
 	QList<Model::Node*> addTagsTo;
 
+	// TODO require argument
 	QString tagText = argument(NAME_ARGUMENT_NAMES[0]);
-	Q_ASSERT(tagText.size() > 0); // TODO should be user warning
+	Q_ASSERT(tagText.size() > 0);
 
 	if (scope() == Scope::Local)
 		addTagsTo << target();
 	else if (scope() == Scope::Global)
 	{
 		// That doesn't make sense, to which nodes should we add the tags?
-		// TODO: warn user
+		// TODO: don't allow global argument!
 	}
 	else if (scope() == Scope::Input)
 		for (const auto& tuple : input.tuples("ast"))
@@ -155,8 +158,9 @@ Optional<TupleSet> TagQuery::addTags(TupleSet input)
 
 Optional<TupleSet> TagQuery::removeTags(TupleSet input)
 {
+	// TODO require argument.
 	QString tagText = argument(NAME_ARGUMENT_NAMES[0]);
-	Q_ASSERT(tagText.size() > 0); // TODO should be user warning
+	Q_ASSERT(tagText.size() > 0);
 
 	// Keep stuff in the input
 	TupleSet result = input;

--- a/InformationScripting/src/queries/TagQuery.cpp
+++ b/InformationScripting/src/queries/TagQuery.cpp
@@ -56,9 +56,9 @@ void TagQuery::registerDefaultQueries()
 		return new TagQuery(&TagQuery::addTags, target, args);
 	});
 	// Alias to "tags -r"
-//	QueryRegistry::instance().registerQueryConstructor("removeTags", [](Model::Node* target, QStringList args) {
-//		return new TagQuery(&TagQuery::removeTags, target, args);
-//	});
+	QueryRegistry::instance().registerQueryConstructor("removeTags", [](Model::Node* target, QStringList args) {
+		return new TagQuery(&TagQuery::removeTags, target, args);
+	});
 }
 
 TagQuery::TagQuery(ExecuteFunction exec, Model::Node* target, QStringList args)

--- a/InformationScripting/src/queries/TagQuery.cpp
+++ b/InformationScripting/src/queries/TagQuery.cpp
@@ -41,7 +41,7 @@ const QStringList TagQuery::ADD_ARGUMENT_NAMES{"a", "add"};
 const QStringList TagQuery::REMOVE_ARGUMENT_NAMES{"r", "remove"};
 const QStringList TagQuery::PERSISTENT_ARGUMENT_NAMES{"p", "persistent"};
 
-TupleSet TagQuery::executeLinear(TupleSet input)
+Optional<TupleSet> TagQuery::executeLinear(TupleSet input)
 {
 	return exec_(this, input);
 }
@@ -56,9 +56,9 @@ void TagQuery::registerDefaultQueries()
 		return new TagQuery(&TagQuery::addTags, target, args);
 	});
 	// Alias to "tags -r"
-	QueryRegistry::instance().registerQueryConstructor("removeTags", [](Model::Node* target, QStringList args) {
-		return new TagQuery(&TagQuery::removeTags, target, args);
-	});
+//	QueryRegistry::instance().registerQueryConstructor("removeTags", [](Model::Node* target, QStringList args) {
+//		return new TagQuery(&TagQuery::removeTags, target, args);
+//	});
 }
 
 TagQuery::TagQuery(ExecuteFunction exec, Model::Node* target, QStringList args)
@@ -72,7 +72,7 @@ TagQuery::TagQuery(ExecuteFunction exec, Model::Node* target, QStringList args)
 	persistent_ = argument(PERSISTENT_ARGUMENT_NAMES[1]) == "yes";
 }
 
-TupleSet TagQuery::tags(TupleSet input)
+Optional<TupleSet> TagQuery::tags(TupleSet input)
 {
 	bool addSet = isArgumentSet(ADD_ARGUMENT_NAMES[0]);
 	bool removeSet = isArgumentSet(REMOVE_ARGUMENT_NAMES[0]);
@@ -80,12 +80,12 @@ TupleSet TagQuery::tags(TupleSet input)
 	if (addSet)
 		return addTags(input);
 	else if (removeSet)
-		return removeTags(input);
+		return removeTags(input).value();
 	else
 		return queryTags(input);
 }
 
-TupleSet TagQuery::queryTags(TupleSet input)
+Optional<TupleSet> TagQuery::queryTags(TupleSet input)
 {
 	QString tagText = argument(NAME_ARGUMENT_NAMES[0]);
 	Q_ASSERT(tagText.size() > 0); // TODO should be user warning
@@ -110,7 +110,7 @@ TupleSet TagQuery::queryTags(TupleSet input)
 	return result;
 }
 
-TupleSet TagQuery::addTags(TupleSet input)
+Optional<TupleSet> TagQuery::addTags(TupleSet input)
 {
 	// Keep stuff in the input
 	TupleSet result = input;
@@ -153,7 +153,7 @@ TupleSet TagQuery::addTags(TupleSet input)
 	return result;
 }
 
-TupleSet TagQuery::removeTags(TupleSet input)
+Optional<TupleSet> TagQuery::removeTags(TupleSet input)
 {
 	QString tagText = argument(NAME_ARGUMENT_NAMES[0]);
 	Q_ASSERT(tagText.size() > 0); // TODO should be user warning

--- a/InformationScripting/src/queries/TagQuery.h
+++ b/InformationScripting/src/queries/TagQuery.h
@@ -30,6 +30,8 @@
 
 #include "ScopedArgumentQuery.h"
 
+#include "../misc/Optional.h"
+
 namespace Model {
 	class SymbolMatcher;
 	class Text;
@@ -40,7 +42,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API TagQuery : public ScopedArgumentQuery
 {
 	public:
-		virtual TupleSet executeLinear(TupleSet input) override;
+		virtual Optional<TupleSet> executeLinear(TupleSet input) override;
 
 		static void registerDefaultQueries();
 
@@ -50,15 +52,15 @@ class INFORMATIONSCRIPTING_API TagQuery : public ScopedArgumentQuery
 		static const QStringList REMOVE_ARGUMENT_NAMES;
 		static const QStringList PERSISTENT_ARGUMENT_NAMES;
 
-		using ExecuteFunction = std::function<TupleSet (TagQuery*, TupleSet)>;
+		using ExecuteFunction = std::function<Optional<TupleSet> (TagQuery*, TupleSet)>;
 		ExecuteFunction exec_{};
 		bool persistent_{true};
 
 		TagQuery(ExecuteFunction exec, Model::Node* target, QStringList args);
-		TupleSet tags(TupleSet input);
-		TupleSet queryTags(TupleSet input);
-		TupleSet addTags(TupleSet input);
-		TupleSet removeTags(TupleSet input);
+		Optional<TupleSet> tags(TupleSet input);
+		Optional<TupleSet> queryTags(TupleSet input);
+		Optional<TupleSet> addTags(TupleSet input);
+		Optional<TupleSet> removeTags(TupleSet input);
 
 		void insertFoundTags(TupleSet& tuples, const Model::SymbolMatcher& matcher, Model::Node* target = nullptr);
 };

--- a/InformationScripting/src/queries/UnionOperator.cpp
+++ b/InformationScripting/src/queries/UnionOperator.cpp
@@ -28,9 +28,9 @@
 
 namespace InformationScripting {
 
-QList<TupleSet> UnionOperator::execute(QList<TupleSet> input)
+QList<Optional<TupleSet> > UnionOperator::execute(QList<TupleSet> input)
 {
-	if (input.size() <= 1) return input;
+	if (input.size() <= 1) return {{"Union requires 2 inputs"}};
 
 	auto outTuples = input.takeFirst();
 	for (auto inTuples : input)

--- a/InformationScripting/src/queries/UnionOperator.h
+++ b/InformationScripting/src/queries/UnionOperator.h
@@ -35,7 +35,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API UnionOperator : public Query
 {
 	public:
-		virtual QList<TupleSet> execute(QList<TupleSet> input) override;
+		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -42,7 +42,7 @@ namespace InformationScripting {
 
 const QStringList VersionControlQuery::COUNT_ARGUMENT_NAMES{"c", "count"};
 
-TupleSet VersionControlQuery::executeLinear(TupleSet)
+Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet)
 {
 	const int CHANGE_COUNT = argument(COUNT_ARGUMENT_NAMES[0]).toInt();
 

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -52,8 +52,8 @@ Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet)
 	// get GitRepository
 	QString path("projects/");
 	path.append(managerName);
-	// TODO user error later:
-	Q_ASSERT(GitRepository::repositoryExists(path));
+	if (!GitRepository::repositoryExists(path)) return {"No repository found"};
+
 	GitRepository repository{path};
 	TupleSet result;
 

--- a/InformationScripting/src/queries/VersionControlQuery.h
+++ b/InformationScripting/src/queries/VersionControlQuery.h
@@ -39,7 +39,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API VersionControlQuery : public ScopedArgumentQuery
 {
 	public:
-		virtual TupleSet executeLinear(TupleSet input) override;
+		virtual Optional<TupleSet> executeLinear(TupleSet input) override;
 
 		static void registerDefaultQueries();
 	private:

--- a/InformationScripting/src/visualization/Heatmap.cpp
+++ b/InformationScripting/src/visualization/Heatmap.cpp
@@ -34,7 +34,7 @@ namespace InformationScripting {
 
 const QStringList Heatmap::VALUE_ATTRIBUTE_NAME_NAMES{"n", "name"};
 
-TupleSet Heatmap::executeLinear(TupleSet input)
+Optional<TupleSet> Heatmap::executeLinear(TupleSet input)
 {
 	QString valueTag = argument(VALUE_ATTRIBUTE_NAME_NAMES[1]);
 	if (valueTag.isEmpty()) valueTag = "count"; // Use count as default tag for heatmaps

--- a/InformationScripting/src/visualization/Heatmap.h
+++ b/InformationScripting/src/visualization/Heatmap.h
@@ -35,7 +35,7 @@ namespace InformationScripting {
 class Heatmap : public ScopedArgumentQuery
 {
 	public:
-		virtual TupleSet executeLinear(TupleSet input) override;
+		virtual Optional<TupleSet> executeLinear(TupleSet input) override;
 
 		static void registerDefaultQueries();
 

--- a/InformationScripting/src/wrappers/DataApi.cpp
+++ b/InformationScripting/src/wrappers/DataApi.cpp
@@ -31,6 +31,8 @@
 
 #include "ModelBase/src/nodes/Node.h"
 
+#include "../misc/Optional.h"
+
 namespace InformationScripting {
 
 using namespace boost::python;
@@ -95,6 +97,8 @@ BOOST_PYTHON_MODULE(DataApi) {
 				.def("take", take1)
 				.def("remove", removeTuple)
 				.def("add", &TupleSet::add);
+
+		class_<Optional<TupleSet>>("OptionalTupleSet", init<TupleSet>());
 }
 
 } /* namespace InformationScripting */


### PR DESCRIPTION
Okay here the new proposal for runtime error handling. It is not complete yet so please do not merge, but please let me know if it is okayish?
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42227455%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42227568%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42227636%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42227685%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42232014%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42232152%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42234677%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42234795%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42235122%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42235179%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42235384%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42235421%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42235475%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42235632%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23issuecomment-148701086%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42235953%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42237866%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42237970%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42238460%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42238484%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42241156%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42360969%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23issuecomment-149197374%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23issuecomment-149216589%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23issuecomment-149238671%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23issuecomment-149258830%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%204a5fe62fb15575c3453c8bda466b5bbf8f6620ca%20InformationScripting/src/queries/TagQuery.cpp%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42235475%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Do%20we%20not%20want%20this%20alias%20any%20more%2C%20or%20why%20did%20this%20get%20commented%3F%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A08%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%27s%20just%20an%20oversight.%20It%20should%20still%20be%20here.%20Thanks%20for%20noticing%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A47%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/TagQuery.cpp%3AL56-65%22%7D%2C%20%22Pull%204a5fe62fb15575c3453c8bda466b5bbf8f6620ca%20InformationScripting/src/misc/Optional.h%2066%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42234795%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20The%20optional%20type%20needs%20to%20support%20not%20one%2C%20but%20many%20warnings.%20Imagine%20that%20during%20execution%2C%20multiple%20queries%20give%20a%20warning%2C%20and%20then%20finally%20we%20get%20an%20error%20from%20somewhere.%20We%20want%20to%20show%20all%20of%20these%20to%20the%20user.%22%2C%20%22created_at%22%3A%20%222015-10-16T11%3A58%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20you%20suggest%20to%20have%20a%20collection%20of%20warnings%20in%20here%3F%20This%20starts%20to%20feel%20kind%20of%20heavy%20to%20me.%20But%20on%20the%20other%20hand%20I%20don%27t%20see%20a%20better%20solution%20a%20the%20moment.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A45%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22More%20abstractly%2C%20we%20need%20a%20way%20to%20describe%20why%20an%20optional%20is%20empty.%20In%20our%20particular%20case%2C%20this%20could%20be%20due%20to%20one%20or%20several%20errors%2C%20which%20were%20possibly%20preceded%20by%20one%20or%20several%20warnings.%20I%20agree%20it%27s%20somewhat%20heavy%20here%2C%20but%20on%20the%20bright%20side%2C%20the%20code%20where%20you%20create/handle%20the%20warnings/errors%2C%20doesn%27t%20change%20much.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A52%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/misc/Optional.h%3AL1-123%22%7D%2C%20%22Pull%204a5fe62fb15575c3453c8bda466b5bbf8f6620ca%20InformationScripting/src/queries/UnionOperator.cpp%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42235632%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20now%20that%20I%20look%20at%20this%20example%2C%20I%27m%20not%20sure%20if%20we%20should%20have%20%60QList%3COptional%3CTupleSet%3E%3E%60%20or%20%60Optional%3CQList%3CTupleSet%3E%3E%60.%20What%20are%20pros%20and%20cons%20of%20each%20approach%3F%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A11%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/UnionOperator.cpp%3AL28-37%22%7D%2C%20%22Pull%204a5fe62fb15575c3453c8bda466b5bbf8f6620ca%20InformationScripting/src/queries/CompositeQuery.cpp%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42235122%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22So%20in%20places%20like%20this.%20You%20shouldn%27t%20ignore%20other%20potential%20errors%2C%20warnings%2C%20but%20you%20should%20combine%20them%20all%20and%20output%20all.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A02%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20should%20probably%20implement%20a%20merge%20funtion%20inside%20Optional%2C%20which%20takes%20a%20list%20of%20Optional%20and%20gives%20you%20back%20one%20Optional%2C%20which%20you%20can%20finally%20check%20for%20error%20and%20break%20if%20it%20has%20at%20least%20one%20error.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A03%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20now%20that%20I%20think%20about%20it%2C%20I%27m%20not%20sure%20about%20the%20merge%20function%20and%20where%20it%20should%20be.%20We%20want%20to%20transition%20from%20a%20%60QList%3COptional%3E%60%20to%20%60Optional%3CQList%3C%60.%20See%20also%20some%20of%20my%20comments%20below%20about%20this.%20Perhaps%2C%20logically%2C%20the%20correct%20thing%20to%20have%20is%20indeed%20%60Optional%3CQList%3CTupleSet%3E%3E%60%20as%20the%20return%20type%20of%20%60Query%3A%3Aexecute%60.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A16%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22About%20the%20first%20comment%2C%20in%20that%20place%20there%20should%20only%20ever%20be%20one%20error%20%28otherwise%20we%20would%20have%20aborted%20already%29%2C%20but%20maybe%20multiple%20warnings.%5Cr%5Cn%5Cr%5CnI%20will%20have%20to%20think%20about%20Optional%3CQList%20vs%20QList%3COptional%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A52%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20what%20about%20a%20hypothetical%20scenario%20where%20two%20independent%20branches%20of%20a%20composite%20query%20both%20have%20an%20error.%20Should%20we%20just%20pick%20one%20of%20those%20at%20random%20and%20return%20it%3F%20Especially%20later%2C%20if%20we%20allow%20parallel%20execution%20at%20some%20point%2C%20this%20will%20be%20a%20problem.%5Cr%5Cn%5Cr%5CnI%20guess%20if%20you%20convert%20everything%20to%20%60Optional%3CQList%3C..%3E%3E%60%20then%20in%20the%20sequential%20case%2C%20we%20can%20still%20get%20away%20with%20one%20error.%5Cr%5Cn%5Cr%5CnMight%20be%20nicer/easier%20though%20to%20treat%20errors%20and%20warnings%20almost%20identically%20in%20%60Optional%60%2C%20so%20to%20have%20a%20list%20that%20can%20hold%20either.%22%2C%20%22created_at%22%3A%20%222015-10-16T13%3A22%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20we%20allow%20parallel%20execution%20we%20will%20have%20to%20rewrite%20this%20code%20anyway.%20Therefore%20I%20will%20simply%20return%20the%20error%20Optional%20if%20there%20is%20an%20error.%5Cr%5Cn%5Cr%5CnI%27m%20not%20sure%20why%20QList%3COptional%3C..%20would%20hinder%20me%20from%20doing%20this%3F%22%2C%20%22created_at%22%3A%20%222015-10-19T11%3A37%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/CompositeQuery.cpp%3AL77-90%22%7D%2C%20%22Pull%204a5fe62fb15575c3453c8bda466b5bbf8f6620ca%20InformationScripting/src/queries/ScriptQuery.cpp%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42235421%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%2C%20always%20use%20%60using%20...%20%3D%20...%60%20instead%20of%20%60typedef%60.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A07%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/ScriptQuery.cpp%3AL97-104%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23issuecomment-148701086%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Overall%2C%20I%20think%20I%20like%20the%20error%20handling%20direction.%20We%20just%20need%20to%20figure%20out%20how%20to%20handle%20lists%20of%20Optionals.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A14%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20I%20think%20this%20is%20now%20more%20or%20less%20ready.%20Should%20I%20rebase%20or%20merge%20upstream%20once%20you%20think%20it%27s%20ready%3F%20I%20think%20rebase%20would%20be%20nicer.%22%2C%20%22created_at%22%3A%20%222015-10-19T12%3A13%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Just%20rebase%20it.%22%2C%20%22created_at%22%3A%20%222015-10-19T13%3A42%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Rebased%22%2C%20%22created_at%22%3A%20%222015-10-19T14%3A53%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20so%20I%27ll%20merge%20this%2C%20but%20I%20still%20want%20to%20discuss%20the%20%60QList%3COptional%3CTupleSet%3E%3E%60%20vs%20%60Optional%3CQList%3CTupleSet%3E%3E%60%20issue.%22%2C%20%22created_at%22%3A%20%222015-10-19T16%3A00%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%204a5fe62fb15575c3453c8bda466b5bbf8f6620ca%20InformationScripting/src/queries/QueryExecutor.cpp%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42235384%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20should%20return%20this%20to%20the%20command%20prompt%20and%20display%20it%20inside%20the%20command%20result.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A07%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/QueryExecutor.cpp%3AL44-60%22%7D%2C%20%22Pull%20c76e78c25018c6625fd6c2e902d855256ba417d4%20InformationScripting/src/misc/Optional.h%2042%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42227636%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22can%20%60QString%60%20ever%20be%20%60constrexp%60%20%3F%20I%20don%27t%20think%20so%20as%20it%20has%20heap%20allocation.%20Therefore%2C%20I%20think%20these%20methods%20can%20never%20be%20used%20as%20%60constexpr%60%20so%20you%20should%20remove%20that.%22%2C%20%22created_at%22%3A%20%222015-10-16T10%3A11%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20same%20applies%20for%20all%20the%20other%20methods%20I%20believe.%22%2C%20%22created_at%22%3A%20%222015-10-16T10%3A11%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22True%22%2C%20%22created_at%22%3A%20%222015-10-16T11%3A18%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/misc/Optional.h%3AL1-123%22%7D%2C%20%22Pull%20c76e78c25018c6625fd6c2e902d855256ba417d4%20InformationScripting/src/misc/Optional.h%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/173%23discussion_r42227455%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20I%20didn%27t%20know%20that%20one%20can%20put%20a%20static%20assert%20directly%20like%20this.%20We%20have%20no%20good%20way%20of%20expressing%20this%20in%20Envision%20at%20the%20moment.%20Good%20to%20know%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-10-16T10%3A08%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20do%20we%20actually%20need%20this%3F%20If%20you%20remove%20the%20%60static_assert%60%20compilation%20will%20still%20fail%20statically%2C%20as%20the%20constructors%20below%20will%20be%20ambiguous%2C%20or%20am%20I%20wrong%3F%22%2C%20%22created_at%22%3A%20%222015-10-16T10%3A10%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22True%2C%20but%20the%20message%20would%20be%20more%20clear%20than%20a%20list%20of%20errors%20about%20ambigious%20contrsuctors.%20I%20can%20remove%20it%20if%20you%20want.%22%2C%20%22created_at%22%3A%20%222015-10-16T11%3A20%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Let%27s%20leave%20it%20for%20now.%22%2C%20%22created_at%22%3A%20%222015-10-16T11%3A56%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/misc/Optional.h%3AL1-123%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull c76e78c25018c6625fd6c2e902d855256ba417d4 InformationScripting/src/misc/Optional.h 40'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/173#discussion_r42227455'>File: InformationScripting/src/misc/Optional.h:L1-123</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, I didn't know that one can put a static assert directly like this. We have no good way of expressing this in Envision at the moment. Good to know :)
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> But do we actually need this? If you remove the `static_assert` compilation will still fail statically, as the constructors below will be ambiguous, or am I wrong?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> True, but the message would be more clear than a list of errors about ambigious contrsuctors. I can remove it if you want.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Let's leave it for now.
- [x] <a href='#crh-comment-Pull c76e78c25018c6625fd6c2e902d855256ba417d4 InformationScripting/src/misc/Optional.h 42'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/173#discussion_r42227636'>File: InformationScripting/src/misc/Optional.h:L1-123</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> can `QString` ever be `constrexp` ? I don't think so as it has heap allocation. Therefore, I think these methods can never be used as `constexpr` so you should remove that.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> The same applies for all the other methods I believe.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> True
- [x] <a href='#crh-comment-Pull 4a5fe62fb15575c3453c8bda466b5bbf8f6620ca InformationScripting/src/misc/Optional.h 66'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/173#discussion_r42234795'>File: InformationScripting/src/misc/Optional.h:L1-123</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, The optional type needs to support not one, but many warnings. Imagine that during execution, multiple queries give a warning, and then finally we get an error from somewhere. We want to show all of these to the user.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> So you suggest to have a collection of warnings in here? This starts to feel kind of heavy to me. But on the other hand I don't see a better solution a the moment.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> More abstractly, we need a way to describe why an optional is empty. In our particular case, this could be due to one or several errors, which were possibly preceded by one or several warnings. I agree it's somewhat heavy here, but on the bright side, the code where you create/handle the warnings/errors, doesn't change much.
- [x] <a href='#crh-comment-Pull 4a5fe62fb15575c3453c8bda466b5bbf8f6620ca InformationScripting/src/queries/CompositeQuery.cpp 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/173#discussion_r42235122'>File: InformationScripting/src/queries/CompositeQuery.cpp:L77-90</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> So in places like this. You shouldn't ignore other potential errors, warnings, but you should combine them all and output all.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You should probably implement a merge funtion inside Optional, which takes a list of Optional and gives you back one Optional, which you can finally check for error and break if it has at least one error.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, now that I think about it, I'm not sure about the merge function and where it should be. We want to transition from a `QList<Optional>` to `Optional<QList<`. See also some of my comments below about this. Perhaps, logically, the correct thing to have is indeed `Optional<QList<TupleSet>>` as the return type of `Query::execute`.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> About the first comment, in that place there should only ever be one error (otherwise we would have aborted already), but maybe multiple warnings.
  I will have to think about Optional<QList vs QList<Optional
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Well, what about a hypothetical scenario where two independent branches of a composite query both have an error. Should we just pick one of those at random and return it? Especially later, if we allow parallel execution at some point, this will be a problem.
  I guess if you convert everything to `Optional<QList<..>>` then in the sequential case, we can still get away with one error.
  Might be nicer/easier though to treat errors and warnings almost identically in `Optional`, so to have a list that can hold either.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> If we allow parallel execution we will have to rewrite this code anyway. Therefore I will simply return the error Optional if there is an error.
  I'm not sure why QList<Optional<.. would hinder me from doing this?
- [x] <a href='#crh-comment-Pull 4a5fe62fb15575c3453c8bda466b5bbf8f6620ca InformationScripting/src/queries/QueryExecutor.cpp 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/173#discussion_r42235384'>File: InformationScripting/src/queries/QueryExecutor.cpp:L44-60</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> We should return this to the command prompt and display it inside the command result.
- [x] <a href='#crh-comment-Pull 4a5fe62fb15575c3453c8bda466b5bbf8f6620ca InformationScripting/src/queries/ScriptQuery.cpp 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/173#discussion_r42235421'>File: InformationScripting/src/queries/ScriptQuery.cpp:L97-104</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please, always use `using ... = ...` instead of `typedef`.
- [x] <a href='#crh-comment-Pull 4a5fe62fb15575c3453c8bda466b5bbf8f6620ca InformationScripting/src/queries/TagQuery.cpp 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/173#discussion_r42235475'>File: InformationScripting/src/queries/TagQuery.cpp:L56-65</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Do we not want this alias any more, or why did this get commented?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> That's just an oversight. It should still be here. Thanks for noticing
- [ ] <a href='#crh-comment-Pull 4a5fe62fb15575c3453c8bda466b5bbf8f6620ca InformationScripting/src/queries/UnionOperator.cpp 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/173#discussion_r42235632'>File: InformationScripting/src/queries/UnionOperator.cpp:L28-37</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, now that I look at this example, I'm not sure if we should have `QList<Optional<TupleSet>>` or `Optional<QList<TupleSet>>`. What are pros and cons of each approach?
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/173#issuecomment-148701086'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Overall, I think I like the error handling direction. We just need to figure out how to handle lists of Optionals.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> So I think this is now more or less ready. Should I rebase or merge upstream once you think it's ready? I think rebase would be nicer.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Just rebase it.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Rebased
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> OK, so I'll merge this, but I still want to discuss the `QList<Optional<TupleSet>>` vs `Optional<QList<TupleSet>>` issue.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/173?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/173?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/173'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
