### PR TITLE
Version control queries

### DIFF
--- a/FilePersistence/src/version_control/GitRepository.cpp
+++ b/FilePersistence/src/version_control/GitRepository.cpp
@@ -1074,8 +1074,7 @@ git_commit* GitRepository::parseCommit(QString revision) const
 
 QString GitRepository::oidToQString(const git_oid* oid) const
 {
-	char sha1[41];
-	sha1[40] = '\0';
+	char sha1[GIT_OID_HEXSZ + 1] = {0};
 
 	git_oid_fmt(sha1, oid);
 

--- a/InformationScripting/src/queries/VersionControlQuery.h
+++ b/InformationScripting/src/queries/VersionControlQuery.h
@@ -30,6 +30,10 @@
 
 #include "ScopedArgumentQuery.h"
 
+namespace FilePersistence {
+	struct CommitMetaData;
+}
+
 namespace InformationScripting {
 
 class INFORMATIONSCRIPTING_API VersionControlQuery : public ScopedArgumentQuery
@@ -42,6 +46,8 @@ class INFORMATIONSCRIPTING_API VersionControlQuery : public ScopedArgumentQuery
 		static const QStringList COUNT_ARGUMENT_NAMES;
 
 		VersionControlQuery(Model::Node* target, QStringList args);
+
+		static void addCommitMetaInformation(TupleSet& ts, const FilePersistence::CommitMetaData& metadata);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/test/scripts/countChanges.py
+++ b/InformationScripting/test/scripts/countChanges.py
@@ -1,0 +1,17 @@
+# script $<"<changes>" | "<countChanges>" | "<heatmap>">$
+
+# assume single input
+input = inputs[0]
+commits = input.take("commit")
+nodeCounts = {}
+for commit in commits:
+    sha1 = commit.commit
+    for change in input.take(sha1):
+        key = getattr(change, sha1)
+        nodeCounts[key] = nodeCounts.get(key, 0) + 1
+
+result = TupleSet()
+for node, count in nodeCounts.items():
+    result.add(Tuple([NamedProperty("count", count), NamedProperty("ast", node)]))
+
+results = [result]


### PR DESCRIPTION
This changes the output of the changes query to the following format:
((commit, sha1) ... commit meta infos...)
for each changed node in a commit there is also a tuple as follows:
(sha1, Node*)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/174%23discussion_r42236166%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/174%23discussion_r42236465%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/174%23issuecomment-148703730%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/174%23discussion_r42237694%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/174%23discussion_r42237951%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/174%23discussion_r42238167%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2088dd94982afa76c3e450c9b186fa8054979779d3%20FilePersistence/src/version_control/GitRepository.cpp%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/174%23discussion_r42236166%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Well%2C%20since%20you%27re%20doing%20this%2C%20using%20default%20initialization%20%60%7B%7D%60%20is%20even%20nicer%2C%20I%20think.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A19%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitRepository.cpp%3AL1074-1081%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/174%23issuecomment-148703730%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22OK%2C%20I%27ll%20merge%20this%20since%20it%20looks%20good.%20Feel%20free%20to%20implement%20the%20improvements%20in%20a%20later%20request.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A26%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2088dd94982afa76c3e450c9b186fa8054979779d3%20InformationScripting/test/scripts/countChanges.py%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/174%23discussion_r42236465%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20should%20definitely%20leave%20this%20script%20to%20serve%20an%20as%20example%2C%20but%20I%20think%20this%20particular%20query%20%28the%20entire%20query%29%20should%20be%20achievable%20without%20python.%20I%20guess%20we%20need%20to%20have%20a%20few%20common%20functions%20that%20do%20grouping/counting%20and%20this%20should%20be%20one%20of%20the%20use%20cases%20where%20we%20do%20that.%20This%20could%20be%20a%20future%20PR%2C%20but%20please%20have%20it%20in%20mind.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A25%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20does%20it%20matter%20if%20it%20is%20implemented%20in%20C%2B%2B%20or%20in%20python%3F%20What%20you%20suggest%20is%20what%20I%20previously%20had%2C%20i.e.%20this%20specific%20use%20case.%20Now%20we%20have%20a%20more%20generic%20output%20and%20can%20use%20it%20in%20many%20ways.%20I%27m%20not%20sure%20what%20the%20advantages%20would%20be%20if%20such%20cases%20would%20be%20supported%20by%20C%2B%2B%20implementation.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A43%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20suggesting%20what%20you%20previously%20had.%20That%20was%20a%20single%20command%20that%20did%20it%20all.%5Cr%5Cn%5Cr%5CnNow%20I%27m%20just%20thinking%20that%20we%20need%20a%20generic%20command%20for%20the%20%60countChanges%60%20part%20of%20the%20three-part%20pipeline%20above.%20One%20which%20is%20not%20specific%20for%20commits%2C%20but%20where%20we%20can%20take%20the%20things%20to%20counts/group%20by%20arguments.%5Cr%5Cn%5Cr%5CnAnd%20you%27re%20right%2C%20we%20don%27t%20have%20to%20do%20this%20in%20C%2B%2B.%20In%20fact%2C%20now%20that%20I%20think%20about%20it%2C%20it%27s%20probably%20nicer%20to%20do%20it%20in%20Python%2C%20so%20that%20we%20get%20to%20show%20how%20it%20can%20be%20used%20for%20such%2C%20more%20generic%2C%20things.%5Cr%5Cn%5Cr%5CnDoes%20this%20make%20sense%3F%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A46%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Aha%20now%20I%20understand%20what%20you%20meant.%20Yes%20makes%20sense.%22%2C%20%22created_at%22%3A%20%222015-10-16T12%3A49%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/test/scripts/countChanges.py%3AL1-18%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 88dd94982afa76c3e450c9b186fa8054979779d3 FilePersistence/src/version_control/GitRepository.cpp 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/174#discussion_r42236166'>File: FilePersistence/src/version_control/GitRepository.cpp:L1074-1081</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Well, since you're doing this, using default initialization `{}` is even nicer, I think.
- [ ] <a href='#crh-comment-Pull 88dd94982afa76c3e450c9b186fa8054979779d3 InformationScripting/test/scripts/countChanges.py 1'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/174#discussion_r42236465'>File: InformationScripting/test/scripts/countChanges.py:L1-18</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You should definitely leave this script to serve an as example, but I think this particular query (the entire query) should be achievable without python. I guess we need to have a few common functions that do grouping/counting and this should be one of the use cases where we do that. This could be a future PR, but please have it in mind.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> What does it matter if it is implemented in C++ or in python? What you suggest is what I previously had, i.e. this specific use case. Now we have a more generic output and can use it in many ways. I'm not sure what the advantages would be if such cases would be supported by C++ implementation.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I'm not suggesting what you previously had. That was a single command that did it all.
  Now I'm just thinking that we need a generic command for the `countChanges` part of the three-part pipeline above. One which is not specific for commits, but where we can take the things to counts/group by arguments.
  And you're right, we don't have to do this in C++. In fact, now that I think about it, it's probably nicer to do it in Python, so that we get to show how it can be used for such, more generic, things.
  Does this make sense?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Aha now I understand what you meant. Yes makes sense.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/174#issuecomment-148703730'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> OK, I'll merge this since it looks good. Feel free to implement the improvements in a later request.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/174?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/174?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/174'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
