### PR TITLE
Coverage queries

### DIFF
--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -71,7 +71,8 @@ HEADERS += src/precompiled.h \
     src/parsing/ArgumentRule.h \
     src/parsing/QueryParsingException.h \
     src/queries/BreakpointManager.h \
-    src/queries/RuntimeQuery.h
+    src/queries/RuntimeQuery.h \
+    src/queries/TopLevelQuery.h
 SOURCES += src/InformationScriptingException.cpp \
     src/InformationScriptingPlugin.cpp \
     test/SimpleTest.cpp \
@@ -125,7 +126,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/parsing/ArgumentRule.cpp \
     src/parsing/QueryParsingException.cpp \
     src/queries/BreakpointManager.cpp \
-    src/queries/RuntimeQuery.cpp
+    src/queries/RuntimeQuery.cpp \
+    src/queries/TopLevelQuery.cpp
 
 # Workaround to not have any pragma's in NodeApi.cpp
 # (because of unused local typedef in BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS):

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -83,7 +83,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 		} catch (const QueryParsingException& e) {
 			return new Interaction::CommandResult(new Interaction::CommandError(e.message()));
 		}
-		auto queryExecutor = std::make_shared<QueryExecutor>();
+		auto queryExecutor = new QueryExecutor();
 		for (auto q : queries)
 			queryExecutor->addQuery(std::unique_ptr<TopLevelQuery>(q));
 		return queryExecutor->execute();

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -77,15 +77,15 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 	else
 	{
 		args.prepend(command);
-		TopLevelQuery* q = nullptr;
+		QList<TopLevelQuery*> queries;
 		try {
-			q = QueryParser::buildQueryFrom(args.join(""), node);
+			queries = QueryParser::buildQueryFrom(args.join(""), node);
 		} catch (const QueryParsingException& e) {
 			return new Interaction::CommandResult(new Interaction::CommandError(e.message()));
 		}
-		Q_ASSERT(q);
 		auto queryExecutor = std::make_shared<QueryExecutor>();
-		queryExecutor->addQuery(std::unique_ptr<TopLevelQuery>(q));
+		for (auto q : queries)
+			queryExecutor->addQuery(std::unique_ptr<TopLevelQuery>(q));
 		return queryExecutor->execute();
 	}
 	return new Interaction::CommandResult();

