### PR TITLE
Query prompt improvements

### DIFF
--- a/Core/src/EnvisionException.cpp
+++ b/Core/src/EnvisionException.cpp
@@ -42,9 +42,9 @@ EnvisionException::EnvisionException()
 	: EnvisionException("")
 {}
 
-EnvisionException::EnvisionException(const QString& message, bool throwInDebugMode) : msg_{message}
+EnvisionException::EnvisionException(const QString& message, bool assertInDebugMode) : msg_{message}
 {
-	if (throwInDebugMode && assertOnThrow()) Q_ASSERT_X(false, "Exception thrown", message.toLatin1());
+	if (assertInDebugMode && assertOnThrow()) Q_ASSERT_X(false, "Exception thrown", message.toLatin1());
 }
 
 EnvisionException::~EnvisionException() {}

--- a/Core/src/EnvisionException.cpp
+++ b/Core/src/EnvisionException.cpp
@@ -39,13 +39,12 @@ bool& EnvisionException::assertOnThrow()
 }
 
 EnvisionException::EnvisionException()
-{
-	if (assertOnThrow()) Q_ASSERT_X(false, "Exception thrown", "");
-}
+	: EnvisionException("")
+{}
 
-EnvisionException::EnvisionException(const QString& message) : msg_{message}
+EnvisionException::EnvisionException(const QString& message, bool throwInDebugMode) : msg_{message}
 {
-	if (assertOnThrow()) Q_ASSERT_X(false, "Exception thrown", message.toLatin1());
+	if (throwInDebugMode && assertOnThrow()) Q_ASSERT_X(false, "Exception thrown", message.toLatin1());
 }
 
 EnvisionException::~EnvisionException() {}

--- a/Core/src/EnvisionException.h
+++ b/Core/src/EnvisionException.h
@@ -38,7 +38,7 @@ class CORE_API EnvisionException
 {
 	public:
 		EnvisionException();
-		EnvisionException(const QString& message);
+		EnvisionException(const QString& message, bool throwInDebugMode = true);
 		virtual ~EnvisionException();
 
 		virtual const QString& name() const;

--- a/Core/src/EnvisionException.h
+++ b/Core/src/EnvisionException.h
@@ -38,7 +38,7 @@ class CORE_API EnvisionException
 {
 	public:
 		EnvisionException();
-		EnvisionException(const QString& message, bool throwInDebugMode = true);
+		EnvisionException(const QString& message, bool assertInDebugMode = true);
 		virtual ~EnvisionException();
 
 		virtual const QString& name() const;

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -73,7 +73,8 @@ HEADERS += src/precompiled.h \
     src/query_prompt/QueryPromptMode.h \
     src/query_prompt/QueryPromptInputStyle.h \
     src/query_prompt/VQueryNodeContainer.h \
-    src/query_prompt/QueryBuilder.h
+    src/query_prompt/QueryBuilder.h \
+    src/queries/PassthroughQuery.h
 SOURCES += src/InformationScriptingException.cpp \
     src/InformationScriptingPlugin.cpp \
     test/SimpleTest.cpp \
@@ -129,7 +130,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/query_prompt/QueryPromptMode.cpp \
     src/query_prompt/QueryPromptInputStyle.cpp \
     src/query_prompt/VQueryNodeContainer.cpp \
-    src/query_prompt/QueryBuilder.cpp
+    src/query_prompt/QueryBuilder.cpp \
+    src/queries/PassthroughQuery.cpp
 
 # Workaround to not have any pragma's in NodeApi.cpp
 # (because of unused local typedef in BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS):

--- a/InformationScripting/src/InformationScriptingException.cpp
+++ b/InformationScripting/src/InformationScriptingException.cpp
@@ -28,8 +28,8 @@
 
 namespace InformationScripting {
 
-InformationScriptingException::InformationScriptingException(const QString& message, bool throwInDebugMode)
-	: Core::EnvisionException(message, throwInDebugMode)
+InformationScriptingException::InformationScriptingException(const QString& message, bool assertInDebugMode)
+	: Core::EnvisionException(message, assertInDebugMode)
 {}
 
 const QString& InformationScriptingException::name() const

--- a/InformationScripting/src/InformationScriptingException.cpp
+++ b/InformationScripting/src/InformationScriptingException.cpp
@@ -28,10 +28,9 @@
 
 namespace InformationScripting {
 
-InformationScriptingException::InformationScriptingException(const QString& message) :
-	Core::EnvisionException(message)
-{
-}
+InformationScriptingException::InformationScriptingException(const QString& message, bool throwInDebugMode)
+	: Core::EnvisionException(message, throwInDebugMode)
+{}
 
 const QString& InformationScriptingException::name() const
 {

--- a/InformationScripting/src/InformationScriptingException.h
+++ b/InformationScripting/src/InformationScriptingException.h
@@ -34,7 +34,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API InformationScriptingException : public Core::EnvisionException
 {
 		public:
-			InformationScriptingException(const QString& message, bool throwInDebugMode = true);
+			InformationScriptingException(const QString& message, bool assertInDebugMode = true);
 			const QString& name() const;
 };
 

--- a/InformationScripting/src/InformationScriptingException.h
+++ b/InformationScripting/src/InformationScriptingException.h
@@ -34,7 +34,7 @@ namespace InformationScripting {
 class INFORMATIONSCRIPTING_API InformationScriptingException : public Core::EnvisionException
 {
 		public:
-			InformationScriptingException(const QString& message);
+			InformationScriptingException(const QString& message, bool throwInDebugMode = true);
 			const QString& name() const;
 };
 

--- a/InformationScripting/src/commands/CScript.cpp
+++ b/InformationScripting/src/commands/CScript.cpp
@@ -73,7 +73,7 @@ Interaction::CommandResult* CScript::execute(Visualization::Item* source, Visual
 	} catch (const QueryParsingException& e) {
 		return new Interaction::CommandResult(new Interaction::CommandError(e.message()));
 	}
-	return queryExecutor->execute();
+	queryExecutor->execute();
 
 	return new Interaction::CommandResult();
 }

--- a/InformationScripting/src/handlers/HQuery.cpp
+++ b/InformationScripting/src/handlers/HQuery.cpp
@@ -79,8 +79,7 @@ void HQuery::initStringComponents()
 		return StringComponents::c(opNode->left(),
 			StringComponents::choose(opNode->op(),
 								OperatorQueryNode::OperatorTypes::Pipe, "|",
-								OperatorQueryNode::OperatorTypes::Substract, "|-",
-								OperatorQueryNode::OperatorTypes::Union, "U"),
+								OperatorQueryNode::OperatorTypes::Substract, "|-"),
 					opNode->right());
 	});
 

--- a/InformationScripting/src/handlers/HQuery.cpp
+++ b/InformationScripting/src/handlers/HQuery.cpp
@@ -79,7 +79,7 @@ void HQuery::initStringComponents()
 		return StringComponents::c(opNode->left(),
 			StringComponents::choose(opNode->op(),
 								OperatorQueryNode::OperatorTypes::Pipe, "|",
-								OperatorQueryNode::OperatorTypes::Substract, "-",
+								OperatorQueryNode::OperatorTypes::Substract, "|-",
 								OperatorQueryNode::OperatorTypes::Union, "U"),
 					opNode->right());
 	});
