### PR TITLE
Dependency targets

### DIFF
--- a/CppExport/CppExport.pro
+++ b/CppExport/CppExport.pro
@@ -12,7 +12,8 @@ HEADERS += src/precompiled.h \
 	src/cppexport_api.h \
 	src/CppExportPlugin.h \
 	src/dependency_analysis/DependencyAnalyzer.h \
-	src/dependency_analysis/DependencyUnit.h
+	src/dependency_analysis/DependencyUnit.h \
+	src/dependency_analysis/DependencyTarget.h
 SOURCES += src/CppExportException.cpp \
 	src/CppExportPlugin.cpp \
 	test/SimpleTest.cpp \

--- a/CppExport/src/dependency_analysis/DependencyAnalyzer.h
+++ b/CppExport/src/dependency_analysis/DependencyAnalyzer.h
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#include "cppexport_api.h"
+#include "../cppexport_api.h"
 
 namespace Model {
 	class Node;

--- a/CppExport/src/dependency_analysis/DependencyTarget.h
+++ b/CppExport/src/dependency_analysis/DependencyTarget.h
@@ -28,31 +28,16 @@
 
 #include "../cppexport_api.h"
 
-#include "DependencyTarget.h"
-
 namespace Model {
 	class Node;
 }
 
-namespace OOModel {
-	class ReferenceExpression;
-}
-
 namespace CppExport {
 
-class CPPEXPORT_API DependencyUnit
+struct CPPEXPORT_API DependencyTarget
 {
-	public:
-		DependencyUnit(QString name, Model::Node* node);
-
-	private:
-		QString name_;
-		Model::Node* node_;
-		QList<DependencyTarget> targets_;
-
-		static QList<DependencyTarget> calculateTargets(Model::Node* node);
-		static bool isSoftDependency(OOModel::ReferenceExpression* reference);
-		static Model::Node* fixedTarget(OOModel::ReferenceExpression* referenceExpression);
+	bool soft_;
+	Model::Node* target_;
 };
 
 }

--- a/CppExport/src/dependency_analysis/DependencyTarget.h
+++ b/CppExport/src/dependency_analysis/DependencyTarget.h
@@ -36,8 +36,8 @@ namespace CppExport {
 
 struct CPPEXPORT_API DependencyTarget
 {
-	bool soft_;
-	Model::Node* target_;
+	bool soft_{};
+	Model::Node* target_{};
 };
 
 }

--- a/CppExport/src/dependency_analysis/DependencyTarget.h
+++ b/CppExport/src/dependency_analysis/DependencyTarget.h
@@ -36,7 +36,7 @@ namespace CppExport {
 
 struct CPPEXPORT_API DependencyTarget
 {
-	bool soft_{};
+	bool nameOnly_{};
 	Model::Node* target_{};
 };
 

--- a/CppExport/src/dependency_analysis/DependencyUnit.cpp
+++ b/CppExport/src/dependency_analysis/DependencyUnit.cpp
@@ -37,11 +37,11 @@ QList<DependencyTarget> DependencyUnit::calculateTargets(Model::Node* node)
 {
 	QList<DependencyTarget> result;
 	for (auto referenceExpression : Model::Node::childrenOfType<OOModel::ReferenceExpression>(node))
-		result.append({isSoftDependency(referenceExpression), fixedTarget(referenceExpression)});
+		result.append({isNameOnlyDependency(referenceExpression), fixedTarget(referenceExpression)});
 	return result;
 }
 
-bool DependencyUnit::isSoftDependency(OOModel::ReferenceExpression* reference)
+bool DependencyUnit::isNameOnlyDependency(OOModel::ReferenceExpression* reference)
 {
 	auto parent = reference->parent();
 	Q_ASSERT(parent);

--- a/CppExport/src/dependency_analysis/DependencyUnit.cpp
+++ b/CppExport/src/dependency_analysis/DependencyUnit.cpp
@@ -30,10 +30,8 @@
 
 namespace CppExport {
 
-DependencyUnit::DependencyUnit(QString name, Model::Node* node) : name_(name), node_(node)
-{
-	targets_ = calculateTargets(node);
-}
+DependencyUnit::DependencyUnit(QString name, Model::Node* node)
+	: name_(name), node_(node), targets_(calculateTargets(node)) {}
 
 QList<DependencyTarget> DependencyUnit::calculateTargets(Model::Node* node)
 {

--- a/CppExport/src/dependency_analysis/DependencyUnit.cpp
+++ b/CppExport/src/dependency_analysis/DependencyUnit.cpp
@@ -30,6 +30,39 @@
 
 namespace CppExport {
 
-DependencyUnit::DependencyUnit(QString name, Model::Node* node) : name_(name), node_(node) {}
+DependencyUnit::DependencyUnit(QString name, Model::Node* node) : name_(name), node_(node)
+{
+	targets_ = calculateTargets(node);
+}
+
+QList<DependencyTarget> DependencyUnit::calculateTargets(Model::Node* node)
+{
+	QList<DependencyTarget> result;
+	for (auto referenceExpression : Model::Node::childrenOfType<OOModel::ReferenceExpression>(node))
+		result.append({isSoftDependency(referenceExpression), fixedTarget(referenceExpression)});
+	return result;
+}
+
+bool DependencyUnit::isSoftDependency(OOModel::ReferenceExpression* reference)
+{
+	auto parent = reference->parent();
+	Q_ASSERT(parent);
+
+	if (reference->firstAncestorOfType<OOModel::MethodCallExpression>()) return false;
+
+	if (DCast<OOModel::TypeQualifierExpression>(parent)) parent = parent->parent();
+	if (!DCast<OOModel::PointerTypeExpression>(parent) && !DCast<OOModel::ReferenceTypeExpression>(parent)) return false;
+
+	return true;
+}
+
+Model::Node* DependencyUnit::fixedTarget(OOModel::ReferenceExpression* referenceExpression)
+{
+	if (auto target = referenceExpression->target()) return target;
+
+	// insert custom resolution adjustments here
+
+	return nullptr;
+}
 
 }

--- a/CppExport/src/dependency_analysis/DependencyUnit.h
+++ b/CppExport/src/dependency_analysis/DependencyUnit.h
@@ -51,7 +51,7 @@ class CPPEXPORT_API DependencyUnit
 		QList<DependencyTarget> targets_;
 
 		static QList<DependencyTarget> calculateTargets(Model::Node* node);
-		static bool isSoftDependency(OOModel::ReferenceExpression* reference);
+		static bool isNameOnlyDependency(OOModel::ReferenceExpression* reference);
 		static Model::Node* fixedTarget(OOModel::ReferenceExpression* referenceExpression);
 };
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857300%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857379%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857429%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857453%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857494%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857501%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857561%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857607%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857769%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857880%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%205b0f46eb1e500cfb7daa3e29ae5b41d9b9f1da73%20CppExport/src/dependency_analysis/DependencyUnit.cpp%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857561%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22target%20is%20a%20field%2C%20so%20it%20should%20be%20initialized%20like%20all%20other%20fileds%3A%20%60%20name_%7B..%7D%2C%20....%2C%20targets_%7BcalculateTargets%28node%29%7D%60%22%2C%20%22created_at%22%3A%20%222015-10-23T12%3A05%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppExport/src/dependency_analysis/DependencyUnit.cpp%3AL30-69%22%7D%2C%20%22Pull%205b0f46eb1e500cfb7daa3e29ae5b41d9b9f1da73%20CppExport/src/dependency_analysis/DependencyUnit.h%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857429%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20call%20this%20%60dependencies_%60%22%2C%20%22created_at%22%3A%20%222015-10-23T12%3A03%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20thing%20is%20that%20this%20does%20not%20yet%20refer%20to%20dependency%20units.%20It%20is%20just%20the%20targets%20of%20references%20occuring%20in%20the%20current%20dependency%20unit.%20The%20dependency%20on%20other%20units%20is%20supposed%20to%20be%20computed%20after%20the%20merge%20step%20as%20far%20as%20I%20understood.%22%2C%20%22created_at%22%3A%20%222015-10-23T12%3A06%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6049349%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/patrick-luethi%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20you%27re%20right.%20Targets%20sounds%20good%20then.%20Leave%20it%20as%20it%20is.%22%2C%20%22created_at%22%3A%20%222015-10-23T12%3A11%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppExport/src/dependency_analysis/DependencyUnit.h%3AL48-59%22%7D%2C%20%22Pull%205b0f46eb1e500cfb7daa3e29ae5b41d9b9f1da73%20CppExport/src/dependency_analysis/DependencyTarget.h%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857300%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22always%20default%20initialize%20primitive%20fields%20like%20this%20one%20and%20the%20one%20under.%22%2C%20%22created_at%22%3A%20%222015-10-23T12%3A01%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Also%2C%20I%27m%20not%20sure%20if%20we%20should%20use%20soft.%20It%27s%20not%20a%20very%20descriptive%20name.%20What%20about%20using%20%60nameOnly_%60%3F%20Is%20it%20somehow%20widely%20understood%20in%20the%20other%20porjects%20that%20soft%20means%20name%20only%20%3F%22%2C%20%22created_at%22%3A%20%222015-10-23T12%3A03%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20that%20is%20true.%20Alternatively%20it%20can%20be%20functionally%20descriptive%20like%3A%20forwardDeclarationSufficient_%22%2C%20%22created_at%22%3A%20%222015-10-23T12%3A04%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6049349%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/patrick-luethi%22%7D%7D%2C%20%7B%22body%22%3A%20%22Let%27s%20use%20%60nameOnly_%60%2C%20it%27s%20shorter%20and%20should%20be%20sufficiently%20detailed.%22%2C%20%22created_at%22%3A%20%222015-10-23T12%3A08%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppExport/src/dependency_analysis/DependencyTarget.h%3AL1-44%22%7D%2C%20%22Pull%205b0f46eb1e500cfb7daa3e29ae5b41d9b9f1da73%20CppExport/src/dependency_analysis/DependencyUnit.h%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857453%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60calculateDependencies%60%22%2C%20%22created_at%22%3A%20%222015-10-23T12%3A04%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppExport/src/dependency_analysis/DependencyUnit.h%3AL48-59%22%7D%2C%20%22Pull%205b0f46eb1e500cfb7daa3e29ae5b41d9b9f1da73%20CppExport/src/dependency_analysis/DependencyUnit.h%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/184%23discussion_r42857494%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22if%20you%20take%20my%20suggestion%20above%2C%20call%20this%20%60isNameOnlyDependency%60%22%2C%20%22created_at%22%3A%20%222015-10-23T12%3A04%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppExport/src/dependency_analysis/DependencyUnit.h%3AL48-59%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 5b0f46eb1e500cfb7daa3e29ae5b41d9b9f1da73 CppExport/src/dependency_analysis/DependencyTarget.h 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/184#discussion_r42857300'>File: CppExport/src/dependency_analysis/DependencyTarget.h:L1-44</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> always default initialize primitive fields like this one and the one under.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Also, I'm not sure if we should use soft. It's not a very descriptive name. What about using `nameOnly_`? Is it somehow widely understood in the other porjects that soft means name only ?
- <a href='https://github.com/patrick-luethi'><img border=0 src='https://avatars.githubusercontent.com/u/6049349?v=3' height=16 width=16'></a> I think that is true. Alternatively it can be functionally descriptive like: forwardDeclarationSufficient_
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Let's use `nameOnly_`, it's shorter and should be sufficiently detailed.
- [x] <a href='#crh-comment-Pull 5b0f46eb1e500cfb7daa3e29ae5b41d9b9f1da73 CppExport/src/dependency_analysis/DependencyUnit.h 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/184#discussion_r42857429'>File: CppExport/src/dependency_analysis/DependencyUnit.h:L48-59</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I would call this `dependencies_`
- <a href='https://github.com/patrick-luethi'><img border=0 src='https://avatars.githubusercontent.com/u/6049349?v=3' height=16 width=16'></a> The thing is that this does not yet refer to dependency units. It is just the targets of references occuring in the current dependency unit. The dependency on other units is supposed to be computed after the merge step as far as I understood.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, you're right. Targets sounds good then. Leave it as it is.
- [x] <a href='#crh-comment-Pull 5b0f46eb1e500cfb7daa3e29ae5b41d9b9f1da73 CppExport/src/dependency_analysis/DependencyUnit.h 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/184#discussion_r42857453'>File: CppExport/src/dependency_analysis/DependencyUnit.h:L48-59</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `calculateDependencies`
- [x] <a href='#crh-comment-Pull 5b0f46eb1e500cfb7daa3e29ae5b41d9b9f1da73 CppExport/src/dependency_analysis/DependencyUnit.h 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/184#discussion_r42857494'>File: CppExport/src/dependency_analysis/DependencyUnit.h:L48-59</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> if you take my suggestion above, call this `isNameOnlyDependency`
- [x] <a href='#crh-comment-Pull 5b0f46eb1e500cfb7daa3e29ae5b41d9b9f1da73 CppExport/src/dependency_analysis/DependencyUnit.cpp 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/184#discussion_r42857561'>File: CppExport/src/dependency_analysis/DependencyUnit.cpp:L30-69</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> target is a field, so it should be initialized like all other fileds: `name_{..}, ...., targets_{calculateTargets(node)}`

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/184?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/184?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/184'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
