### PR TITLE
Continuation queries

### DIFF
--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -76,14 +76,14 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 	else if (command != "fallback")
 	{
 		args.prepend(command);
+		QueryExecutor queryExecutor;
 		Query* q = nullptr;
 		try {
 			q = QueryParser::buildQueryFrom(args.join(""), node);
 		} catch (const QueryParsingException& e) {
 			return new Interaction::CommandResult(new Interaction::CommandError(e.message()));
 		}
-		Q_ASSERT(q);
-		QueryExecutor queryExecutor(q);
+		queryExecutor.addQuery(q);
 		return queryExecutor.execute();
 	}
 	return new Interaction::CommandResult();

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -79,7 +79,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 		QueryExecutor queryExecutor;
 		Query* q = nullptr;
 		try {
-			q = QueryParser::buildQueryFrom(args.join(""), node);
+			q = QueryParser::buildQueryFrom(args.join(""), node, &queryExecutor);
 		} catch (const QueryParsingException& e) {
 			return new Interaction::CommandResult(new Interaction::CommandError(e.message()));
 		}

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -73,17 +73,15 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 	{
 		new QueryPrompt(source);
 	}
-	else if (command != "fallback")
+	else
 	{
 		args.prepend(command);
 		QueryExecutor* queryExecutor = new QueryExecutor();
-		Query* q = nullptr;
 		try {
-			q = QueryParser::buildQueryFrom(args.join(""), node, queryExecutor);
+			QueryParser::buildQueryFrom(args.join(""), node, queryExecutor);
 		} catch (const QueryParsingException& e) {
 			return new Interaction::CommandResult(new Interaction::CommandError(e.message()));
 		}
-		queryExecutor->addQuery(q);
 		return queryExecutor->execute();
 	}
 	return new Interaction::CommandResult();

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -76,15 +76,15 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 	else if (command != "fallback")
 	{
 		args.prepend(command);
-		QueryExecutor queryExecutor;
+		QueryExecutor* queryExecutor = new QueryExecutor();
 		Query* q = nullptr;
 		try {
-			q = QueryParser::buildQueryFrom(args.join(""), node, &queryExecutor);
+			q = QueryParser::buildQueryFrom(args.join(""), node, queryExecutor);
 		} catch (const QueryParsingException& e) {
 			return new Interaction::CommandResult(new Interaction::CommandError(e.message()));
 		}
-		queryExecutor.addQuery(q);
-		return queryExecutor.execute();
+		queryExecutor->addQuery(q);
+		return queryExecutor->execute();
 	}
 	return new Interaction::CommandResult();
 }

--- a/InformationScripting/src/parsing/QueryParser.cpp
+++ b/InformationScripting/src/parsing/QueryParser.cpp
@@ -31,38 +31,52 @@
 #include "../queries/SubstractOperator.h"
 #include "../queries/UnionOperator.h"
 
-
 #include "../queries/QueryRegistry.h"
