### PR TITLE
Make it possible to specify a isSuggestable function in NameResolver

### DIFF
--- a/ModelBase/src/util/NameResolver.h
+++ b/ModelBase/src/util/NameResolver.h
@@ -36,8 +36,11 @@ class SymbolMatcher;
 class MODELBASE_API NameResolver {
 
 	public:
-		static QList<QPair<QString, Node*>> findAllMatches(const SymbolMatcher& matcher, QString nameSoFar, Node* root);
-		static QList<QPair<QString, Node*>> mostLikelyMatches(const QString& nodeName, int matchLimit, Node* root = nullptr);
+		using IsSuggestable = std::function<bool (Node::SymbolTypes)>;
+		static QList<QPair<QString, Node*>> findAllMatches(const SymbolMatcher& matcher, QString nameSoFar,
+																			Node* root, IsSuggestable suggestable);
+		static QList<QPair<QString, Node*>> mostLikelyMatches(const QString& nodeName, int matchLimit,
+																				Node* root = nullptr, IsSuggestable suggestable = isSuggestable);
 
 	private:
 		static bool isSuggestable(Node::SymbolTypes symbolType);


### PR DESCRIPTION
This makes it possible to find Variables as well in the
AstQuery::nameQuery function.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/176?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/176'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