--- a/InformationScripting/src/parsing/QueryParser.cpp
+++ b/InformationScripting/src/parsing/QueryParser.cpp
@@ -58,10 +58,9 @@ QList<TopLevelQuery*> QueryParser::buildQueryFrom(const QString& text, Model::No
 	QList<TopLevelQuery*> results;
 	for (auto part : parts)
 	{
-		qDebug() << part;
 		auto type = parser.typeOf(part);
 		if (Type::Operator == type)
-			results << new TopLevelQuery(parser.parseOperator(nullptr, part));
+			results << new TopLevelQuery(parser.parseOperator(nullptr, part, true));
 		else if (Type::Query == type)
 			results << new TopLevelQuery(parser.parseQuery(nullptr, part));
 		else if (Type::List == type)

--- a/InformationScripting/src/parsing/QueryParser.h
+++ b/InformationScripting/src/parsing/QueryParser.h
@@ -53,7 +53,7 @@ class INFORMATIONSCRIPTING_API QueryParser
 		 * queryOrOp	:= query | operator
 		 * list			:= {queryOrOp [, queryOrOp]+}
 		 */
-		static TopLevelQuery* buildQueryFrom(const QString& text, Model::Node* target);
+		static QList<TopLevelQuery*> buildQueryFrom(const QString& text, Model::Node* target);
 
 	private:
 		QueryParser() = default;

--- a/InformationScripting/src/parsing/QueryParser.h
+++ b/InformationScripting/src/parsing/QueryParser.h
@@ -36,6 +36,7 @@ namespace InformationScripting {
 
 class CompositeQuery;
 class Query;
+class TopLevelQuery;
 
 class INFORMATIONSCRIPTING_API QueryParser
 {
@@ -52,7 +53,7 @@ class INFORMATIONSCRIPTING_API QueryParser
 		 * queryOrOp	:= query | operator
 		 * list			:= {queryOrOp [, queryOrOp]+}
 		 */
-		static Query* buildQueryFrom(const QString& text, Model::Node* target);
+		static TopLevelQuery* buildQueryFrom(const QString& text, Model::Node* target);
 
 	private:
 		QueryParser() = default;
@@ -60,10 +61,10 @@ class INFORMATIONSCRIPTING_API QueryParser
 		Type typeOf(const QString& text);
 		QPair<QStringList, QList<QChar> > split(const QString& text, const QList<QChar>& splitChars);
 
-		Query* parseQuery(const QString& text);
-		QList<Query*> parseList(const QString& text);
-		Query* parseOperator(const QString& text, bool connectInput = false);
-		QList<Query*> parseOperatorPart(const QString& text);
+		Query* parseQuery(Query* parent, const QString& text);
+		QList<Query*> parseList(Query* parent, const QString& text);
+		Query* parseOperator(Query* parent, const QString& text, bool connectInput = false);
+		QList<Query*> parseOperatorPart(Query* parent, const QString& text);
 
 		void connectQueriesWith(CompositeQuery* composite, const QList<Query*>& queries,
 										Query* connectionQuery, Query* outputQuery = nullptr);

--- a/InformationScripting/src/precompiled.h
+++ b/InformationScripting/src/precompiled.h
@@ -46,6 +46,8 @@
 // Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
 // and will be included in their precompiled headers
 
+#include <queue>
+
 #if defined(INFORMATIONSCRIPTING_LIBRARY)
 // Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
 // plug-ins which depend on this one will not include these headers.

--- a/InformationScripting/src/queries/AddASTPropertiesAsTuples.cpp
+++ b/InformationScripting/src/queries/AddASTPropertiesAsTuples.cpp
@@ -32,6 +32,8 @@
 
 namespace InformationScripting {
 
+AddASTPropertiesAsTuples::AddASTPropertiesAsTuples(Query* parent) : LinearQuery{parent} {}
+
 Optional<TupleSet> AddASTPropertiesAsTuples::executeLinear(TupleSet input)
 {
 	input.addPropertiesAsTuples<Model::Node*>("ast");
@@ -40,9 +42,9 @@ Optional<TupleSet> AddASTPropertiesAsTuples::executeLinear(TupleSet input)
 
 void AddASTPropertiesAsTuples::registerDefaultQueries()
 {
-	QueryRegistry::instance().registerQueryConstructor("addASTProperties", [](Model::Node*, QStringList)
+	QueryRegistry::instance().registerQueryConstructor("addASTProperties", [](Query* parent, Model::Node*, QStringList)
 	{
-		return new AddASTPropertiesAsTuples();
+		return new AddASTPropertiesAsTuples(parent);
 	});
 }
 

--- a/InformationScripting/src/queries/AddASTPropertiesAsTuples.h
+++ b/InformationScripting/src/queries/AddASTPropertiesAsTuples.h
@@ -35,6 +35,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API AddASTPropertiesAsTuples : public LinearQuery
 {
 	public:
+		AddASTPropertiesAsTuples(Query* parent);
 		virtual Optional<TupleSet> executeLinear(TupleSet input) override;
 
 		static void registerDefaultQueries();

--- a/InformationScripting/src/queries/AstNameFilter.cpp
+++ b/InformationScripting/src/queries/AstNameFilter.cpp
@@ -33,8 +33,8 @@
 
 namespace InformationScripting {
 
-AstNameFilter::AstNameFilter(Model::SymbolMatcher matcher)
-	: GenericFilter {
+AstNameFilter::AstNameFilter(Query* parent, Model::SymbolMatcher matcher)
+	: GenericFilter {parent,
 		  [matcher](const Tuple& t) {
 			auto it = t.find("ast");
 			if (it != t.end())
@@ -49,9 +49,9 @@ AstNameFilter::AstNameFilter(Model::SymbolMatcher matcher)
 
 void AstNameFilter::registerDefaultQueries()
 {
-	QueryRegistry::instance().registerQueryConstructor("filter", [](Model::Node*, QStringList args) {
+	QueryRegistry::instance().registerQueryConstructor("filter", [](Query* parent, Model::Node*, QStringList args) {
 		Q_ASSERT(args.size() > 0);
-		return new AstNameFilter(Model::SymbolMatcher::guessMatcher(args[0]));
+		return new AstNameFilter(parent, Model::SymbolMatcher::guessMatcher(args[0]));
 	});
 }
 

--- a/InformationScripting/src/queries/AstNameFilter.h
+++ b/InformationScripting/src/queries/AstNameFilter.h
@@ -37,7 +37,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API AstNameFilter : public GenericFilter
 {
 	public:
-		AstNameFilter(Model::SymbolMatcher matcher);
+		AstNameFilter(Query* parent, Model::SymbolMatcher matcher);
 
 		static void registerDefaultQueries();
 };

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -52,8 +52,9 @@ const QStringList AstQuery::NAME_ARGUMENT_NAMES{"n", "name"};
 const QStringList AstQuery::ADD_AS_NAMES{"a", "addAs"};
 const QStringList AstQuery::ATTRIBUTE_NAME_NAMES{"at", "attribute"};
 
-AstQuery::AstQuery(Model::Node* target, QStringList args, ExecuteFunction exec, std::vector<ArgumentRule> argumentRules)
-	: LinearQuery{target}, arguments_{{
+AstQuery::AstQuery(Query* parent, Model::Node* target, QStringList args,
+						 ExecuteFunction exec, std::vector<ArgumentRule> argumentRules)
+	: LinearQuery{parent, target}, arguments_{{
 		 {NODETYPE_ARGUMENT_NAMES, "AST Type argument", NODETYPE_ARGUMENT_NAMES[1]},
 		 {NAME_ARGUMENT_NAMES, "Name of a symbol", NAME_ARGUMENT_NAMES[1]},
 		 {ADD_AS_NAMES, "Add as relation or nodes", ADD_AS_NAMES[1], "relation"},

--- a/InformationScripting/src/queries/AstQuery.h
+++ b/InformationScripting/src/queries/AstQuery.h
@@ -65,7 +65,8 @@ class INFORMATIONSCRIPTING_API AstQuery : public LinearQuery
 		using ExecuteFunction = std::function<Optional<TupleSet> (AstQuery*, TupleSet)>;
 		ExecuteFunction exec_{};
 
-		AstQuery(Model::Node* target, QStringList args, ExecuteFunction exec, std::vector<ArgumentRule> argumentRules = {});
+		AstQuery(Query* parent, Model::Node* target, QStringList args,
+					ExecuteFunction exec, std::vector<ArgumentRule> argumentRules = {});
 
 		static void setTypeTo(QStringList& args, QString type);
 

--- a/InformationScripting/src/queries/BreakpointManager.cpp
+++ b/InformationScripting/src/queries/BreakpointManager.cpp
@@ -37,7 +37,7 @@ const QStringList BreakpointManager::VISIBLE_ARGUMENT_NAMES{"v", "visible"};
 Optional<TupleSet> BreakpointManager::executeLinear(TupleSet input)
 {
 	auto tuples = input;
-	OODebug::JavaDebugger::BreakpointType type = OODebug::JavaDebugger::BreakpointType::Internal;
+	auto type = OODebug::JavaDebugger::BreakpointType::Internal;
 	if (arguments_.argument(VISIBLE_ARGUMENT_NAMES[0]) != "no")
 		type = OODebug::JavaDebugger::BreakpointType::User;
 

--- a/InformationScripting/src/queries/BreakpointManager.cpp
+++ b/InformationScripting/src/queries/BreakpointManager.cpp
@@ -53,13 +53,14 @@ Optional<TupleSet> BreakpointManager::executeLinear(TupleSet input)
 
 void BreakpointManager::registerDefaultQueries()
 {
-	QueryRegistry::instance().registerQueryConstructor("addBreakpoints", [](Model::Node* target, QStringList args) {
-		return new BreakpointManager(target, args);
+	QueryRegistry::instance().registerQueryConstructor("addBreakpoints",
+	[](Query* parent, Model::Node* target, QStringList args) {
+		return new BreakpointManager(parent, target, args);
 	});
 }
 
-BreakpointManager::BreakpointManager(Model::Node* target, QStringList args)
-	: LinearQuery{target}, arguments_{{
+BreakpointManager::BreakpointManager(Query* parent, Model::Node* target, QStringList args)
+	: LinearQuery{parent, target}, arguments_{{
 	{VISIBLE_ARGUMENT_NAMES, "Wether the breakpoint is visible, default = no", VISIBLE_ARGUMENT_NAMES[1], "no"}
 }, QStringList("addBreakpoints") + args}
 {}

--- a/InformationScripting/src/queries/BreakpointManager.h
+++ b/InformationScripting/src/queries/BreakpointManager.h
@@ -44,7 +44,7 @@ class INFORMATIONSCRIPTING_API BreakpointManager : public LinearQuery
 		ArgumentParser arguments_;
 		static const QStringList VISIBLE_ARGUMENT_NAMES;
 
-		BreakpointManager(Model::Node* target, QStringList args);
+		BreakpointManager(Query* parent, Model::Node* target, QStringList args);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/CompositeQuery.cpp
+++ b/InformationScripting/src/queries/CompositeQuery.cpp
@@ -28,6 +28,8 @@
 
 namespace InformationScripting {
 
+CompositeQuery::CompositeQuery(Query* parent) : Query{parent} {}
+
 CompositeQuery::~CompositeQuery()
 {
 	SAFE_DELETE(inNode_);

--- a/InformationScripting/src/queries/CompositeQuery.h
+++ b/InformationScripting/src/queries/CompositeQuery.h
@@ -35,6 +35,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 {
 	public:
+		CompositeQuery(Query* parent);
 		virtual ~CompositeQuery() override;
 
 		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;

--- a/InformationScripting/src/queries/GenericFilter.cpp
+++ b/InformationScripting/src/queries/GenericFilter.cpp
@@ -28,7 +28,8 @@
 
 namespace InformationScripting {
 
-GenericFilter::GenericFilter(GenericFilter::KeepTuple f) : keepTuple_{f}
+GenericFilter::GenericFilter(Query* parent, GenericFilter::KeepTuple f)
+	: LinearQuery{parent}, keepTuple_{f}
 {}
 
 Optional<TupleSet> GenericFilter::executeLinear(TupleSet input)

--- a/InformationScripting/src/queries/GenericFilter.h
+++ b/InformationScripting/src/queries/GenericFilter.h
@@ -38,7 +38,7 @@ class INFORMATIONSCRIPTING_API GenericFilter : public LinearQuery
 {
 	public:
 		using KeepTuple = std::function<bool(const Tuple&)>;
-		GenericFilter(KeepTuple f);
+		GenericFilter(Query* parent, KeepTuple f);
 
 		virtual Optional<TupleSet> executeLinear(TupleSet input) override;
 

--- a/InformationScripting/src/queries/LinearQuery.cpp
+++ b/InformationScripting/src/queries/LinearQuery.cpp
@@ -28,7 +28,7 @@
 
 namespace InformationScripting {
 
-LinearQuery::LinearQuery(Model::Node* target) : Query{target} {}
+LinearQuery::LinearQuery(Query* parent, Model::Node* target) : Query{parent, target} {}
 
 QList<Optional<TupleSet> > LinearQuery::execute(QList<TupleSet> input)
 {

--- a/InformationScripting/src/queries/LinearQuery.h
+++ b/InformationScripting/src/queries/LinearQuery.h
@@ -35,7 +35,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API LinearQuery : public Query
 {
 	public:
-		LinearQuery(Model::Node* target = nullptr);
+		LinearQuery(Query* parent, Model::Node* target = nullptr);
 		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;
 		virtual Optional<TupleSet> executeLinear(TupleSet) = 0;
 };

--- a/InformationScripting/src/queries/NodePropertyAdder.cpp
+++ b/InformationScripting/src/queries/NodePropertyAdder.cpp
@@ -28,8 +28,8 @@
 
 namespace InformationScripting {
 
-NodePropertyAdder::NodePropertyAdder(const QString& propertyName, Property value)
- : name_{propertyName}, value_{value}
+NodePropertyAdder::NodePropertyAdder(Query* parent, const QString& propertyName, Property value)
+ : Query{parent}, name_{propertyName}, value_{value}
 {}
 
 QList<Optional<TupleSet>> NodePropertyAdder::execute(QList<TupleSet> input)

--- a/InformationScripting/src/queries/NodePropertyAdder.h
+++ b/InformationScripting/src/queries/NodePropertyAdder.h
@@ -35,7 +35,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API NodePropertyAdder : public Query
 {
 	public:
-		NodePropertyAdder(const QString& propertyName, Property value);
+		NodePropertyAdder(Query* parent, const QString& propertyName, Property value);
 		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;
 
 	private:

--- a/InformationScripting/src/queries/Query.h
+++ b/InformationScripting/src/queries/Query.h
@@ -34,19 +34,30 @@
 
 namespace InformationScripting {
 
+class QueryExecutor;
+
 class INFORMATIONSCRIPTING_API Query
 {
 	public:
-		Query(Model::Node* target = nullptr);
+		Query(Query* parent, Model::Node* target = nullptr);
 		virtual ~Query() = default;
 		virtual QList<Optional<TupleSet>> execute(QList<TupleSet>) = 0;
+		virtual QueryExecutor* executor() const;
+
+		Query* parent() const;
+		void setParent(Query* parent);
+
 		Model::Node* target() const;
 
 	private:
+		Query* parent_{};
 		Model::Node* target_{};
 };
 
-inline Query::Query(Model::Node *target) : target_{target} {}
+inline Query::Query(Query* parent, Model::Node *target) : parent_{parent}, target_{target} {}
+inline QueryExecutor* Query::executor() const { return parent()->executor(); }
+inline Query* Query::parent() const { return parent_; }
+inline void Query::setParent(Query *parent) { Q_ASSERT(parent); parent_ = parent;}
 inline Model::Node* Query::target() const { return target_; }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/QueryExecutor.cpp
+++ b/InformationScripting/src/queries/QueryExecutor.cpp
@@ -26,8 +26,6 @@
 
 #include "QueryExecutor.h"
 
-#include "TopLevelQuery.h"
-
 #include "visualization/DefaultVisualizer.h"
 
 #include "InteractionBase/src/commands/CommandResult.h"
@@ -37,11 +35,11 @@ namespace InformationScripting {
 QueryExecutor::~QueryExecutor()
 {
 	Q_ASSERT(queries_.empty());
-	qDebug() << "DELETE QUERYEXECUTOR";
 }
 
 void QueryExecutor::addQuery(std::unique_ptr<TopLevelQuery>&& query)
 {
+	query->setExecutor(this);
 	queries_.emplace(std::move(query));
 }
 
@@ -98,7 +96,7 @@ QList<Optional<TupleSet>> QueryExecutor::runContinuation(const QList<TupleSet>& 
 	}
 	if (queries_.empty())
 	{
-		executeLast(q, queryInput);
+		executeLast(query.get(), queryInput);
 		return {{TupleSet()}};	// empty return value no one should care about the last
 	}
 
@@ -125,6 +123,7 @@ QString QueryExecutor::executeLast(Query* q, const QList<TupleSet>& input)
 			errorMessage = results[0].errors()[0];
 		}
 	}
+	delete this;
 	return errorMessage;
 }
 

--- a/InformationScripting/src/queries/QueryExecutor.cpp
+++ b/InformationScripting/src/queries/QueryExecutor.cpp
@@ -49,13 +49,66 @@ Interaction::CommandResult* QueryExecutor::execute()
 {
 	Q_ASSERT(!queries_.empty());
 
-	bool hasError = false;
+	auto query = std::move(queries_.front());
+	queries_.pop();
+
 	QString errorMessage{};
+
+	if (queries_.empty())
+		errorMessage = executeLast(query.get(), {});
+	else
+	{
+		auto results = query->execute({});
+		for (const auto& result : results)
+			if (result)
+				firstResult_.push_back(result.value());
+			else
+				errorMessage = result.errors().join("");
+		// If we had an error we don't store anything for the continuation
+		if (!errorMessage.isNull()) firstResult_.clear();
+	}
+
+	if (!errorMessage.isNull())
+		return new Interaction::CommandResult(new Interaction::CommandError(errorMessage));
+	else
+		return new Interaction::CommandResult();
+}
+
+QList<Optional<TupleSet>> QueryExecutor::runContinuation(const QList<TupleSet>& input)
+{
+	if (queries_.empty()) return {{"No continuation to execute"}};
 
 	auto query = std::move(queries_.front());
 	queries_.pop();
 
-	auto results = query->execute({});
+	auto queryInput = input;
+	if (!firstResult_.isEmpty())
+	{
+		// Merge the larger of the lists in the other
+		auto merger = [](TupleSet left, const TupleSet& right) { left.unite(right); return left; };
+		if (firstResult_.size() > input.size())
+			std::transform(input.begin(), input.end(), firstResult_.begin(), queryInput.begin(), merger);
+		else
+		{
+			// make sure there is enough space in queryInput list:
+			queryInput = firstResult_;
+			std::transform(firstResult_.begin(), firstResult_.end(), input.begin(), queryInput.begin(), merger);
+		}
+		firstResult_.clear();
+	}
+	if (queries_.empty())
+	{
+		executeLast(q, queryInput);
+		return {{TupleSet()}};	// empty return value no one should care about the last
+	}
+
+	return query->execute(queryInput);
+}
+
+QString QueryExecutor::executeLast(Query* q, const QList<TupleSet>& input)
+{
+	QString errorMessage{};
+	auto results = q->execute(input);
 	if (results.size())
 	{
 		// TODO how to handle warnings? CommandResult has no warnings?
@@ -69,15 +122,10 @@ Interaction::CommandResult* QueryExecutor::execute()
 		}
 		else
 		{
-			hasError = true;
 			errorMessage = results[0].errors()[0];
 		}
 	}
-
-	if (hasError)
-		return new Interaction::CommandResult(new Interaction::CommandError(errorMessage));
-	else
-		return new Interaction::CommandResult();
+	return errorMessage;
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/QueryExecutor.h
+++ b/InformationScripting/src/queries/QueryExecutor.h
@@ -28,6 +28,8 @@
 
 #include "../informationscripting_api.h"
 
+#include "../misc/Optional.h"
+
 namespace Interaction {
 	class CommandResult;
 }
@@ -35,6 +37,8 @@ namespace Interaction {
 namespace InformationScripting {
 
 class TopLevelQuery;
+class TupleSet;
+class Query;
 
 class INFORMATIONSCRIPTING_API QueryExecutor
 {
@@ -44,8 +48,13 @@ class INFORMATIONSCRIPTING_API QueryExecutor
 
 		Interaction::CommandResult* execute();
 
+		QList<Optional<TupleSet> > runContinuation(const QList<TupleSet>& input);
+
 	private:
 		std::queue<std::unique_ptr<TopLevelQuery>> queries_{};
+		QList<TupleSet> firstResult_;
+
+		QString executeLast(Query* q, const QList<TupleSet>& input);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/QueryExecutor.h
+++ b/InformationScripting/src/queries/QueryExecutor.h
@@ -34,18 +34,18 @@ namespace Interaction {
 
 namespace InformationScripting {
 
-class Query;
+class TopLevelQuery;
 
 class INFORMATIONSCRIPTING_API QueryExecutor
 {
 	public:
-		QueryExecutor(Query* q);
 		~QueryExecutor();
+		void addQuery(std::unique_ptr<TopLevelQuery>&& query);
 
 		Interaction::CommandResult* execute();
 
 	private:
-		Query* query_{};
+		std::queue<std::unique_ptr<TopLevelQuery>> queries_{};
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/QueryExecutor.h
+++ b/InformationScripting/src/queries/QueryExecutor.h
@@ -29,6 +29,7 @@
 #include "../informationscripting_api.h"
 
 #include "../misc/Optional.h"
+#include "TopLevelQuery.h"
 
 namespace Interaction {
 	class CommandResult;

--- a/InformationScripting/src/queries/QueryRegistry.cpp
+++ b/InformationScripting/src/queries/QueryRegistry.cpp
@@ -37,17 +37,17 @@ QueryRegistry& QueryRegistry::instance()
 	return instance;
 }
 
-Query* QueryRegistry::buildQuery(const QString& command, Model::Node* target, QStringList args)
+Query* QueryRegistry::buildQuery(Query* parent, const QString& command, Model::Node* target, QStringList args)
 {
 	if (auto constructor = constructors_[command])
-		return constructor(target, args);
+		return constructor(parent, target, args);
 	if (args.size() > 1 && args[0] == "=")
 	{
 		// TODO we need some way to specify a condition on the node.
 		// Or eventually decide that we don't allow condition in the property adder
-		return new NodePropertyAdder(command, args[1]);
+		return new NodePropertyAdder(parent, command, args[1]);
 	}
-	if (auto script = tryBuildQueryFromScript(command, target, args))
+	if (auto script = tryBuildQueryFromScript(parent, command, target, args))
 		return script;
 	return nullptr;
 }
@@ -61,11 +61,11 @@ QStringList QueryRegistry::scriptQueries() const
 	return result;
 }
 
-Query* QueryRegistry::tryBuildQueryFromScript(const QString& name, Model::Node* target, QStringList args)
+Query* QueryRegistry::tryBuildQueryFromScript(Query* parent, const QString& name, Model::Node* target, QStringList args)
 {
 	QString scriptName{scriptLocation_ + name + ".py"};
 	if (QFile::exists(scriptName))
-		return new ScriptQuery(scriptName, target, args);
+		return new ScriptQuery(parent, scriptName, target, args);
 	return nullptr;
 }
 

--- a/InformationScripting/src/queries/RuntimeQuery.cpp
+++ b/InformationScripting/src/queries/RuntimeQuery.cpp
@@ -73,13 +73,14 @@ Optional<TupleSet> RuntimeQuery::executeLinear(TupleSet input)
 
 void RuntimeQuery::registerDefaultQueries()
 {
-	QueryRegistry::instance().registerQueryConstructor("traceExecution", [](Model::Node* target, QStringList) {
-		return new RuntimeQuery(target);
+	QueryRegistry::instance().registerQueryConstructor("traceExecution",
+	[](Query* parent, Model::Node* target, QStringList) {
+		return new RuntimeQuery(parent, target);
 	});
 }
 
-RuntimeQuery::RuntimeQuery(Model::Node* target)
-	: LinearQuery{target}
+RuntimeQuery::RuntimeQuery(Query* parent, Model::Node* target)
+	: LinearQuery{parent, target}
 {}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/RuntimeQuery.cpp
+++ b/InformationScripting/src/queries/RuntimeQuery.cpp
@@ -36,20 +36,21 @@
 #include "OODebug/src/debugger/JavaDebugger.h"
 #include "OODebug/src/debugger/jdwp/messages/EventSet.h"
 
+#include "QueryExecutor.h"
+
 namespace InformationScripting {
 
 Optional<TupleSet> RuntimeQuery::executeLinear(TupleSet input)
 {
-	// FIXME change this once we have a yield mechanism:
-	std::unordered_map<Model::Node*, int> execCount;
-	auto listener = [&execCount](Model::Node* target, auto...) {
-		++execCount[target];
+	auto execCount = std::make_shared<std::unordered_map<Model::Node*, int>>();
+	auto listener = [execCount](Model::Node* target, auto...) {
+		++(*execCount)[target];
 		return false;
 	};
 
-	std::vector<int> callbackIds;
+	auto callbackIds = std::make_shared<std::vector<int>>();
 	for (const auto& breakpointTuple : input.tuples("breakpoint"))
-		callbackIds.push_back(
+		callbackIds->push_back(
 					OODebug::JavaDebugger::instance().addBreakpointListener(breakpointTuple["breakpoint"], listener));
 
 	auto manager = target()->manager();
@@ -59,16 +60,21 @@ Optional<TupleSet> RuntimeQuery::executeLinear(TupleSet input)
 	if (executionResult->code() == Interaction::CommandResult::Error)
 		return {"errror during exection"};
 
-	// FIXME needs yield here. Doesn't work currently
+	auto queryExecutor = executor();
+	Q_ASSERT(queryExecutor);
+	OODebug::JavaDebugger::instance().addProgramExitLister([callbackIds, execCount, queryExecutor]()
+		{
+			for (int id : *callbackIds)
+				OODebug::JavaDebugger::instance().removeBreakpointListener(id);
 
-	// FIXME this should happen as a pre resume command once we have yield.
-	for (int id : callbackIds)
-		OODebug::JavaDebugger::instance().removeBreakpointListener(id);
+			TupleSet result;
+			for (const auto& val : *execCount)
+				result.add({{"count", val.second}, {"ast", val.first}});
 
-	TupleSet result;
-	for (const auto& val : execCount)
-		result.add({{"count", val.second}, {"ast", val.first}});
-	return result;
+			queryExecutor->runContinuation({result});
+		}
+	);
+	return TupleSet();
 }
 
 void RuntimeQuery::registerDefaultQueries()

--- a/InformationScripting/src/queries/RuntimeQuery.h
+++ b/InformationScripting/src/queries/RuntimeQuery.h
@@ -39,7 +39,7 @@ class INFORMATIONSCRIPTING_API RuntimeQuery : public LinearQuery
 		static void registerDefaultQueries();
 
 	private:
-		RuntimeQuery(Model::Node* target);
+		RuntimeQuery(Query* parent, Model::Node* target);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/ScriptQuery.cpp
+++ b/InformationScripting/src/queries/ScriptQuery.cpp
@@ -35,8 +35,8 @@
 
 namespace InformationScripting {
 
-ScriptQuery::ScriptQuery(const QString& scriptPath, Model::Node* target, const QStringList& args)
-	: Query{target}, scriptPath_{scriptPath}, arguments_{args}
+ScriptQuery::ScriptQuery(Query* parent, const QString& scriptPath, Model::Node* target, const QStringList& args)
+	: Query{parent, target}, scriptPath_{scriptPath}, arguments_{args}
 {}
 
 // Since we can't create a module in another way, we create an empty one here.
@@ -136,7 +136,7 @@ QList<Optional<TupleSet>> ScriptQuery::queryExecutor(QString name, boost::python
 	boost::python::stl_input_iterator<TupleSet> inputsBegin(input), inputsEnd;
 	auto inputConverted = QList<TupleSet>::fromStdList(std::list<TupleSet>(inputsBegin, inputsEnd));
 
-	std::unique_ptr<Query> query{QueryRegistry::instance().buildQuery(name, target(), argsConverted)};
+	std::unique_ptr<Query> query{QueryRegistry::instance().buildQuery(this, name, target(), argsConverted)};
 	auto result = query->execute(inputConverted);
 
 	return result;

--- a/InformationScripting/src/queries/ScriptQuery.h
+++ b/InformationScripting/src/queries/ScriptQuery.h
@@ -39,7 +39,7 @@ namespace InformationScripting {
 class ScriptQuery : public Query
 {
 	public:
-		ScriptQuery(const QString& scriptPath, Model::Node* target, const QStringList& args = {});
+		ScriptQuery(Query* parent, const QString& scriptPath, Model::Node* target, const QStringList& args = {});
 
 		static void initPythonEnvironment();
 		static void unloadPythonEnvironment();

--- a/InformationScripting/src/queries/SubstractOperator.cpp
+++ b/InformationScripting/src/queries/SubstractOperator.cpp
@@ -30,6 +30,8 @@
 
 namespace InformationScripting {
 
+SubstractOperator::SubstractOperator(Query* parent) : Query{parent} {}
+
 QList<Optional<TupleSet> > SubstractOperator::execute(QList<TupleSet> input)
 {
 	Q_ASSERT(input.size() == 2);

--- a/InformationScripting/src/queries/TagQuery.cpp
+++ b/InformationScripting/src/queries/TagQuery.cpp
@@ -60,8 +60,9 @@ void TagQuery::registerDefaultQueries()
 		{{ArgumentRule::RequireAll, {{NAME_ARGUMENT_NAMES[1]}}}});
 }
 
-TagQuery::TagQuery(Model::Node* target, QStringList args, ExecuteFunction exec, std::vector<ArgumentRule> argumentRules)
-	: LinearQuery{target}, arguments_{{
+TagQuery::TagQuery(Query* parent, Model::Node* target, QStringList args,
+						 ExecuteFunction exec, std::vector<ArgumentRule> argumentRules)
+	: LinearQuery{parent, target}, arguments_{{
 			{NAME_ARGUMENT_NAMES, "Tag name, or regex to find tag", NAME_ARGUMENT_NAMES[1]},
 			QCommandLineOption{ADD_ARGUMENT_NAMES},
 			QCommandLineOption{REMOVE_ARGUMENT_NAMES},

--- a/InformationScripting/src/queries/TagQuery.h
+++ b/InformationScripting/src/queries/TagQuery.h
@@ -61,7 +61,8 @@ class INFORMATIONSCRIPTING_API TagQuery : public LinearQuery
 		ExecuteFunction exec_{};
 		bool persistent_{true};
 
-		TagQuery(Model::Node* target, QStringList args, ExecuteFunction exec, std::vector<ArgumentRule> argumentRules = {});
+		TagQuery(Query* parent, Model::Node* target, QStringList args,
+					ExecuteFunction exec, std::vector<ArgumentRule> argumentRules = {});
 		Optional<TupleSet> tags(TupleSet input);
 		Optional<TupleSet> queryTags(TupleSet input);
 		Optional<TupleSet> addTags(TupleSet input);

--- a/InformationScripting/src/queries/TopLevelQuery.cpp
+++ b/InformationScripting/src/queries/TopLevelQuery.cpp
@@ -44,14 +44,14 @@ QList<Optional<TupleSet>> TopLevelQuery::execute(QList<TupleSet> input)
 	return childQuery_->execute(input);
 }
 
-QueryExecutor*TopLevelQuery::executor() const
+QueryExecutor* TopLevelQuery::executor() const
 {
 	return executor_;
 }
 
 void TopLevelQuery::setExecutor(QueryExecutor* executor)
 {
-	Q_ASSERT(executor_);
+	Q_ASSERT(executor);
 	executor_ = executor;
 }
 

--- a/InformationScripting/src/queries/TopLevelQuery.cpp
+++ b/InformationScripting/src/queries/TopLevelQuery.cpp
@@ -24,19 +24,35 @@
 **
 ***********************************************************************************************************************/
 
-#pragma once
+#include "TopLevelQuery.h"
 
-#include "../informationscripting_api.h"
-
-#include "Query.h"
+#include "QueryExecutor.h"
 
 namespace InformationScripting {
 
-class INFORMATIONSCRIPTING_API SubstractOperator : public Query
+TopLevelQuery::TopLevelQuery(Query* child)
+	: Query{nullptr}, childQuery_{child}
 {
-	public:
-		SubstractOperator(Query* parent);
-		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;
-};
+	Q_ASSERT(childQuery_);
+	childQuery_->setParent(this);
+}
+
+TopLevelQuery::~TopLevelQuery() {}
+
+QList<Optional<TupleSet>> TopLevelQuery::execute(QList<TupleSet> input)
+{
+	return childQuery_->execute(input);
+}
+
+QueryExecutor*TopLevelQuery::executor() const
+{
+	return executor_;
+}
+
+void TopLevelQuery::setExecutor(QueryExecutor* executor)
+{
+	Q_ASSERT(executor_);
+	executor_ = executor;
+}
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/TopLevelQuery.h
+++ b/InformationScripting/src/queries/TopLevelQuery.h
@@ -32,11 +32,26 @@
 
 namespace InformationScripting {
 
-class INFORMATIONSCRIPTING_API SubstractOperator : public Query
+/**
+ * Represents a query to be used by the query executor.
+ * This query only has the purpose of providing executor information to it's child queries.
+ */
+class INFORMATIONSCRIPTING_API TopLevelQuery final : public Query
 {
 	public:
-		SubstractOperator(Query* parent);
+		/**
+		 * Takes ownership of \a child.
+		 */
+		TopLevelQuery(Query* child);
+		virtual ~TopLevelQuery() override;
 		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;
+		virtual QueryExecutor* executor() const override;
+
+		void setExecutor(QueryExecutor* executor);
+
+	private:
+		std::unique_ptr<Query> childQuery_{};
+		QueryExecutor* executor_{};
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/UnionOperator.cpp
+++ b/InformationScripting/src/queries/UnionOperator.cpp
@@ -28,6 +28,8 @@
 
 namespace InformationScripting {
 
+UnionOperator::UnionOperator(Query* parent) : Query{parent} {}
+
 QList<Optional<TupleSet> > UnionOperator::execute(QList<TupleSet> input)
 {
 	if (input.size() <= 1) return {{"Union requires 2 inputs"}};

--- a/InformationScripting/src/queries/UnionOperator.h
+++ b/InformationScripting/src/queries/UnionOperator.h
@@ -35,6 +35,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API UnionOperator : public Query
 {
 	public:
+		UnionOperator(Query* parent);
 		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;
 };
 

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -95,13 +95,14 @@ Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet)
 
 void VersionControlQuery::registerDefaultQueries()
 {
-	QueryRegistry::instance().registerQueryConstructor("changes", [](Model::Node* target, QStringList args) {
-		return new VersionControlQuery(target, args);
+	QueryRegistry::instance().registerQueryConstructor("changes",
+	[](Query* parent, Model::Node* target, QStringList args) {
+		return new VersionControlQuery(parent, target, args);
 	});
 }
 
-VersionControlQuery::VersionControlQuery(Model::Node* target, QStringList args)
-	: LinearQuery{target}, arguments_{{
+VersionControlQuery::VersionControlQuery(Query* parent, Model::Node* target, QStringList args)
+	: LinearQuery{parent, target}, arguments_{{
 		{COUNT_ARGUMENT_NAMES, "The amount of revision to look at", COUNT_ARGUMENT_NAMES[1], "10"}
 }, QStringList{"changes"} + args}
 {}

--- a/InformationScripting/src/queries/VersionControlQuery.h
+++ b/InformationScripting/src/queries/VersionControlQuery.h
@@ -48,7 +48,7 @@ class INFORMATIONSCRIPTING_API VersionControlQuery : public LinearQuery
 
 		static const QStringList COUNT_ARGUMENT_NAMES;
 
-		VersionControlQuery(Model::Node* target, QStringList args);
+		VersionControlQuery(Query* parent, Model::Node* target, QStringList args);
 
 		static void addCommitMetaInformation(TupleSet& ts, const FilePersistence::CommitMetaData& metadata);
 };

--- a/InformationScripting/src/visualization/Heatmap.cpp
+++ b/InformationScripting/src/visualization/Heatmap.cpp
@@ -62,13 +62,13 @@ Optional<TupleSet> Heatmap::executeLinear(TupleSet input)
 
 void Heatmap::registerDefaultQueries()
 {
-	QueryRegistry::instance().registerQueryConstructor("heatmap", [](Model::Node*, QStringList args) {
-		return new Heatmap(args);
+	QueryRegistry::instance().registerQueryConstructor("heatmap", [](Query* parent, Model::Node*, QStringList args) {
+		return new Heatmap(parent, args);
 	});
 }
 
-Heatmap::Heatmap(QStringList args)
-	: arguments_{{
+Heatmap::Heatmap(Query* parent, QStringList args)
+	: LinearQuery{parent}, arguments_{{
 		{VALUE_ATTRIBUTE_NAME_NAMES, "Name of the attribute that contains the count value",
 					 VALUE_ATTRIBUTE_NAME_NAMES[1], "count"} // Use count as default tag for heatmaps
 		}, QStringList("heatmap") + args}

--- a/InformationScripting/src/visualization/Heatmap.h
+++ b/InformationScripting/src/visualization/Heatmap.h
@@ -47,7 +47,7 @@ class Heatmap : public LinearQuery
 		QPair<int, int> valueRange_; // min, max
 		ArgumentParser arguments_;
 
-		Heatmap(QStringList args);
+		Heatmap(Query* parent, QStringList args);
 
 		QColor colorForValue(int value);
 };

--- a/OODebug/src/debugger/JavaDebugger.cpp
+++ b/OODebug/src/debugger/JavaDebugger.cpp
@@ -296,6 +296,10 @@ JavaDebugger::JavaDebugger()
 	debugConnector_.addEventListener(Protocol::EventKind::VM_START, [this] (Event e) { handleVMStart(e); });
 	debugConnector_.addEventListener(Protocol::EventKind::SINGLE_STEP,
 												[this] (Event e) { handleSingleStep(e.singleStep()); });
+	debugConnector_.addEventListener(Protocol::EventKind::VM_DEATH, [this] (Event) {
+		for (auto listener : exitListeners_) listener();
+		exitListeners_.clear();
+	});
 }
 
 bool JavaDebugger::isParentClassLoaded(Model::Node* node)

--- a/OODebug/src/debugger/JavaDebugger.h
+++ b/OODebug/src/debugger/JavaDebugger.h
@@ -91,6 +91,13 @@ class OODEBUG_API JavaDebugger
 		int addBreakpointListener(Model::Node* node, BreakpointListener listener);
 		void removeBreakpointListener(int id);
 
+		using ProgramExitSingleShot = std::function<void ()>;
+		/**
+		 *	Register a listener for the next program exit. Once the event happened the listener will be destroyed
+		 * and not called in any subsequent event.
+		 */
+		void addProgramExitLister(ProgramExitSingleShot listener);
+
 	private:
 		JavaDebugger();
 
@@ -138,6 +145,8 @@ class OODEBUG_API JavaDebugger
 		QMultiHash<Model::Node*, std::pair<int, BreakpointListener>> breakpointListeners_;
 		int nextBreakpointListenerId_{0};
 
+		QVector<ProgramExitSingleShot> exitListeners_;
+
 		static const QString BREAKPOINT_OVERLAY_GROUP;
 		static const QString PLOT_OVERLAY_GROUP;
 		static const QString CURRENT_LINE_OVERLAY_GROUP;
@@ -148,6 +157,11 @@ inline int JavaDebugger::addBreakpointListener(Model::Node* node, BreakpointList
 	int id = nextBreakpointListenerId_++;
 	breakpointListeners_.insertMulti(node, {id, listener});
 	return id;
+}
+
+inline void JavaDebugger::addProgramExitLister(JavaDebugger::ProgramExitSingleShot listener)
+{
+	exitListeners_.push_back(listener);
 }
 
 } /* namespace OODebug */


### PR DESCRIPTION
Raw pointer version.

The most changes are because all Queries now have to have the parent in the constructor.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42985709%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42986351%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42986884%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42987021%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42987215%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42987329%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42987490%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42987710%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42988204%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42988374%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42988453%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42988498%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42988975%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42989029%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42989106%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42989433%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42989591%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23issuecomment-151170758%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23issuecomment-151170758%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Closing%20since%20we%20discussed%20a%20nicer%20solution%20in%20person.%22%2C%20%22created_at%22%3A%20%222015-10-26T15%3A18%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%200d17b03c011064ab54470bd68b67449793cdc77d%20InformationScripting/src/queries/QueryExecutor.cpp%2031%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42986351%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20are%20you%20using%20move%20here%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A25%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20we%20don%27t%20move%20the%20call%20to%20pop%28%29%20below%20would%20destroy%20the%20unique_ptr%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A36%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20I%20see.%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A50%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/QueryExecutor.cpp%3AL26-113%22%7D%2C%20%22Pull%200d17b03c011064ab54470bd68b67449793cdc77d%20InformationScripting/src/parsing/QueryParser.cpp%2025%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42987215%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20sure%20I%20understand%20what%20%5C%22in%20operator%20parts%5C%22%20means%2C%20can%20you%20clarify%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A35%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20means%20the%20yield%20operator%20can%20only%20be%20in%20an%20operator%20scope%2C%20i.e.%20not%20standalone%20and%20not%20in%20a%20list.%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A38%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK.%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A57%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/parsing/QueryParser.cpp%3AL39-84%22%7D%2C%20%22Pull%200d17b03c011064ab54470bd68b67449793cdc77d%20InformationScripting/src/parsing/QueryParser.h%2025%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42986884%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22So%20I%20see%20that%20we%20added%20the%20parent%20of%20each%20query.%20I%20know%20we%20talked%20about%20this%2C%20but%20somehow%20I%27m%20not%20happy%20with%20either%20solution.%20The%20core%20issue%20is%20that%20most%20queries%2C%20don%27t%20care%20about%20their%20parents%20or%20about%20the%20executor%2C%20and%20are%20standalone%20units.%20Now%2C%20because%20one%20query%20might%20need%20this%20we%20make%20it%20a%20requirement%20for%20all%20to%20know%20about%20the%20parent/executor.%20Can%20you%20think%20of%20a%20way%20to%20provide%20this%20information%20only%20to%20queries%20that%20care%20about%20this%3F%20Perhaps%20when%20creating%20a%20query%20call%20a%20virtual%20setExecutor%20method%20which%20most%20queries%20ignore%20by%20default%2C%20but%20the%20ones%20that%20care%20about%20it%2C%20record%20it%3F%20Or%20something%20along%20those%20lines.%20What%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A32%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Then%20why%20not%20have%20the%20QueryExecutor%20as%20a%20field%20in%20the%20Query%20baseclass%20and%20have%20a%20setter/getter%20for%20it%20%28it%20doesn%27t%20even%20need%20to%20be%20virtual%29%2C%20then%20we%20don%27t%20even%20need%20the%20TopLevelQuery.%20This%20comes%20at%20an%20overhead%20of%20a%20single%20pointer%20field%20in%20the%20base%20class%20which%20isn%27t%20that%20bad.%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A41%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20fact%2C%20compared%20to%20the%20current%20solution%2C%20this%20doesn%27t%20even%20present%20any%20more%20overhead.%20But%20can%27t%20we%20take%20this%20a%20bit%20further%20and%20only%20allow%20queries%20that%20actually%20care%20about%20the%20Executor%20to%20store%20it%20%28and%20we%20won%27t%20need%20a%20virtual%20function%29.%5Cr%5Cn%5Cr%5CnMy%20principle%20problem%20is%20not%20the%20overhead%2C%20but%20the%20fact%20that%20we%20force%20all%20queries%20to%20care%20about%20things%20which%20they%20shouldn%27t.%20If%20we%20can%20skip%20this%2C%20that%20would%20be%20better%2C%20but%20otherwise%20a%20solution%20like%20the%20current%20one%20is%20ok.%5Cr%5Cn%5Cr%5CnIn%20your%20view%2C%20would%20you%20prefer%20a%20QE%20filed%20in%20each%20query%2C%20as%20opposed%20to%20the%20current%20solution%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A56%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20If%20we%20imagine%20someone%20implementing%20a%20new%20Query%20which%20needs%20access%20to%20the%20QE%20it%20might%20make%20sense%20if%20it%20is%20already%20there%3F%20On%20the%20other%20hand%20I%20agree%20that%20most%20queries%20don%27t%20need%20to%20know%20about%20it.%20Overall%20I%20slightly%20tend%20to%20have%20it%20in%20the%20Query%20base%20class%2C%20in%20a%20way%20the%20queries%20still%20don%27t%20need%20to%20care%20about%20it%2C%20if%20they%20don%27t%20want%20to%20use%20it%20they%20don%27t%20set%20the%20field.%22%2C%20%22created_at%22%3A%20%222015-10-26T13%3A01%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20do%20you%20mean%20they%20don%27t%20set%20the%20field%3F%20I%20thought%20we%27d%20provide%20a%20setter%20in%20the%20base%20class%20and%20call%20it%20for%20all%20queries%2C%20in%20which%20case%20a%20query%20never%20needs%20to%20set%20any%20field%20%28even%20if%20it%20wants%20to%20use%20the%20executor%29.%20Did%20you%20have%20another%20design%20in%20mind%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T13%3A03%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/parsing/QueryParser.h%3AL61-71%22%7D%2C%20%22Pull%200d17b03c011064ab54470bd68b67449793cdc77d%20InformationScripting/src/queries/QueryExecutor.h%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42988204%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20entirely%20very%20happy%20about%20the%20new%20API.%20Do%20we%20really%20need%20three%20methods%20for%20executing%20queries%3A%20execute%2C%20runContinuation%2C%20and%20executeLast%3F%20I%27m%20especially%20not%20happy%20about%20having%20two%20public%20methods.%20Can%27t%20we%20reduce%20this%20to%20one%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A47%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20we%20execute%20from%20the%20command%20prompt%20we%20would%20like%20to%20have%20a%20CommandResult%20if%20we%20execute%20a%20continuation%20we%20would%20like%20to%20have%20the%20return%20value%20from%20the%20query.%20Not%20sure%20how%20to%20solve%20this%20nicely.%20Even%20though%20I%20fully%20agree%20with%20your%20concern.%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A51%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Do%20we%20ever%20care%20about%20the%20return%20value%20from%20the%20Query%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A58%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/QueryExecutor.h%3AL28-62%22%7D%2C%20%22Pull%200d17b03c011064ab54470bd68b67449793cdc77d%20InformationScripting/src/commands/CScript.cpp%20158%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/186%23discussion_r42985709%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Whoa%2C%20there%20were%20a%20ton%20of%20test%20commands%20here%20before.%20What%20happened%20to%20those%3F%20Are%20they%20gone%20for%20good%3F%20Can%20we%20still%20execute%20those%20in%20a%20nice%20way%2C%20e.g.%20directly%20using%20the%20built-in%20functionality%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A17%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20I%20was%20to%20tired%20to%20port%20them%20to%20the%20new%20API.%20In%20fact%20they%20were%20testing%20so%20they%20shouldn%27t%20live%20in%20this%20file%20anyways.%20To%20execute%20them%20one%20can%20still%20copy%20the%20%20the%20actual%20script%20from%20somewhere%20%28e.g.%20https%3A//docs.google.com/document/d/11XOBGknfOR2A9kliF4os0dbqqOvrzj6g632BCkniPsI%29%20and%20execute%20it.%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A33%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20see.%20OK%20we%20don%27t%20need%20to%20implement%20these%20in%20the%20code%2C%20but%20it%20would%20be%20nice%20to%20have%20the%20data%20from%20the%20script%20checked%20in.%20Perhaps%20add%20a%20text%20file%20to%20the%20/test%20directory%20and%20just%20put%20the%20test%20commands%20there.%22%2C%20%22created_at%22%3A%20%222015-10-26T12%3A49%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/commands/CScript.cpp%3AL74-93%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 0d17b03c011064ab54470bd68b67449793cdc77d InformationScripting/src/commands/CScript.cpp 158'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/186#discussion_r42985709'>File: InformationScripting/src/commands/CScript.cpp:L74-93</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Whoa, there were a ton of test commands here before. What happened to those? Are they gone for good? Can we still execute those in a nice way, e.g. directly using the built-in functionality?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Well I was to tired to port them to the new API. In fact they were testing so they shouldn't live in this file anyways. To execute them one can still copy the  the actual script from somewhere (e.g. https://docs.google.com/document/d/11XOBGknfOR2A9kliF4os0dbqqOvrzj6g632BCkniPsI) and execute it.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I see. OK we don't need to implement these in the code, but it would be nice to have the data from the script checked in. Perhaps add a text file to the /test directory and just put the test commands there.
- [ ] <a href='#crh-comment-Pull 0d17b03c011064ab54470bd68b67449793cdc77d InformationScripting/src/queries/QueryExecutor.cpp 31'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/186#discussion_r42986351'>File: InformationScripting/src/queries/QueryExecutor.cpp:L26-113</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why are you using move here?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> If we don't move the call to pop() below would destroy the unique_ptr
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Ok, I see.
- [ ] <a href='#crh-comment-Pull 0d17b03c011064ab54470bd68b67449793cdc77d InformationScripting/src/parsing/QueryParser.h 25'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/186#discussion_r42986884'>File: InformationScripting/src/parsing/QueryParser.h:L61-71</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> So I see that we added the parent of each query. I know we talked about this, but somehow I'm not happy with either solution. The core issue is that most queries, don't care about their parents or about the executor, and are standalone units. Now, because one query might need this we make it a requirement for all to know about the parent/executor. Can you think of a way to provide this information only to queries that care about this? Perhaps when creating a query call a virtual setExecutor method which most queries ignore by default, but the ones that care about it, record it? Or something along those lines. What do you think?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Then why not have the QueryExecutor as a field in the Query baseclass and have a setter/getter for it (it doesn't even need to be virtual), then we don't even need the TopLevelQuery. This comes at an overhead of a single pointer field in the base class which isn't that bad.?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> In fact, compared to the current solution, this doesn't even present any more overhead. But can't we take this a bit further and only allow queries that actually care about the Executor to store it (and we won't need a virtual function).
  My principle problem is not the overhead, but the fact that we force all queries to care about things which they shouldn't. If we can skip this, that would be better, but otherwise a solution like the current one is ok.
  In your view, would you prefer a QE filed in each query, as opposed to the current solution?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Hm If we imagine someone implementing a new Query which needs access to the QE it might make sense if it is already there? On the other hand I agree that most queries don't need to know about it. Overall I slightly tend to have it in the Query base class, in a way the queries still don't need to care about it, if they don't want to use it they don't set the field.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> What do you mean they don't set the field? I thought we'd provide a setter in the base class and call it for all queries, in which case a query never needs to set any field (even if it wants to use the executor). Did you have another design in mind?
- [ ] <a href='#crh-comment-Pull 0d17b03c011064ab54470bd68b67449793cdc77d InformationScripting/src/parsing/QueryParser.cpp 25'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/186#discussion_r42987215'>File: InformationScripting/src/parsing/QueryParser.cpp:L39-84</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I'm not sure I understand what "in operator parts" means, can you clarify?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> It means the yield operator can only be in an operator scope, i.e. not standalone and not in a list.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> OK.
- [ ] <a href='#crh-comment-Pull 0d17b03c011064ab54470bd68b67449793cdc77d InformationScripting/src/queries/QueryExecutor.h 26'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/186#discussion_r42988204'>File: InformationScripting/src/queries/QueryExecutor.h:L28-62</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I'm not entirely very happy about the new API. Do we really need three methods for executing queries: execute, runContinuation, and executeLast? I'm especially not happy about having two public methods. Can't we reduce this to one?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> If we execute from the command prompt we would like to have a CommandResult if we execute a continuation we would like to have the return value from the query. Not sure how to solve this nicely. Even though I fully agree with your concern.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Do we ever care about the return value from the Query?
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/186#issuecomment-151170758'>General Comment</a></b>
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Closing since we discussed a nicer solution in person.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/186?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/186?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/186'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