@@ -233,11 +233,12 @@ bool HQuery::canBeRemoved(const QString& exp, int index)
 		if (index > 0) before = exp[index-1];
 		if (index < exp.length()-1) after = exp[index+1];
 
+		// Since all operators start with OP_PIPE it is enough to check for the pipe below:
 		if (before == SimpleQueryParser::LIST_RIGHT)
 			return after.isNull() || after == SimpleQueryParser::LIST_DELIM || after == SimpleQueryParser::OP_PIPE;
 
 		if (after == SimpleQueryParser::LIST_LEFT)
-			return before.isNull() || before == SimpleQueryParser::LIST_DELIM || before == SimpleQueryParser::OP_PIPE;
+			return before.isNull() || before == SimpleQueryParser::LIST_DELIM || isOperatorAtIndex(exp, index - 1);
 
 		return true;
 	}
@@ -262,7 +263,7 @@ int HQuery::processEnter(QString& exp, int index)
 
 			if (subLists == 0)
 			{
-				if (foundIndex < 0 || foundIndex == exp.length() || exp[foundIndex] == SimpleQueryParser::OP_PIPE)
+				if (foundIndex < 0 || foundIndex == exp.length() || isOperatorAtIndex(exp, foundIndex))
 				{
 					// We don't have a list, we must insert the list delimiters
 					needsDelimiter = true;
@@ -333,6 +334,13 @@ int HQuery::removeListsWithOneElement(QString& exp, int& index, int iteratorInde
 
 	Q_ASSERT(listStart >= 0 || iteratorIndex >= exp.length());
 	return iteratorIndex;
+}
+
+bool HQuery::isOperatorAtIndex(const QString& exp, int index)
+{
+	return exp[index] == SimpleQueryParser::OP_PIPE
+			|| (exp[index] == SimpleQueryParser::OP_MINUS_POSTFIX
+				 && index > 0 && exp[index-1] == SimpleQueryParser::OP_PIPE);
 }
 
 }

--- a/InformationScripting/src/handlers/HQuery.h
+++ b/InformationScripting/src/handlers/HQuery.h
@@ -58,6 +58,8 @@ class HQuery : public Interaction::GenericHandler {
 
 		static int processEnter(QString& exp, int index);
 		static int removeListsWithOneElement(QString& exp, int& index, int iteratorIndex = -1);
+
+		static bool isOperatorAtIndex(const QString& exp, int index);
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/nodes/OperatorQueryNode.h
+++ b/InformationScripting/src/nodes/OperatorQueryNode.h
@@ -44,7 +44,7 @@ class INFORMATIONSCRIPTING_API OperatorQueryNode : public Super<QueryNode>
 	PRIVATE_ATTRIBUTE_VALUE(Model::Integer, opr, setOpr, int)
 
 	public:
-		enum OperatorTypes { Pipe, Substract, Union };
+		enum OperatorTypes { Pipe, Substract };
 
 		OperatorTypes op() const;
 		void setOp(const OperatorTypes& oper);

--- a/InformationScripting/src/parsing/QueryParser.cpp
+++ b/InformationScripting/src/parsing/QueryParser.cpp
@@ -56,27 +56,27 @@ void QueryParser::buildQueryFrom(const QString& text, Model::Node* target, Query
 			if (i > 0) parts[i].prepend(OPEN_SCOPE_SYMBOL[0]);
 		}
 	}
-	for (auto part : parts)
-	{
-		auto type = parser.typeOf(part);
-		if (Type::Operator == type)
-			executor->addQuery(parser.parseOperator(part));
-		else if (Type::Query == type)
-			executor->addQuery(parser.parseQuery(part));
-		else if (Type::List == type)
-		{
-			auto queries = parser.parseList(part);
-			auto result = new CompositeQuery();
-			for (int i = 0; i < queries.size(); ++i)
-			{
-				result->connectInput(i, queries[i]);
-				result->connectToOutput(queries[i], i);
-			}
-			executor->addQuery(result);
-		}
-		else
-			Q_ASSERT(false);
-	}
+//	for (auto part : parts)
+//	{
+//		auto type = parser.typeOf(part);
+//		if (Type::Operator == type)
+//			executor->addQuery(parser.parseOperator(part));
+//		else if (Type::Query == type)
+//			executor->addQuery(parser.parseQuery(part));
+//		else if (Type::List == type)
+//		{
+//			auto queries = parser.parseList(part);
+//			auto result = new CompositeQuery();
+//			for (int i = 0; i < queries.size(); ++i)
+//			{
+//				result->connectInput(i, queries[i]);
+//				result->connectToOutput(queries[i], i);
+//			}
+//			executor->addQuery(result);
+//		}
+//		else
+//			Q_ASSERT(false);
+//	}
 }
 
 QueryParser::Type QueryParser::typeOf(const QString& text)
@@ -123,7 +123,7 @@ Query* QueryParser::parseQuery(const QString& text)
 	QString command = data.takeFirst();
 	auto q = QueryRegistry::instance().buildQuery(command, target_, data, executor_);
 	Q_ASSERT(q); // TODO this should be an error for the user.
-	return q;
+	return q.release();
 }
 
 QList<Query*> QueryParser::parseList(const QString& text)