+#include "../queries/QueryExecutor.h"
 
 namespace InformationScripting {
 
 const QStringList QueryParser::OPEN_SCOPE_SYMBOL{"$<", "\"<", "{<"};
 const QStringList QueryParser::CLOSE_SCOPE_SYMBOL{">$", ">\"", ">}"};
 
-Query* QueryParser::buildQueryFrom(const QString& text, Model::Node* target, QueryExecutor* executor)
+void QueryParser::buildQueryFrom(const QString& text, Model::Node* target, QueryExecutor* executor)
 {
 	QueryParser parser;
 	parser.target_ = target;
 	parser.executor_ = executor;
 	Q_ASSERT(text.size());
-	auto type = parser.typeOf(text);
-	if (Type::Operator == type)
-		return parser.parseOperator(text);
-	else if (Type::Query == type)
-		return parser.parseQuery(text);
-	else if (Type::List == type)
+	// For now assume that we only have yield in operator parts:
+	auto parts = text.split("|" + OPEN_SCOPE_SYMBOL[1] + "yield" + CLOSE_SCOPE_SYMBOL[1] + "|",
+			QString::SkipEmptyParts);
+	if (parts.size() > 1)
 	{
-		auto queries = parser.parseList(text);
-		auto result = new CompositeQuery();
-		for (int i = 0; i < queries.size(); ++i)
+		for (int i = 0; i < parts.size(); ++i)
 		{
-			result->connectInput(i, queries[i]);
-			result->connectToOutput(queries[i], i);
+			if (i + 1 < parts.size()) parts[i].append(CLOSE_SCOPE_SYMBOL[0]);
+			if (i > 0) parts[i].prepend(OPEN_SCOPE_SYMBOL[0]);
 		}
-		return result;
 	}
-	Q_ASSERT(false);
-	return nullptr;
+	for (auto part : parts)
+	{
+		auto type = parser.typeOf(part);
+		if (Type::Operator == type)
+			executor->addQuery(parser.parseOperator(part));
+		else if (Type::Query == type)
+			executor->addQuery(parser.parseQuery(part));
+		else if (Type::List == type)
+		{
+			auto queries = parser.parseList(part);
+			auto result = new CompositeQuery();
+			for (int i = 0; i < queries.size(); ++i)
+			{
+				result->connectInput(i, queries[i]);
+				result->connectToOutput(queries[i], i);
+			}
+			executor->addQuery(result);
+		}
+		else
+			Q_ASSERT(false);
+	}
 }
 
 QueryParser::Type QueryParser::typeOf(const QString& text)
@@ -121,7 +135,7 @@ QList<Query*> QueryParser::parseList(const QString& text)
 	{
 		auto type = typeOf(part);
 		if (Type::Operator == type)
-			result.push_back(parseOperator(part, true));
+			result.push_back(parseOperator(part));
 		else if (Type::Query == type)
 			result.push_back(parseQuery(part));
 		else
@@ -130,7 +144,7 @@ QList<Query*> QueryParser::parseList(const QString& text)
 	return result;
 }
 
-Query* QueryParser::parseOperator(const QString& text, bool connectInput)
+Query* QueryParser::parseOperator(const QString& text)
 {
 	// TODO it might be better to be able to register operators.
 	// But that need some additional information on how they are used, thus we currently hardcode the operators.
@@ -140,11 +154,9 @@ Query* QueryParser::parseOperator(const QString& text, bool connectInput)
 	Q_ASSERT(parts.size()); // TODO error for user
 	CompositeQuery* composite = new CompositeQuery();
 	auto previousQueries = parseOperatorPart(parts[0]);
-	if (connectInput)
-	{
-		for (int i = 0; i < previousQueries.size(); ++i)
-			composite->connectInput(i, previousQueries[i]);
-	}
+
+	for (int i = 0; i < previousQueries.size(); ++i)
+		composite->connectInput(i, previousQueries[i]);
 
 	for (int i = 1; i < parts.size(); ++i)
 	{

--- a/InformationScripting/src/parsing/QueryParser.cpp
+++ b/InformationScripting/src/parsing/QueryParser.cpp
@@ -39,10 +39,11 @@ namespace InformationScripting {
 const QStringList QueryParser::OPEN_SCOPE_SYMBOL{"$<", "\"<", "{<"};
 const QStringList QueryParser::CLOSE_SCOPE_SYMBOL{">$", ">\"", ">}"};
 
-Query* QueryParser::buildQueryFrom(const QString& text, Model::Node* target)
+Query* QueryParser::buildQueryFrom(const QString& text, Model::Node* target, QueryExecutor* executor)
 {
 	QueryParser parser;
 	parser.target_ = target;
+	parser.executor_ = executor;
 	Q_ASSERT(text.size());
 	auto type = parser.typeOf(text);
 	if (Type::Operator == type)
@@ -106,7 +107,7 @@ Query* QueryParser::parseQuery(const QString& text)
 										 text.size() - 2 * SCOPE_SYMBOL_LENGTH_).split(" ", QString::SkipEmptyParts);
 	Q_ASSERT(data.size());
 	QString command = data.takeFirst();
-	auto q = QueryRegistry::instance().buildQuery(command, target_, data);
+	auto q = QueryRegistry::instance().buildQuery(command, target_, data, executor_);
 	Q_ASSERT(q); // TODO this should be an error for the user.
 	return q;
 }

--- a/InformationScripting/src/parsing/QueryParser.h
+++ b/InformationScripting/src/parsing/QueryParser.h
@@ -36,6 +36,7 @@ namespace InformationScripting {
 
 class CompositeQuery;
 class Query;
+class QueryExecutor;
 
 class INFORMATIONSCRIPTING_API QueryParser
 {
@@ -52,7 +53,7 @@ class INFORMATIONSCRIPTING_API QueryParser
 		 * queryOrOp	:= query | operator
 		 * list			:= {queryOrOp [, queryOrOp]+}
 		 */
-		static Query* buildQueryFrom(const QString& text, Model::Node* target);
+		static Query* buildQueryFrom(const QString& text, Model::Node* target, QueryExecutor* executor);
 
 	private:
 		QueryParser() = default;
@@ -69,6 +70,7 @@ class INFORMATIONSCRIPTING_API QueryParser
 										Query* connectionQuery, Query* outputQuery = nullptr);
 
 		Model::Node* target_{};
+		QueryExecutor* executor_{};
 
 		static constexpr int SCOPE_SYMBOL_LENGTH_{2};
 		static const QStringList OPEN_SCOPE_SYMBOL;

--- a/InformationScripting/src/parsing/QueryParser.h
+++ b/InformationScripting/src/parsing/QueryParser.h
@@ -53,7 +53,7 @@ class INFORMATIONSCRIPTING_API QueryParser
 		 * queryOrOp	:= query | operator
 		 * list			:= {queryOrOp [, queryOrOp]+}
 		 */
-		static Query* buildQueryFrom(const QString& text, Model::Node* target, QueryExecutor* executor);
+		static void buildQueryFrom(const QString& text, Model::Node* target, QueryExecutor* executor);
 
 	private:
 		QueryParser() = default;
@@ -63,7 +63,7 @@ class INFORMATIONSCRIPTING_API QueryParser
 
 		Query* parseQuery(const QString& text);
 		QList<Query*> parseList(const QString& text);
-		Query* parseOperator(const QString& text, bool connectInput = false);
+		Query* parseOperator(const QString& text);
 		QList<Query*> parseOperatorPart(const QString& text);
 
 		void connectQueriesWith(CompositeQuery* composite, const QList<Query*>& queries,

--- a/InformationScripting/src/precompiled.h
+++ b/InformationScripting/src/precompiled.h
@@ -43,6 +43,8 @@
 #if defined __cplusplus
 // Add C++ includes here
 
+#include <queue>
+
 // Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
 // and will be included in their precompiled headers
 

--- a/InformationScripting/src/queries/BreakpointManager.cpp
+++ b/InformationScripting/src/queries/BreakpointManager.cpp
@@ -37,7 +37,7 @@ const QStringList BreakpointManager::VISIBLE_ARGUMENT_NAMES{"v", "visible"};
 Optional<TupleSet> BreakpointManager::executeLinear(TupleSet input)
 {
 	auto tuples = input;
-	OODebug::JavaDebugger::BreakpointType type = OODebug::JavaDebugger::BreakpointType::Internal;
+	auto type = OODebug::JavaDebugger::BreakpointType::Internal;
 	if (arguments_.argument(VISIBLE_ARGUMENT_NAMES[0]) != "no")
 		type = OODebug::JavaDebugger::BreakpointType::User;
 

--- a/InformationScripting/src/queries/QueryExecutor.cpp
+++ b/InformationScripting/src/queries/QueryExecutor.cpp
@@ -43,7 +43,7 @@ void QueryExecutor::addQuery(Query* query)
 	queries_.emplace(std::unique_ptr<Query>(query));
 }
 
-Interaction::CommandResult* QueryExecutor::execute()
+Interaction::CommandResult* QueryExecutor::execute(const QList<TupleSet>& input)
 {
 	Q_ASSERT(!queries_.empty());
 
@@ -53,7 +53,7 @@ Interaction::CommandResult* QueryExecutor::execute()
 	auto query = std::move(queries_.front());
 	queries_.pop();
 
-	auto results = query->execute({});
+	auto results = query->execute(input);
 	if (results.size())
 	{
 		// TODO how to handle warnings? CommandResult has no warnings?
@@ -71,6 +71,8 @@ Interaction::CommandResult* QueryExecutor::execute()
 			errorMessage = results[0].errors()[0];
 		}
 	}
+
+	if (queries_.empty()) delete this;
 
 	if (hasError)
 		return new Interaction::CommandResult(new Interaction::CommandError(errorMessage));

--- a/InformationScripting/src/queries/QueryExecutor.cpp
+++ b/InformationScripting/src/queries/QueryExecutor.cpp
@@ -31,6 +31,8 @@
 
 #include "InteractionBase/src/commands/CommandResult.h"
 
+#include "VisualizationBase/src/VisualizationManager.h"
+
 namespace InformationScripting {
 
 QueryExecutor::~QueryExecutor()
@@ -72,7 +74,12 @@ Interaction::CommandResult* QueryExecutor::execute(const QList<TupleSet>& input)
 		}
 	}
 
-	if (queries_.empty()) delete this;
+	if (queries_.empty())
+	{
+		// deleteLater
+		QApplication::postEvent(Visualization::VisualizationManager::instance().mainScene(),
+																 new Visualization::CustomSceneEvent([this](){delete this;}));
+	}
 
 	if (hasError)
 		return new Interaction::CommandResult(new Interaction::CommandError(errorMessage));

--- a/InformationScripting/src/queries/QueryExecutor.h
+++ b/InformationScripting/src/queries/QueryExecutor.h
@@ -39,13 +39,13 @@ class Query;
 class INFORMATIONSCRIPTING_API QueryExecutor
 {
 	public:
-		QueryExecutor(Query* q);
 		~QueryExecutor();
+		void addQuery(Query* query);
 
 		Interaction::CommandResult* execute();
 
 	private:
-		Query* query_{};
+		std::queue<std::unique_ptr<Query>> queries_{};
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/QueryExecutor.h
+++ b/InformationScripting/src/queries/QueryExecutor.h
@@ -35,6 +35,7 @@ namespace Interaction {
 namespace InformationScripting {
 
 class Query;
+class TupleSet;
 
 class INFORMATIONSCRIPTING_API QueryExecutor
 {
@@ -42,7 +43,7 @@ class INFORMATIONSCRIPTING_API QueryExecutor
 		~QueryExecutor();
 		void addQuery(Query* query);
 
-		Interaction::CommandResult* execute();
+		Interaction::CommandResult* execute(const QList<TupleSet>& input = {});
 
 	private:
 		std::queue<std::unique_ptr<Query>> queries_{};

--- a/InformationScripting/src/queries/RuntimeQuery.cpp
+++ b/InformationScripting/src/queries/RuntimeQuery.cpp
@@ -36,6 +36,8 @@
 #include "OODebug/src/debugger/JavaDebugger.h"
 #include "OODebug/src/debugger/jdwp/messages/EventSet.h"
 
+#include "QueryExecutor.h"
+
 namespace InformationScripting {
 
 Optional<TupleSet> RuntimeQuery::executeLinear(TupleSet input)
@@ -73,10 +75,10 @@ Optional<TupleSet> RuntimeQuery::executeLinear(TupleSet input)
 
 void RuntimeQuery::registerDefaultQueries()
 {
-	QueryRegistry::registerQuery<RuntimeQuery>("traceExecution");
+	QueryRegistry::registerQuery<RuntimeQuery, QueryRegistry::ExtraArguments::QueryExecutor>("traceExecution");
 }
 
-RuntimeQuery::RuntimeQuery(Model::Node* target, QStringList)
+RuntimeQuery::RuntimeQuery(Model::Node* target, QStringList, QueryExecutor*)
 	: LinearQuery{target}
 {}
 

--- a/InformationScripting/src/queries/RuntimeQuery.h
+++ b/InformationScripting/src/queries/RuntimeQuery.h
@@ -31,6 +31,8 @@
 
 namespace InformationScripting {
 
+class QueryExecutor;
+
 class INFORMATIONSCRIPTING_API RuntimeQuery : public LinearQuery
 {
 	public:
@@ -41,7 +43,7 @@ class INFORMATIONSCRIPTING_API RuntimeQuery : public LinearQuery
 	private:
 		friend class QueryRegistry;
 
-		RuntimeQuery(Model::Node* target, QStringList);
+		RuntimeQuery(Model::Node* target, QStringList, QueryExecutor* executor = nullptr);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/RuntimeQuery.h
+++ b/InformationScripting/src/queries/RuntimeQuery.h
@@ -43,6 +43,8 @@ class INFORMATIONSCRIPTING_API RuntimeQuery : public LinearQuery
 	private:
 		friend class QueryRegistry;
 
+		QueryExecutor* executor_{};
+
 		RuntimeQuery(Model::Node* target, QStringList, QueryExecutor* executor = nullptr);
 };
 

--- a/InformationScripting/src/queries/ScriptQuery.cpp
+++ b/InformationScripting/src/queries/ScriptQuery.cpp
@@ -35,8 +35,9 @@
 
 namespace InformationScripting {
 
-ScriptQuery::ScriptQuery(const QString& scriptPath, Model::Node* target, const QStringList& args)
-	: Query{target}, scriptPath_{scriptPath}, arguments_{args}
+ScriptQuery::ScriptQuery(const QString& scriptPath, Model::Node* target,
+								 const QStringList& args, QueryExecutor* executor)
+	: Query{target}, scriptPath_{scriptPath}, arguments_{args}, executor_{executor}
 {}
 
 // Since we can't create a module in another way, we create an empty one here.
@@ -136,7 +137,7 @@ QList<Optional<TupleSet>> ScriptQuery::queryExecutor(QString name, boost::python
 	boost::python::stl_input_iterator<TupleSet> inputsBegin(input), inputsEnd;
 	auto inputConverted = QList<TupleSet>::fromStdList(std::list<TupleSet>(inputsBegin, inputsEnd));
 
-	std::unique_ptr<Query> query{QueryRegistry::instance().buildQuery(name, target(), argsConverted)};
+	std::unique_ptr<Query> query{QueryRegistry::instance().buildQuery(name, target(), argsConverted, executor_)};
 	auto result = query->execute(inputConverted);
 
 	return result;

--- a/InformationScripting/src/queries/ScriptQuery.h
+++ b/InformationScripting/src/queries/ScriptQuery.h
@@ -36,10 +36,12 @@ namespace Model {
 
 namespace InformationScripting {
 
+class QueryExecutor;
+
 class ScriptQuery : public Query
 {
 	public:
-		ScriptQuery(const QString& scriptPath, Model::Node* target, const QStringList& args = {});
+		ScriptQuery(const QString& scriptPath, Model::Node* target, const QStringList& args, QueryExecutor* executor);
 
 		static void initPythonEnvironment();
 		static void unloadPythonEnvironment();
@@ -50,6 +52,7 @@ class ScriptQuery : public Query
 		QString scriptPath_;
 		// Note since we only register QList<T> to python we don't use QStringList here:
 		QList<QString> arguments_;
+		QueryExecutor* executor_{};
 
 		void importStar(boost::python::dict& main_namespace, boost::python::object apiObject);
 

--- a/OODebug/src/debugger/JavaDebugger.cpp
+++ b/OODebug/src/debugger/JavaDebugger.cpp
@@ -296,6 +296,10 @@ JavaDebugger::JavaDebugger()
 	debugConnector_.addEventListener(Protocol::EventKind::VM_START, [this] (Event e) { handleVMStart(e); });
 	debugConnector_.addEventListener(Protocol::EventKind::SINGLE_STEP,
 												[this] (Event e) { handleSingleStep(e.singleStep()); });
+	debugConnector_.addEventListener(Protocol::EventKind::VM_DEATH, [this] (Event) {
+		for (auto listener : exitListeners_) listener();
+		exitListeners_.clear();
+	});
 }
 
 bool JavaDebugger::isParentClassLoaded(Model::Node* node)

--- a/OODebug/src/debugger/JavaDebugger.h
+++ b/OODebug/src/debugger/JavaDebugger.h
@@ -91,6 +91,13 @@ class OODEBUG_API JavaDebugger
 		int addBreakpointListener(Model::Node* node, BreakpointListener listener);
 		void removeBreakpointListener(int id);
 
+		using ProgramExitSingleShot = std::function<void ()>;
+		/**
+		 *	Register a listener for the next program exit. Once the event happened the listener will be destroyed
+		 * and not called in any subsequent event.
+		 */
+		void addProgramExitLister(ProgramExitSingleShot listener);
+
 	private:
 		JavaDebugger();
 
@@ -138,6 +145,8 @@ class OODEBUG_API JavaDebugger
 		QMultiHash<Model::Node*, std::pair<int, BreakpointListener>> breakpointListeners_;
 		int nextBreakpointListenerId_{0};
 
+		QVector<ProgramExitSingleShot> exitListeners_;
+
 		static const QString BREAKPOINT_OVERLAY_GROUP;
 		static const QString PLOT_OVERLAY_GROUP;
 		static const QString CURRENT_LINE_OVERLAY_GROUP;
@@ -148,6 +157,11 @@ inline int JavaDebugger::addBreakpointListener(Model::Node* node, BreakpointList
 	int id = nextBreakpointListenerId_++;
 	breakpointListeners_.insertMulti(node, {id, listener});
 	return id;
+}
+
+inline void JavaDebugger::addProgramExitLister(JavaDebugger::ProgramExitSingleShot listener)
+{
+	exitListeners_.push_back(listener);
 }
 
 } /* namespace OODebug */


### PR DESCRIPTION
Contains some elements of #186 but is mostly new and much simpler :)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43024029%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43024534%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43024632%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43024795%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43025282%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43025756%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43026426%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43026517%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43026632%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43026806%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43036865%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43039744%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43055056%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43061211%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20a83fe8a075ec1a980a6e2204298224d490681373%20InformationScripting/src/queries/RuntimeQuery.h%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43024029%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20the%20executor%20parameter%20have%20a%20default%20nullptr%20value%3F%20Isn%27t%20it%20better%20if%20we%20don%27t%20allow%20that%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T17%3A23%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20it%20would%20be%20better%20but%20if%20you%20look%20at%3A%20QueryRegistry%3A%3AregisterQuery%20%20%28https%3A//github.com/dimitar-asenov/Envision/pull/191/files%23diff-c6b1741a8add6502996a2ba771a07d9aR85%20%29%20is%20implemented%20you%20see%20that%20it%20needs%20both%20constructors.%20There%20is%20no%20static_if%20so%20it%20has%20to%20work%20for%20both%20cases.%20%22%2C%20%22created_at%22%3A%20%222015-10-26T17%3A27%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20see.%20Well%20you%20don%27t%20technically%20need%20%60static_if%60.%20That%20would%20be%20a%20direct%20way%20of%20doing%20things%2C%20but%20one%20could%20use%20explicit%20specializations%20to%20achieve%20the%20same%20effect.%5Cr%5Cn%5Cr%5CnIn%20any%20case%2C%20you%20don%27t%20have%20to%20do%20it%20as%20it%20will%20be%20quite%20some%20additional%20code.%22%2C%20%22created_at%22%3A%20%222015-10-26T17%3A35%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20you%20can%27t%20use%20partial%20specialization%20on%20methods%2C%20so%20things%20would%20need%20another%20indirection.%22%2C%20%22created_at%22%3A%20%222015-10-26T17%3A40%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%27s%20true.%20As%20I%20said%2C%20don%27t%20do%20it%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-10-26T17%3A42%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/RuntimeQuery.h%3AL43-52%22%7D%2C%20%22Pull%20a83fe8a075ec1a980a6e2204298224d490681373%20InformationScripting/src/queries/QueryExecutor.cpp%2051%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/191%23discussion_r43024534%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20still%20feel%20a%20bit%20uneasy%20about%20this.%20Could%20you%20quickly%20have%20a%20look%20at%20Qt%20functionality%20for%20late%20deleting%20stuff%3F%20I%20remember%20that%20they%20had%20some%20mechanism%20to%20delete%20stuff%20later%20%28maybe%20schedule%20the%20deletion%20in%20an%20event%3F%29%20I%20guess%20we%20could%20this%20this%20ourselves%2C%20regardless%20of%20QT%20support%2C%20just%20post%20an%20event%20that%20deletes.%22%2C%20%22created_at%22%3A%20%222015-10-26T17%3A26%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22deleteLater%20only%20works%20on%20QObject%20subclasses.%20Do%20you%20want%20me%20to%20check%20the%20actual%20implementation%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T17%3A28%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20think%20that%27s%20necessary.%20Couldn%27t%20we%20just%20post%20an%20event%20that%20deletes%20this%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T17%3A31%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20deleteLater%20is%20just%3A%5Cr%5Cn%60%60%60%20QCoreApplication%3A%3ApostEvent%28this%2C%20new%20QDeferredDeleteEvent%28%29%29%3B%60%60%60%5Cr%5Cn%5Cr%5Cnsee%20also%3A%20https%3A//github.com/qtproject/qtbase/blob/dev/src/corelib/kernel/qobject.cpp%23L2136%5Cr%5Cnso%20I%20think%20I%20can%20use%20this.%22%2C%20%22created_at%22%3A%20%222015-10-26T17%3A39%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Alright%2C%20let%27s%20try%20that%20and%20see%20what%20happens.%20It%20feels%20like%20much%20less%20of%20a%20hack%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-10-26T17%3A40%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20no%2C%20that%20doesn%27t%20work%2C%20the%20first%20argument%20has%20to%20be%20QObject%2A%5Cr%5CnAny%20other%20ideas%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T18%3A56%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Can%27t%20you%20just%20post%20a%20global%20event%20of%20some%20sort%3F%20We%20just%20need%20anyone%20to%20delete%20it%3F%20We%20could%20post%20an%20event%20to%20the%20scene.%20There%20already%20should%20be%20a%20custom%20event%20class%20for%20scene%2C%20which%20essentially%20allows%20you%20to%20post%20a%20lambda%20to%20be%20executed.%22%2C%20%22created_at%22%3A%20%222015-10-26T19%3A19%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20could%20use%20%60%60%60QApplication%3A%3ApostEvent%28Visualization%3A%3AVisualizationManager%3A%3Ainstance%28%29.mainScene%28%29%2C%5Cr%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%20new%20Visualization%3A%3ACustomSceneEvent%28%5Bthis%5D%28%29%7Bdelete%20this%3B%7D%29%29%60%60%60%22%2C%20%22created_at%22%3A%20%222015-10-26T21%3A22%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20looks%20pretty%20good%20to%20me.%22%2C%20%22created_at%22%3A%20%222015-10-26T22%3A15%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/QueryExecutor.cpp%3AL67-84%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull a83fe8a075ec1a980a6e2204298224d490681373 InformationScripting/src/queries/RuntimeQuery.h 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/191#discussion_r43024029'>File: InformationScripting/src/queries/RuntimeQuery.h:L43-52</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Should the executor parameter have a default nullptr value? Isn't it better if we don't allow that?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Yes it would be better but if you look at: QueryRegistry::registerQuery  (https://github.com/dimitar-asenov/Envision/pull/191/files#diff-c6b1741a8add6502996a2ba771a07d9aR85 ) is implemented you see that it needs both constructors. There is no static_if so it has to work for both cases.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I see. Well you don't technically need `static_if`. That would be a direct way of doing things, but one could use explicit specializations to achieve the same effect.
  In any case, you don't have to do it as it will be quite some additional code.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Well you can't use partial specialization on methods, so things would need another indirection.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> That's true. As I said, don't do it :)
- [ ] <a href='#crh-comment-Pull a83fe8a075ec1a980a6e2204298224d490681373 InformationScripting/src/queries/QueryExecutor.cpp 51'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/191#discussion_r43024534'>File: InformationScripting/src/queries/QueryExecutor.cpp:L67-84</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I still feel a bit uneasy about this. Could you quickly have a look at Qt functionality for late deleting stuff? I remember that they had some mechanism to delete stuff later (maybe schedule the deletion in an event?) I guess we could this this ourselves, regardless of QT support, just post an event that deletes.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> deleteLater only works on QObject subclasses. Do you want me to check the actual implementation?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I don't think that's necessary. Couldn't we just post an event that deletes this?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> I think deleteLater is just:
  `QCoreApplication::postEvent(this, new QDeferredDeleteEvent());`
  see also: https://github.com/qtproject/qtbase/blob/dev/src/corelib/kernel/qobject.cpp#L2136
  so I think I can use this.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Alright, let's try that and see what happens. It feels like much less of a hack :)
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Ah no, that doesn't work, the first argument has to be QObject*
  Any other ideas?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Can't you just post a global event of some sort? We just need anyone to delete it? We could post an event to the scene. There already should be a custom event class for scene, which essentially allows you to post a lambda to be executed.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> I could use `QApplication::postEvent(Visualization::VisualizationManager::instance().mainScene(),
  new Visualization::CustomSceneEvent([this](){delete this;}))`
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> That looks pretty good to me.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/191?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/191?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/191'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