--- a/InformationScripting/src/parsing/QueryParsingException.cpp
+++ b/InformationScripting/src/parsing/QueryParsingException.cpp
@@ -29,7 +29,7 @@
 namespace InformationScripting {
 
 QueryParsingException::QueryParsingException(const QString& message)
-	: InformationScriptingException(message)
+	: InformationScriptingException(message, false)
 {}
 
 const QString& QueryParsingException::name() const

--- a/InformationScripting/src/parsing/SimpleQueryParser.cpp
+++ b/InformationScripting/src/parsing/SimpleQueryParser.cpp
@@ -35,7 +35,7 @@ constexpr QChar SimpleQueryParser::LIST_LEFT;
 constexpr QChar SimpleQueryParser::LIST_RIGHT;
 constexpr QChar SimpleQueryParser::LIST_DELIM;
 constexpr QChar SimpleQueryParser::OP_PIPE;
-
+constexpr QChar SimpleQueryParser::OP_MINUS_POSTFIX;
 
 QueryNode* SimpleQueryParser::parse(const QString& queryString)
 {
@@ -78,7 +78,13 @@ QueryNode* SimpleQueryParser::parseAny(const QString& queryString, int& index)
 	// We must have an operator, create it and keep parsing.
 	Q_ASSERT(ch == OP_PIPE);
 	auto op = new OperatorQueryNode();
-	op->setOp(OperatorQueryNode::Pipe);
+	if (index + 1 < queryString.size() && queryString[index + 1] == OP_MINUS_POSTFIX)
+	{
+		op->setOp(OperatorQueryNode::Substract);
+		++index;
+	}
+	else
+		op->setOp(OperatorQueryNode::Pipe);
 	op->setLeft(query);
 	op->setRight(parseAny(queryString, ++index));
 	return op;

--- a/InformationScripting/src/parsing/SimpleQueryParser.cpp
+++ b/InformationScripting/src/parsing/SimpleQueryParser.cpp
@@ -71,7 +71,20 @@ QueryNode* SimpleQueryParser::parseAny(const QString& queryString, int& index)
 		if (index < queryString.length())
 			ch = queryString[index];
 	}
-	else query = new CommandNode(commandString); // Create the command. Note that it could be an empty string.
+	else
+	{
+		// Create the command. Note that it could be an empty string.
+		auto parts = commandString.split(" ");
+		if (parts.isEmpty())
+			query = new CommandNode("");
+		else
+		{
+			auto command = new CommandNode(parts.takeFirst());
+			for (auto part : parts)
+				command->arguments()->append(new CommandArgument(part));
+			query = command;
+		}
+	}
 
 	if (ch == LIST_DELIM || ch == LIST_RIGHT || index >= queryString.length()) return query;
 

--- a/InformationScripting/src/parsing/SimpleQueryParser.h
+++ b/InformationScripting/src/parsing/SimpleQueryParser.h
@@ -43,6 +43,7 @@ class INFORMATIONSCRIPTING_API SimpleQueryParser
 		static constexpr QChar LIST_DELIM{0x2022};
 
 		static constexpr QChar OP_PIPE{'|'};
+		static constexpr QChar OP_MINUS_POSTFIX{'-'};
 
 	private:
 		static QueryNode* parseAny(const QString& queryString, int& index);

--- a/InformationScripting/src/queries/CompositeQuery.cpp
+++ b/InformationScripting/src/queries/CompositeQuery.cpp
@@ -110,13 +110,13 @@ QList<Optional<TupleSet> > CompositeQuery::execute(QList<TupleSet> input)
 	return outNode_->calculatedOutputs_;
 }
 
-Query* CompositeQuery::addQuery(std::unique_ptr<Query> query)
+Query* CompositeQuery::addQuery(std::unique_ptr<Query>&& query)
 {
 	auto rawQ = query.get();
 	// A query should only be added once:
 	Q_ASSERT(std::find_if(nodes_.begin(), nodes_.end(), [rawQ](QueryNode* existing) {return existing->q_.get() == rawQ;})
 					== nodes_.end());
-	auto newNode = new QueryNode(std::move(query));
+	auto newNode = new QueryNode(std::forward<std::unique_ptr<Query>>(query));
 	nodes_.push_back(newNode);
 	return rawQ;
 }

--- a/InformationScripting/src/queries/CompositeQuery.h
+++ b/InformationScripting/src/queries/CompositeQuery.h
@@ -40,6 +40,13 @@ class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;
 
 		/**
+		 * Adds the \a query to this CompositeQuery. This CompositeQuery will take ownership of \a query.
+		 * The returned value is the underlying raw pointer in \a query which can be used to wire \a query with other
+		 * queries.
+		 */
+		Query* addQuery(std::unique_ptr<Query> query);
+
+		/**
 		 * Connects output 0 from Query \a from to input 0 of Query \a to.
 		 *
 		 * If either \a from or \a to was not yet inserted they will be and this query will take ownership of it.
@@ -66,8 +73,7 @@ class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 		};
 
 		struct QueryNode {
-				QueryNode(Query* q) : q_{q} {}
-				~QueryNode();
+				QueryNode(std::unique_ptr<Query> q) : q_{std::move(q)} {}
 
 				/**
 				 * Describes an input mapping:
@@ -91,7 +97,7 @@ class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 				bool canExecute() const;
 				void execute();
 
-				Query* q_{};
+				std::unique_ptr<Query> q_{};
 		};
 		// Pseudo node to connect, to get input from execute method
 		QueryNode* inNode_{new QueryNode(nullptr)};

--- a/InformationScripting/src/queries/CompositeQuery.h
+++ b/InformationScripting/src/queries/CompositeQuery.h
@@ -44,7 +44,7 @@ class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 		 * The returned value is the underlying raw pointer in \a query which can be used to wire \a query with other
 		 * queries.
 		 */
-		Query* addQuery(std::unique_ptr<Query> query);
+		Query* addQuery(std::unique_ptr<Query>&& query);
 
 		/**
 		 * Connects output 0 from Query \a from to input 0 of Query \a to.
@@ -73,7 +73,7 @@ class INFORMATIONSCRIPTING_API CompositeQuery : public Query
 		};
 
 		struct QueryNode {
-				QueryNode(std::unique_ptr<Query> q) : q_{std::move(q)} {}
+				QueryNode(std::unique_ptr<Query>&& q) : q_{std::forward<std::unique_ptr<Query>>(q)} {}
 
 				/**
 				 * Describes an input mapping:

--- a/InformationScripting/src/queries/PassthroughQuery.cpp
+++ b/InformationScripting/src/queries/PassthroughQuery.cpp
@@ -1,0 +1,39 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "PassthroughQuery.h"
+
+namespace InformationScripting {
+
+QList<Optional<TupleSet>> PassthroughQuery::execute(QList<TupleSet> input)
+{
+	QList<Optional<TupleSet>> result;
+	for (const auto& in : input)
+		result.push_back(in);
+	return result;
+}
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/PassthroughQuery.h
+++ b/InformationScripting/src/queries/PassthroughQuery.h
@@ -1,0 +1,41 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../informationscripting_api.h"
+
+#include "Query.h"
+
+namespace InformationScripting {
+
+class INFORMATIONSCRIPTING_API PassthroughQuery : public Query
+{
+	public:
+		virtual QList<Optional<TupleSet>> execute(QList<TupleSet> input) override;
+};
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/QueryExecutor.cpp
+++ b/InformationScripting/src/queries/QueryExecutor.cpp
@@ -40,9 +40,9 @@ QueryExecutor::~QueryExecutor()
 	Q_ASSERT(queries_.empty());
 }
 
-void QueryExecutor::addQuery(Query* query)
+void QueryExecutor::addQuery(std::unique_ptr<Query> query)
 {
-	queries_.emplace(std::unique_ptr<Query>(query));
+	queries_.emplace(std::move(query));
 }
 
 Interaction::CommandResult* QueryExecutor::execute(const QList<TupleSet>& input)

--- a/InformationScripting/src/queries/QueryExecutor.cpp
+++ b/InformationScripting/src/queries/QueryExecutor.cpp
@@ -45,12 +45,11 @@ void QueryExecutor::addQuery(std::unique_ptr<Query> query)
 	queries_.emplace(std::move(query));
 }
 
-Interaction::CommandResult* QueryExecutor::execute(const QList<TupleSet>& input)
+QList<QString> QueryExecutor::execute(const QList<TupleSet>& input)
 {
 	Q_ASSERT(!queries_.empty());
 
-	bool hasError = false;
-	QString errorMessage{};
+	QList<QString> errorMessages;
 
 	auto query = std::move(queries_.front());
 	queries_.pop();
@@ -68,10 +67,7 @@ Interaction::CommandResult* QueryExecutor::execute(const QList<TupleSet>& input)
 			results.clear();
 		}
 		else
-		{
-			hasError = true;
-			errorMessage = results[0].errors()[0];
-		}
+			errorMessages = results[0].errors();
 	}
 
 	if (queries_.empty())
@@ -81,10 +77,7 @@ Interaction::CommandResult* QueryExecutor::execute(const QList<TupleSet>& input)
 																 new Visualization::CustomSceneEvent([this](){delete this;}));
 	}
 
-	if (hasError)
-		return new Interaction::CommandResult(new Interaction::CommandError(errorMessage));
-	else
-		return new Interaction::CommandResult();
+	return errorMessages;
 }
 
 } /* namespace InformationScripting */

--- a/InformationScripting/src/queries/QueryExecutor.cpp
+++ b/InformationScripting/src/queries/QueryExecutor.cpp
@@ -40,9 +40,9 @@ QueryExecutor::~QueryExecutor()
 	Q_ASSERT(queries_.empty());
 }
 
-void QueryExecutor::addQuery(std::unique_ptr<Query> query)
+void QueryExecutor::addQuery(std::unique_ptr<Query>&& query)
 {
-	queries_.emplace(std::move(query));
+	queries_.emplace(std::forward<std::unique_ptr<Query>>(query));
 }
 
 QList<QString> QueryExecutor::execute(const QList<TupleSet>& input)

--- a/InformationScripting/src/queries/QueryExecutor.h
+++ b/InformationScripting/src/queries/QueryExecutor.h
@@ -43,7 +43,7 @@ class INFORMATIONSCRIPTING_API QueryExecutor
 		~QueryExecutor();
 		void addQuery(std::unique_ptr<Query> query);
 
-		Interaction::CommandResult* execute(const QList<TupleSet>& input = {});
+		QList<QString> execute(const QList<TupleSet>& input = {});
 
 	private:
 		std::queue<std::unique_ptr<Query>> queries_{};

--- a/InformationScripting/src/queries/QueryExecutor.h
+++ b/InformationScripting/src/queries/QueryExecutor.h
@@ -41,7 +41,7 @@ class INFORMATIONSCRIPTING_API QueryExecutor
 {
 	public:
 		~QueryExecutor();
-		void addQuery(std::unique_ptr<Query> query);
+		void addQuery(std::unique_ptr<Query>&& query);
 
 		QList<QString> execute(const QList<TupleSet>& input = {});
 

--- a/InformationScripting/src/queries/QueryExecutor.h
+++ b/InformationScripting/src/queries/QueryExecutor.h
@@ -41,7 +41,7 @@ class INFORMATIONSCRIPTING_API QueryExecutor
 {
 	public:
 		~QueryExecutor();
-		void addQuery(Query* query);
+		void addQuery(std::unique_ptr<Query> query);
 
 		Interaction::CommandResult* execute(const QList<TupleSet>& input = {});
 

--- a/InformationScripting/src/query_prompt/QueryBuilder.cpp
+++ b/InformationScripting/src/query_prompt/QueryBuilder.cpp
@@ -93,7 +93,8 @@ std::unique_ptr<Query> QueryBuilder::visitOperator(QueryBuilder* self, OperatorQ
 	else if (leftComposite)
 	{
 		// union
-		connectQueriesWith(composite.get(), leftComposite, new UnionOperator(), right);
+		auto unionQuery = composite->addQuery(std::unique_ptr<Query>(new UnionOperator()));
+		connectQueriesWith(composite.get(), leftComposite, unionQuery, right);
 	}
 	else if (rightComposite)
 	{

--- a/InformationScripting/src/query_prompt/QueryBuilder.cpp
+++ b/InformationScripting/src/query_prompt/QueryBuilder.cpp
@@ -31,6 +31,7 @@
 #include "../nodes/OperatorQueryNode.h"
 
 #include "../queries/CompositeQuery.h"
+#include "../queries/PassthroughQuery.h"
 #include "../queries/QueryRegistry.h"
 #include "../queries/SubstractOperator.h"
 #include "../queries/UnionOperator.h"
@@ -54,7 +55,7 @@ std::unique_ptr<Query> QueryBuilder::visitCommand(QueryBuilder* self, CommandNod
 {
 	auto text = command->name();
 	if (text.isEmpty())
-		throw QueryParsingException("Empty command is not allowed");
+		return std::unique_ptr<Query>(new PassthroughQuery());
 	auto parts = text.split(" ", QString::SplitBehavior::SkipEmptyParts);
 	auto cmd = parts.takeFirst();
 	if (auto q = QueryRegistry::instance().buildQuery(cmd, self->target_, parts, self->executor_))

--- a/InformationScripting/src/query_prompt/QueryBuilder.cpp
+++ b/InformationScripting/src/query_prompt/QueryBuilder.cpp
@@ -53,12 +53,14 @@ void QueryBuilder::init()
 
 std::unique_ptr<Query> QueryBuilder::visitCommand(QueryBuilder* self, CommandNode* command)
 {
-	auto text = command->name();
-	if (text.isEmpty())
+	auto cmd = command->name();
+	if (cmd.isEmpty())
 		return std::unique_ptr<Query>(new PassthroughQuery());
-	auto parts = text.split(" ", QString::SplitBehavior::SkipEmptyParts);
-	auto cmd = parts.takeFirst();
-	if (auto q = QueryRegistry::instance().buildQuery(cmd, self->target_, parts, self->executor_))
+	QStringList args;
+	for (auto arg : *command->arguments())
+		if (auto argNode = DCast<CommandArgument>(arg))
+			args << argNode->argument();
+	if (auto q = QueryRegistry::instance().buildQuery(cmd, self->target_, args, self->executor_))
 		return q;
 	throw QueryParsingException(QString("%1 is not a valid command").arg(cmd));
 }

--- a/InformationScripting/src/query_prompt/QueryBuilder.h
+++ b/InformationScripting/src/query_prompt/QueryBuilder.h
@@ -43,7 +43,7 @@ class OperatorQueryNode;
 class Query;
 class QueryExecutor;
 
-class INFORMATIONSCRIPTING_API QueryBuilder : public Model::Visitor<QueryBuilder, Query*>
+class INFORMATIONSCRIPTING_API QueryBuilder : public Model::Visitor<QueryBuilder, std::unique_ptr<Query>>
 {
 	public:
 		QueryBuilder(Model::Node* target, QueryExecutor* executor);
@@ -53,9 +53,9 @@ class INFORMATIONSCRIPTING_API QueryBuilder : public Model::Visitor<QueryBuilder
 		QueryExecutor* executor_{};
 		Model::Node* target_{};
 
-		static Query* visitCommand(QueryBuilder* self, CommandNode* command);
-		static Query* visitList(QueryBuilder* self, CompositeQueryNode* list);
-		static Query* visitOperator(QueryBuilder* self, OperatorQueryNode* op);
+		static std::unique_ptr<Query> visitCommand(QueryBuilder* self, CommandNode* command);
+		static std::unique_ptr<Query> visitList(QueryBuilder* self, CompositeQueryNode* list);
+		static std::unique_ptr<Query> visitOperator(QueryBuilder* self, OperatorQueryNode* op);
 
 		static void connectQueriesWith(CompositeQuery* composite, CompositeQuery* queries,
 										Query* connectionQuery, Query* outputQuery = nullptr);

--- a/InformationScripting/src/query_prompt/QueryPromptMode.cpp
+++ b/InformationScripting/src/query_prompt/QueryPromptMode.cpp
@@ -30,6 +30,7 @@
 #include "../nodes/QueryNodeContainer.h"
 #include "../queries/QueryExecutor.h"
 #include "../queries/Query.h"
+#include "../parsing/QueryParsingException.h"
 
 #include "VisualizationBase/src/items/Static.h"
 
@@ -66,8 +67,16 @@ void QueryPromptMode::onEnterKeyPress(Qt::KeyboardModifiers)
 		// Note a QueryExecutor should always be allocated with new, it is self destroying:
 		auto executor = new QueryExecutor();
 		QueryBuilder builder{node, executor};
-		executor->addQuery(builder.visit(queryNode));
-		errors = executor->execute();
+		try
+		{
+			executor->addQuery(builder.visit(queryNode));
+			errors = executor->execute();
+		}
+		catch (const QueryParsingException& parsingException)
+		{
+			errors = {parsingException.message()};
+			SAFE_DELETE(executor);
+		}
 	}
 	else
 		errors = {"Queries only work on nodes"};

--- a/InformationScripting/src/query_prompt/QueryPromptMode.cpp
+++ b/InformationScripting/src/query_prompt/QueryPromptMode.cpp
@@ -64,7 +64,10 @@ void QueryPromptMode::onEnterKeyPress(Qt::KeyboardModifiers)
 	if (node)
 	{
 		auto queryNode = inputItem_->query()->query();
-		// Note a QueryExecutor should always be allocated with new, it is self destroying:
+		// Note a QueryExecutor should always be allocated with new, it is self destroying.
+		// The QueryBuilder below might however throw an exception when building the queries, if that is the case
+		// The executor will not execute and thus will never delete itself, thus we have to manually destroy it
+		// in the catch code.
 		auto executor = new QueryExecutor();
 		QueryBuilder builder{node, executor};
 		try

--- a/InformationScripting/src/visualization/VOperatorQueryNode.cpp
+++ b/InformationScripting/src/visualization/VOperatorQueryNode.cpp
@@ -45,7 +45,6 @@ void VOperatorQueryNode::initializeForms()
 			{
 				case OperatorQueryNode::OperatorTypes::Pipe : return &v->style()->pipeOp();
 				case OperatorQueryNode::OperatorTypes::Substract : return &v->style()->substractOp();
-				case OperatorQueryNode::OperatorTypes::Union : return &v->style()->unionOp();
 				default: return &v->style()->pipeOp();
 			}
 	});

--- a/InformationScripting/src/visualization/VOperatorQueryNodeStyle.h
+++ b/InformationScripting/src/visualization/VOperatorQueryNodeStyle.h
@@ -41,7 +41,6 @@ class INFORMATIONSCRIPTING_API VOperatorQueryNodeStyle : public Super<Visualizat
 
 	Property<Visualization::SymbolStyle> pipeOp{this, "pipeOp"};
 	Property<Visualization::SymbolStyle> substractOp{this, "substractOp"};
-	Property<Visualization::SymbolStyle> unionOp{this, "unionOp"};
 };
 
 } /* namespace InformationScripting */

--- a/InformationScripting/styles/item/VCommandNode/default
+++ b/InformationScripting/styles/item/VCommandNode/default
@@ -4,9 +4,9 @@
 	<arguments prototypes="../VList/default">
 		<itemsStyle prototypes="layout/SequentialLayout/default">
 			<direction>0</direction>
-			<spaceBetweenElements>15</spaceBetweenElements>
+			<spaceBetweenElements>10</spaceBetweenElements>
 			<noInnerCursors>true</noInnerCursors>
-			<minHeight>15</minHeight>
+			<minHeight>10</minHeight>
 			<drawShapeWhenEmpty>true</drawShapeWhenEmpty>
 			<extraCursorsOutsideShape>true</extraCursorsOutsideShape>
 		</itemsStyle>

--- a/InformationScripting/styles/item/VOperatorQueryNode/default
+++ b/InformationScripting/styles/item/VOperatorQueryNode/default
@@ -4,7 +4,7 @@
 		<symbol>|</symbol>
 	</pipeOp>
 	<substractOp prototypes="../Symbol/default">
-		<symbol>-</symbol>
+		<symbol>|-</symbol>
 	</substractOp>
 	<unionOp prototypes="../Symbol/default">
 		<symbol>U</symbol>

--- a/InformationScripting/styles/item/VOperatorQueryNode/default
+++ b/InformationScripting/styles/item/VOperatorQueryNode/default
@@ -6,7 +6,4 @@
 	<substractOp prototypes="../Symbol/default">
 		<symbol>|-</symbol>
 	</substractOp>
-	<unionOp prototypes="../Symbol/default">
-		<symbol>U</symbol>
-	</unionOp>
 </style>


### PR DESCRIPTION
Before we clean up the structure.

What we still need to bring back is yield, but I guess we can also do that later.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43725033%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43725404%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43725448%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726015%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726154%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726331%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726588%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726604%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726682%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726713%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726911%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43727103%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43727200%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43727391%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43727621%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43727810%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43728882%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43729617%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43729778%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23issuecomment-153306804%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23issuecomment-153309134%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23issuecomment-153306804%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Added%20some%20commits%20to%20address%20your%20comments.%20I%20guess%20the%20prompt%20styling%20we%20can%20still%20do%20later%3F%22%2C%20%22created_at%22%3A%20%222015-11-03T10%3A16%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%20Please%20do%20not%20forget%20to%20adjust%20the%20styles.%20It%20will%20look%20nice%20and%20should%20be%20super%20quick%20to%20do.%22%2C%20%22created_at%22%3A%20%222015-11-03T10%3A25%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2046fe4ce3f438130c3fa10f548031d78980ebe59b%20InformationScripting/src/queries/QueryExecutor.cpp%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43725448%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20%60%26%26%60%22%2C%20%22created_at%22%3A%20%222015-11-03T08%3A48%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/QueryExecutor.cpp%3AL40-56%22%7D%2C%20%22Pull%2046fe4ce3f438130c3fa10f548031d78980ebe59b%20InformationScripting/src/query_prompt/QueryBuilder.cpp%2080%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726588%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Now%20that%20we%27ve%20decided%20to%20use%20%7C%20for%20pipes%2C%20unions%20and%20splits%2C%20we%20should%20probably%20rename%20this%20operator%20to%20%60PipeOperator%60.%20What%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A05%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20agree%2C%20it%20is%20more%20descriptive%20the%20way%20it%20is%2C%20even%20though%20the%20representation%20is%20a%20%7C%20the%20operator%20performs%20a%20union.%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A07%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20it%20also%20performs%20a%20split.%20We%20should%20either%20make%20the%20name%20more%20precise/complete%20or%20at%20least%20make%20it%20consistent%20with%20the%20rest%20of%20the%20names%2C%20which%20use%20%60pipe%60.%20Maybe%20we%20can%20come%20up%20with%20an%20even%20better%20name%20that%20achieves%20both%20purposes%2C%20something%20like%20%60MagicPipeOperator%60%2C%20but%20less%20%5C%22magical%5C%22%20%3AD%20Any%20ideas%2C%20or%20do%20you%20insist%20on%20the%20current%20name%3F%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A21%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20the%20pipe%20operator%20also%20performs%20a%20split%2C%20but%20this%20UnionOperator%20is%20only%20for%20unions.%20A%20split%20and%20a%20normal%20pipe%20are%20only%20implicit%2C%20since%20they%20just%20describe%20a%20wiring%20in%20the%20composite%20operator%2C%20but%20for%20the%20union%20we%20need%20to%20take%20some%20special%20action.%5Cr%5Cn%5Cr%5CnEven%20if%20the%20user%20only%20thinks%20about%20a%20Pipe%20I%20think%20at%20this%20level%20it%20makes%20to%20talk%20about%20a%20union%2C%20since%20that%20is%20the%20only%20thing%20that%20this%20operator%20does.%5Cr%5Cn%5Cr%5CnBut%20if%20you%20really%20want%20to%20name%20it%20differently%20we%20can%20do%20so%2C%20but%20I%20guess%20in%20some%20way%20it%20still%20will%20need%20union%20in%20the%20name%2C%20otherwise%20someone%20in%20the%20future%20might%20think%3A%20%5C%22Oh%20cool%20a%20pipe%20operator%2C%20let%27s%20use%20it%20for%20a%20split%5C%22%20and%20it%20won%27t%20work%20as%20expected.%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A36%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20I%20totally%20misunderstood%20the%20purpose%20of%20this%20operator.%20Sorry%20for%20the%20confusion%2C%20just%20keep%20the%20current%20name%2C%20it%20is%20indeed%20as%20precise%20as%20it%20gets%20and%20is%20the%20right%20thing%20at%20this%20level.%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A48%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/query_prompt/QueryBuilder.cpp%3AL95-109%22%7D%2C%20%22Pull%2046fe4ce3f438130c3fa10f548031d78980ebe59b%20InformationScripting/styles/item/VOperatorQueryNode/default%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726682%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20should%20remove%20the%20style%20loading%20code%20and%20the%20text%20belonging%20to%20the%20union%20operator%20below.%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A06%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/styles/item/VOperatorQueryNode/default%3AL4-11%22%7D%2C%20%22Pull%2046fe4ce3f438130c3fa10f548031d78980ebe59b%20InformationScripting/src/queries/CompositeQuery.cpp%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43725033%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20instead%20of%20using%20%60move%60%20here%2C%20it%27s%20more%20correct%20to%20change%20the%20parameter%20type%20of%20the%20method%20to%20%60%26%26%60.%20Then%20you%20might%20need%20to%20use%20%60move%60%20in%20the%20client%20code%2C%20but%20that%27s%20the%20legitimate%20place%20to%20do%20this.%22%2C%20%22created_at%22%3A%20%222015-11-03T08%3A41%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20I%20used%20this%20answer%20http%3A//stackoverflow.com/a/8114913%20as%20a%20guideline.%20It%20advises%20to%20use%20value%20semantics%20whenever%20we%20take%20ownership.%20On%20the%20other%20hand%20to%20this%20answer%20there%20is%20a%20comment%20which%20suggests%20to%20use%20%26%26.%20Should%20I%20still%20use%20%26%26%3F%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A05%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20I%20read%20that%20in%20detail%20and%20thought%20about%20it%2C%20and%20I%20still%20think%20%60%26%26%60%20is%20the%20right%20way%3A%5Cr%5Cn-%20There%20are%20a%20few%20subtle%20differences%20that%20you%20can%20read%20in%20the%20comments%20that%20point%20in%20%60%26%26%60%27s%20favor.%20One%20of%20them%20is%20the%20performance%20penalty%20you%20pay%20for%20an%20extra%20temporary%20creation%20which%20you%20don%27t%20need.%5Cr%5Cn-%20The%20author%27s%20only%20argument%20for%20using%20values%20is%20that%20ownership%20transfer%20is%20guaranteed.%20But%20why%20is%20that%20important%3F%20In%20general%2C%20every%20time%20you%20see%20a%20%60std%3A%3Amove%60%20you%20must%20assume%20that%20whatever%20you%27re%20moving%20is%20now%20gone.%20Whether%20that%27s%20actually%20so%20or%20not%2C%20is%20irrelevant%20and%20you%20certainly%20shouldn%27t%20go%20ahead%20and%20determine%20whether%20the%20value%20you%27re%20left%20with%20is%20still%20the%20old%20one.%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A46%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/CompositeQuery.cpp%3AL110-127%22%7D%2C%20%22Pull%2046fe4ce3f438130c3fa10f548031d78980ebe59b%20InformationScripting/src/handlers/HQuery.cpp%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726331%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22To%20make%20this%20true%2C%20we%20should%20probably%20remove%20the%20%60OperatorQueryNode%3A%3AOperatorTypes%3A%3AUnion%2C%20%5C%22U%5C%22%60%20above.%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A01%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/handlers/HQuery.cpp%3AL233-245%22%7D%2C%20%22Pull%2046fe4ce3f438130c3fa10f548031d78980ebe59b%20InformationScripting/src/queries/CompositeQuery.h%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43725404%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Better%20just%20get%20the%20argument%20as%20%60%26%26%60%20and%20not%20use%20move.%20This%20expresses%20the%20intent%20more%20clearly.%20You%20might%20need%20in%20this%20case%20to%20use%20%60std%3A%3Aforward%60%20in%20the%20client%20code%3A%20http%3A//en.cppreference.com/w/cpp/utility/forward%22%2C%20%22created_at%22%3A%20%222015-11-03T08%3A47%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/CompositeQuery.h%3AL73-80%22%7D%2C%20%22Pull%2046fe4ce3f438130c3fa10f548031d78980ebe59b%20InformationScripting/src/parsing/SimpleQueryParser.cpp%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43727103%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Does%20this%20work%20well%2C%20particularly%20when%20you%20type%20spaces%20and%20stuff%3F%20have%20you%20checked%20it%20with%20a%20few%20different%20cases%3F%5Cr%5Cn%5Cr%5CnNow%20that%20we%20have%20this%20feature%20it%20would%20be%20nice%20if%20we%20highlight%20commands%20and%20arguments%20in%20different%20ways.%20Commands%20should%20look%20more%20like%20keywords.%20Don%27t%20use%20the%20predefined%20styles%20however%20as%20those%20assume%20a%20light%20prompt.%20We%27ll%20need%20lighter%20font%20colors%20to%20better%20work%20with%20the%20new%20dark%20prompt.%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A13%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/parsing/SimpleQueryParser.cpp%3AL71-104%22%7D%2C%20%22Pull%2046fe4ce3f438130c3fa10f548031d78980ebe59b%20Core/src/EnvisionException.cpp%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726015%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20parameter%20is%20not%20named%20properly.%20If%20it%20is%20set%20to%20true%2C%20the%20name%20suggests%20that%20the%20exception%20will%20be%20thrown%2C%20but%20what%20we%20get%20is%20the%20old%20behavior%20where%20there%20is%20an%20assertion%20violation.%5Cr%5Cn%5Cr%5CnCall%20this%20%60doNotAssertInDebugMode%60%20and%20make%20it%20false%20by%20default.%22%2C%20%22created_at%22%3A%20%222015-11-03T08%3A57%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Why%20not%20just%20%60%60%60assertInDebugMode%60%60%60%20and%20make%20it%20true%20by%20default%3F%20That%20was%20my%20intention%20I%20just%20named%20it%20wrongly.%3F%20%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A16%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Also%20fine.%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A19%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Core/src/EnvisionException.cpp%3AL39-51%22%7D%2C%20%22Pull%2046fe4ce3f438130c3fa10f548031d78980ebe59b%20InformationScripting/src/query_prompt/QueryPromptMode.cpp%2060%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/201%23discussion_r43726154%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20line%20contradicts%20the%20comment%20in%20line%2067%20above.%22%2C%20%22created_at%22%3A%20%222015-11-03T08%3A59%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20true%2C%20but%20since%20the%20exception%20would%20be%20thrown%20in%20the%20first%20statement%20%60%60%60builder.visit%28..%29%60%60%60%20the%20execute%2C%20which%20would%20destroy%20the%20executor%20is%20never%20executed%2C%20so%20we%20have%20to%20destroy%20it%20here.%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A10%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%27s%20a%20bit%20brittle%2C%20but%20oh%20well.%20At%20least%20document%20this%20in%20the%20comment%20above.%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A14%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/query_prompt/QueryPromptMode.cpp%3AL67-89%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 46fe4ce3f438130c3fa10f548031d78980ebe59b InformationScripting/src/queries/CompositeQuery.cpp 10'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/201#discussion_r43725033'>File: InformationScripting/src/queries/CompositeQuery.cpp:L110-127</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, instead of using `move` here, it's more correct to change the parameter type of the method to `&&`. Then you might need to use `move` in the client code, but that's the legitimate place to do this.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Hm I used this answer http://stackoverflow.com/a/8114913 as a guideline. It advises to use value semantics whenever we take ownership. On the other hand to this answer there is a comment which suggests to use &&. Should I still use &&?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> So I read that in detail and thought about it, and I still think `&&` is the right way:
- There are a few subtle differences that you can read in the comments that point in `&&`'s favor. One of them is the performance penalty you pay for an extra temporary creation which you don't need.
- The author's only argument for using values is that ownership transfer is guaranteed. But why is that important? In general, every time you see a `std::move` you must assume that whatever you're moving is now gone. Whether that's actually so or not, is irrelevant and you certainly shouldn't go ahead and determine whether the value you're left with is still the old one.
- [x] <a href='#crh-comment-Pull 46fe4ce3f438130c3fa10f548031d78980ebe59b InformationScripting/src/queries/CompositeQuery.h 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/201#discussion_r43725404'>File: InformationScripting/src/queries/CompositeQuery.h:L73-80</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Better just get the argument as `&&` and not use move. This expresses the intent more clearly. You might need in this case to use `std::forward` in the client code: http://en.cppreference.com/w/cpp/utility/forward
- [x] <a href='#crh-comment-Pull 46fe4ce3f438130c3fa10f548031d78980ebe59b InformationScripting/src/queries/QueryExecutor.cpp 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/201#discussion_r43725448'>File: InformationScripting/src/queries/QueryExecutor.cpp:L40-56</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Use `&&`
- [x] <a href='#crh-comment-Pull 46fe4ce3f438130c3fa10f548031d78980ebe59b Core/src/EnvisionException.cpp 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/201#discussion_r43726015'>File: Core/src/EnvisionException.cpp:L39-51</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This parameter is not named properly. If it is set to true, the name suggests that the exception will be thrown, but what we get is the old behavior where there is an assertion violation.
  Call this `doNotAssertInDebugMode` and make it false by default.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Why not just `assertInDebugMode` and make it true by default? That was my intention I just named it wrongly.?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Also fine.
- [x] <a href='#crh-comment-Pull 46fe4ce3f438130c3fa10f548031d78980ebe59b InformationScripting/src/query_prompt/QueryPromptMode.cpp 60'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/201#discussion_r43726154'>File: InformationScripting/src/query_prompt/QueryPromptMode.cpp:L67-89</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This line contradicts the comment in line 67 above.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Hm true, but since the exception would be thrown in the first statement `builder.visit(..)` the execute, which would destroy the executor is never executed, so we have to destroy it here.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> That's a bit brittle, but oh well. At least document this in the comment above.
- [x] <a href='#crh-comment-Pull 46fe4ce3f438130c3fa10f548031d78980ebe59b InformationScripting/src/handlers/HQuery.cpp 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/201#discussion_r43726331'>File: InformationScripting/src/handlers/HQuery.cpp:L233-245</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> To make this true, we should probably remove the `OperatorQueryNode::OperatorTypes::Union, "U"` above.
- [x] <a href='#crh-comment-Pull 46fe4ce3f438130c3fa10f548031d78980ebe59b InformationScripting/src/query_prompt/QueryBuilder.cpp 80'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/201#discussion_r43726588'>File: InformationScripting/src/query_prompt/QueryBuilder.cpp:L95-109</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Now that we've decided to use | for pipes, unions and splits, we should probably rename this operator to `PipeOperator`. What do you think?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> I don't agree, it is more descriptive the way it is, even though the representation is a | the operator performs a union.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Well, it also performs a split. We should either make the name more precise/complete or at least make it consistent with the rest of the names, which use `pipe`. Maybe we can come up with an even better name that achieves both purposes, something like `MagicPipeOperator`, but less "magical" :D Any ideas, or do you insist on the current name?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Yes the pipe operator also performs a split, but this UnionOperator is only for unions. A split and a normal pipe are only implicit, since they just describe a wiring in the composite operator, but for the union we need to take some special action.
  Even if the user only thinks about a Pipe I think at this level it makes to talk about a union, since that is the only thing that this operator does.
  But if you really want to name it differently we can do so, but I guess in some way it still will need union in the name, otherwise someone in the future might think: "Oh cool a pipe operator, let's use it for a split" and it won't work as expected.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Oh, I totally misunderstood the purpose of this operator. Sorry for the confusion, just keep the current name, it is indeed as precise as it gets and is the right thing at this level.
- [x] <a href='#crh-comment-Pull 46fe4ce3f438130c3fa10f548031d78980ebe59b InformationScripting/styles/item/VOperatorQueryNode/default 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/201#discussion_r43726682'>File: InformationScripting/styles/item/VOperatorQueryNode/default:L4-11</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You should remove the style loading code and the text belonging to the union operator below.
- [x] <a href='#crh-comment-Pull 46fe4ce3f438130c3fa10f548031d78980ebe59b InformationScripting/src/parsing/SimpleQueryParser.cpp 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/201#discussion_r43727103'>File: InformationScripting/src/parsing/SimpleQueryParser.cpp:L71-104</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Does this work well, particularly when you type spaces and stuff? have you checked it with a few different cases?
  Now that we have this feature it would be nice if we highlight commands and arguments in different ways. Commands should look more like keywords. Don't use the predefined styles however as those assume a light prompt. We'll need lighter font colors to better work with the new dark prompt.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/201#issuecomment-153306804'>General Comment</a></b>
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Added some commits to address your comments. I guess the prompt styling we can still do later?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks. Please do not forget to adjust the styles. It will look nice and should be super quick to do.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/201?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/201?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/201'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
