### PR TITLE
Query improvements

### DIFF
--- a/FilePersistence/src/version_control/History.cpp
+++ b/FilePersistence/src/version_control/History.cpp
@@ -161,6 +161,8 @@ QString History::findRootPath(QString revision, QString currentPath, const Diff*
 		SAFE_DELETE(file);
 	}
 
+	tree->buildLookupHash();
+
 	GenericNode* rootNode = tree->find(rootNodeId_);
 	if (rootNode)
 		return currentPath;

--- a/InformationScripting/InformationScripting.pro
+++ b/InformationScripting/InformationScripting.pro
@@ -71,7 +71,8 @@ HEADERS += src/precompiled.h \
     src/queries/Heatmap.h \
     src/query_prompt/parsing/QueryParser.h \
     src/query_framework/QueryParsingException.h \
-    src/queries/Count.h
+    src/queries/Count.h \
+    src/queries/Join.h
 SOURCES += src/InformationScriptingException.cpp \
     src/InformationScriptingPlugin.cpp \
     test/SimpleTest.cpp \
@@ -126,7 +127,8 @@ SOURCES += src/InformationScriptingException.cpp \
     src/query_framework/HighlightOverlay.cpp \
     src/query_prompt/parsing/QueryParser.cpp \
     src/query_framework/QueryParsingException.cpp \
-    src/queries/Count.cpp
+    src/queries/Count.cpp \
+    src/queries/Join.cpp
 
 # The workaround below is currently not needed but might be in the future, thus we leave it as reference.
 # Workaround to not have any pragma's in NodeApi.cpp

--- a/InformationScripting/src/InformationScriptingPlugin.cpp
+++ b/InformationScripting/src/InformationScriptingPlugin.cpp
@@ -38,6 +38,7 @@
 #include "queries/RuntimeQuery.h"
 #include "queries/Heatmap.h"
 #include "queries/Count.h"
+#include "queries/Join.h"
 #include "query_prompt/HQuery.h"
 #include "query_prompt/visualization/VCommandNode.h"
 #include "query_prompt/visualization/VCommandArgument.h"
@@ -70,6 +71,7 @@ bool InformationScriptingPlugin::initialize(Core::EnvisionManager&)
 	BreakpointManager::registerDefaultQueries();
 	RuntimeQuery::registerDefaultQueries();
 	Count::registerDefaultQueries();
+	Join::registerDefaultQueries();
 	TagExtension::registerExtension();
 	Model::CompositeNode::registerNewExtension<TagExtension>();
 	VCommandNode::setDefaultClassHandler(HQuery::instance());

--- a/InformationScripting/src/dataformat/Tuple.cpp
+++ b/InformationScripting/src/dataformat/Tuple.cpp
@@ -28,19 +28,26 @@
 
 namespace InformationScripting {
 
-Tuple::Tuple(std::initializer_list<NamedProperty> initialValues, QString tag)
+Tuple::Tuple(const QString& tag, std::initializer_list<NamedProperty> initialValues)
 	: values_{initialValues}, tag_{tag}
 {}
 
-Tuple::Tuple(QList<NamedProperty> initialValues, QString tag)
+Tuple::Tuple(const QString& tag, QList<NamedProperty> initialValues)
 	: values_{initialValues}, tag_{tag}
 {}
 
-QString Tuple::tag() const
+Tuple::Tuple(std::initializer_list<NamedProperty> initialValues)
+	: values_{initialValues}
 {
-	if (!tag_.isNull()) return tag_;
-	if (values_.size()) return values_[0].first;
-	return {};
+	Q_ASSERT(values_.size() > 0);
+	tag_ = values_[0].first;
+}
+
+Tuple::Tuple(QList<NamedProperty> initialValues)
+	: values_{initialValues}
+{
+	Q_ASSERT(!initialValues.isEmpty());
+	tag_ = initialValues[0].first;
 }
 
 void Tuple::add(const NamedProperty& p)

--- a/InformationScripting/src/dataformat/Tuple.cpp
+++ b/InformationScripting/src/dataformat/Tuple.cpp
@@ -28,16 +28,17 @@
 
 namespace InformationScripting {
 
-Tuple::Tuple(std::initializer_list<NamedProperty> initialValues)
-	: values_{initialValues}
+Tuple::Tuple(std::initializer_list<NamedProperty> initialValues, QString tag)
+	: values_{initialValues}, tag_{tag}
 {}
 
-Tuple::Tuple(QList<NamedProperty> initialValues)
-	: values_{initialValues}
+Tuple::Tuple(QList<NamedProperty> initialValues, QString tag)
+	: values_{initialValues}, tag_{tag}
 {}
 
 QString Tuple::tag() const
 {
+	if (!tag_.isNull()) return tag_;
 	if (values_.size()) return values_[0].first;
 	return {};
 }

--- a/InformationScripting/src/dataformat/Tuple.h
+++ b/InformationScripting/src/dataformat/Tuple.h
@@ -36,8 +36,10 @@ class INFORMATIONSCRIPTING_API Tuple
 {
 	public:
 		Tuple() = default;
-		Tuple(std::initializer_list<NamedProperty> initialValues, QString tag = {});
-		Tuple(QList<NamedProperty> initialValues, QString tag = {});
+		Tuple(const QString& tag, std::initializer_list<NamedProperty> initialValues);
+		Tuple(const QString& tag, QList<NamedProperty> initialValues);
+		Tuple(std::initializer_list<NamedProperty> initialValues);
+		Tuple(QList<NamedProperty> initialValues);
 
 		QString tag() const;
 
@@ -79,6 +81,7 @@ class INFORMATIONSCRIPTING_API Tuple
 
 uint qHash(const Tuple& t, uint seed = 0);
 
+inline QString Tuple::tag() const { return tag_; }
 inline int Tuple::size() const { return values_.size(); }
 inline bool Tuple::contains(const QString& name) const { return find(name) != end(); }
 inline bool Tuple::operator==(const Tuple& other) const { return values_ == other.values_; }

--- a/InformationScripting/src/dataformat/Tuple.h
+++ b/InformationScripting/src/dataformat/Tuple.h
@@ -36,8 +36,8 @@ class INFORMATIONSCRIPTING_API Tuple
 {
 	public:
 		Tuple() = default;
-		Tuple(std::initializer_list<NamedProperty> initialValues);
-		Tuple(QList<NamedProperty> initialValues);
+		Tuple(std::initializer_list<NamedProperty> initialValues, QString tag = {});
+		Tuple(QList<NamedProperty> initialValues, QString tag = {});
 
 		QString tag() const;
 
@@ -73,6 +73,7 @@ class INFORMATIONSCRIPTING_API Tuple
 		const_iterator cend() const;
 	private:
 		QList<NamedProperty> values_;
+		QString tag_;
 
 };
 

--- a/InformationScripting/src/python_bindings/DataApi.cpp
+++ b/InformationScripting/src/python_bindings/DataApi.cpp
@@ -44,6 +44,10 @@ object Tuple_getAttr(const Tuple& self, const QString& name) {
 	return pythonObject(self[name]);
 }
 
+uint Tuple_hash(const Tuple& self) {
+	return self.hashValue();
+}
+
 NamedProperty tuple_getItem(Tuple &t, int index)
 {
 	 if (index >= 0 && index < t.size())
@@ -89,7 +93,7 @@ BOOST_PYTHON_MODULE(DataApi) {
 				.def("__getattr__", &Tuple_getAttr)
 				.def("size", &Tuple::size)
 				.def("__getitem__", &tuple_getItem)
-				.def("__hash__", &Tuple::hashValue);
+				.def("__hash__", &Tuple_hash);
 
 		QSet<Tuple> (TupleSet::*tuplesAll)() const = &TupleSet::tuples;
 		QSet<Tuple> (TupleSet::*tuplesString)(const QString&) const = &TupleSet::tuples;

--- a/InformationScripting/src/queries/Join.cpp
+++ b/InformationScripting/src/queries/Join.cpp
@@ -1,0 +1,155 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "Join.h"
+
+#include "../query_framework/QueryRegistry.h"
+
+namespace InformationScripting {
+
+const QStringList Join::VALUE_ARGUMENT_NAMES{"v", "values"};
+const QStringList Join::AS_ARGUMENT_NAMES{"a", "as"};
+const QStringList Join::ON_ARGUMENT_NAMES{"o", "on"};
+
+Optional<TupleSet> Join::executeLinear(TupleSet input)
+{
+	// First check which values we want to join on
+
+	const QRegularExpression onRegex{"(\\w+)\\.(\\w+)=(\\w+)\\.(\\w+)"};
+	auto onMatches = onRegex.match(arguments_.argument(ON_ARGUMENT_NAMES[1]));
+	if (!onMatches.hasMatch())
+		return {"Join requires the on argument in form tag.value=tag2.value"};
+
+	std::pair<std::pair<QString, QString>, std::pair<QString, QString>> joinOn{
+		{onMatches.captured(1), onMatches.captured(2)}, {onMatches.captured(3), onMatches.captured(4)}};
+
+	QList<std::pair<QString, QString>> values;
+	QString tag1;
+	QString tag2;
+	for (const auto& value : arguments_.argument(VALUE_ARGUMENT_NAMES[1]).split(",", QString::SkipEmptyParts))
+	{
+		auto parts = value.split(".", QString::SkipEmptyParts);
+		if (parts.size() <= 1)
+			return {"join values need to be fully specified with a dot"};
+		if (parts.size() > 2)
+			return {"join values can only have a single . (dot)"};
+		values.push_back({parts[0], parts[1]});
+
+		if (tag1.isNull() || tag1 == parts[0]) tag1 = parts[0];
+		else if (tag1 != parts[0] && tag2.isNull()) tag2 = parts[0];
+		else if (tag2 != parts[0]) return {"join values can only be from 2 different tuples"};
+	}
+	if (tag1.isNull() || tag2.isNull())
+		return {"join only works on 2 different tuples"};
+
+	auto tag1Tuples = input.tuples(tag1);
+	auto tag2Tuples = input.tuples(tag2);
+	if (tag1Tuples.isEmpty() || tag2Tuples.isEmpty())
+		return {input, "Not enough input for join"};
+
+	if (tag1 != joinOn.first.first)
+		std::swap(joinOn.first, joinOn.second);
+
+	if (tag1 != joinOn.first.first || tag2 != joinOn.second.first)
+		return {"join: Tags in values have to match with the tags in the on argument"};
+
+	auto id1Name = joinOn.first.second;
+	auto id2Name = joinOn.second.second;
+
+	for (const auto& tuple1 : tag1Tuples)
+	{
+		// the id always has to be a string, or some other statically defined value. :(
+		// We should reimplement this in python, there we won't have this limitation
+		auto it = tuple1.find(id1Name);
+		if (it == tuple1.end())
+			return {QString("Tuple %1 does not contain %2 which is required for join").arg(tag1, id1Name)};
+		QString id1 = it->second;
+
+		bool attributeNotFound = false;
+		auto it2 = std::find_if(tag2Tuples.begin(), tag2Tuples.end(), [id1, &attributeNotFound, id2Name](const Tuple& t)
+		{
+			auto idIt = t.find(id2Name);
+			if (idIt == t.end()) attributeNotFound = true;
+			else
+			{
+				QString id = idIt->second;
+				return id == id1;
+			}
+			return false;
+		});
+
+		if (attributeNotFound)
+			return {QString("Tuple %1 does not contain %2 which is required for join").arg(tag2, id2Name)};
+
+
+		if (it2 != tag2Tuples.end())
+		{
+			// Found a match
+			auto props1 = extractProperties(tuple1, values);
+			if (props1.hasErrors()) return props1.errors()[0];
+			auto props2 = extractProperties(*it2, values);
+			if (props2.hasErrors()) return props2.errors()[0];
+			input.add(Tuple(props1.value() + props2.value(), arguments_.argument(AS_ARGUMENT_NAMES[1])));
+		}
+
+	}
+	return input;
+}
+
+void Join::registerDefaultQueries()
+{
+	QueryRegistry::registerQuery<Join>("join",
+		std::vector<ArgumentRule>{{ArgumentRule::RequireAll,
+											{{VALUE_ARGUMENT_NAMES[1]}, {AS_ARGUMENT_NAMES[1]}, {ON_ARGUMENT_NAMES[1]}}}});
+}
+
+Join::Join(Model::Node* target, QStringList args, std::vector<ArgumentRule> argumentRules)
+	: LinearQuery{target}, arguments_{{
+	{VALUE_ARGUMENT_NAMES, "Name of the attribute(s) that be in the joined tuple",  VALUE_ARGUMENT_NAMES[1]},
+	{AS_ARGUMENT_NAMES, "Name of the joined tuple",  AS_ARGUMENT_NAMES[1]},
+	{ON_ARGUMENT_NAMES, "Name of the attributes to join on",  ON_ARGUMENT_NAMES[1]}
+	}, args}
+{
+	for (const auto& rule : argumentRules)
+		rule.check(arguments_);
+}
+
+Optional<QList<NamedProperty>> Join::extractProperties(const Tuple& t, const QList<std::pair<QString, QString>>& values)
+{
+	QList<NamedProperty> result;
+	for (const auto& v : values)
+	{
+		if (v.first == t.tag())
+		{
+			auto it = t.find(v.second);
+			if (it == t.end()) return QString("Tuple %1 does not have any value %2").arg(t.tag(), v.second);
+			else result.push_back(*it);
+		}
+	}
+	return result;
+}
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/Join.cpp
+++ b/InformationScripting/src/queries/Join.cpp
@@ -109,7 +109,7 @@ Optional<TupleSet> Join::executeLinear(TupleSet input)
 			if (props1.hasErrors()) return props1.errors()[0];
 			auto props2 = extractProperties(*it2, values);
 			if (props2.hasErrors()) return props2.errors()[0];
-			input.add(Tuple(props1.value() + props2.value(), arguments_.argument(AS_ARGUMENT_NAMES[1])));
+			input.add(Tuple(arguments_.argument(AS_ARGUMENT_NAMES[1]), props1.value() + props2.value()));
 		}
 
 	}

--- a/InformationScripting/src/queries/Join.cpp
+++ b/InformationScripting/src/queries/Join.cpp
@@ -81,24 +81,21 @@ Optional<TupleSet> Join::executeLinear(TupleSet input)
 
 	for (const auto& tuple1 : tag1Tuples)
 	{
-		// the id always has to be a string, or some other statically defined value. :(
-		// We should reimplement this in python, there we won't have this limitation
 		auto it = tuple1.find(id1Name);
 		if (it == tuple1.end())
 			return {QString("Tuple %1 does not contain %2 which is required for join").arg(tag1, id1Name)};
-		QString id1 = it->second;
+		Property id1 = it->second;
 
 		bool attributeNotFound = false;
 		auto it2 = std::find_if(tag2Tuples.begin(), tag2Tuples.end(), [id1, &attributeNotFound, id2Name](const Tuple& t)
 		{
 			auto idIt = t.find(id2Name);
-			if (idIt == t.end()) attributeNotFound = true;
-			else
+			if (idIt == t.end())
 			{
-				QString id = idIt->second;
-				return id == id1;
+				attributeNotFound = true;
+				return false;
 			}
-			return false;
+			return idIt->second == id1;
 		});
 
 		if (attributeNotFound)

--- a/InformationScripting/src/queries/Join.h
+++ b/InformationScripting/src/queries/Join.h
@@ -1,0 +1,58 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../informationscripting_api.h"
+
+#include "LinearQuery.h"
+#include "../query_framework/ArgumentParser.h"
+
+namespace InformationScripting {
+
+class INFORMATIONSCRIPTING_API Join : public LinearQuery
+{
+	public:
+		virtual Optional<TupleSet> executeLinear(TupleSet input) override;
+
+		static void registerDefaultQueries();
+
+	private:
+		friend class QueryRegistry;
+
+		static const QStringList VALUE_ARGUMENT_NAMES;
+		static const QStringList AS_ARGUMENT_NAMES;
+		static const QStringList ON_ARGUMENT_NAMES;
+
+		ArgumentParser arguments_;
+
+		Join(Model::Node* target, QStringList args, std::vector<ArgumentRule> argumentRules);
+
+		Optional<QList<NamedProperty>> extractProperties(const Tuple& t,
+																		 const QList<std::pair<QString, QString>>& values);
+};
+
+} /* namespace InformationScripting */

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -108,7 +108,7 @@ void VersionControlQuery::registerDefaultQueries()
 
 VersionControlQuery::VersionControlQuery(Model::Node* target, QStringList args)
 	: LinearQuery{target}, arguments_{{
-		{COUNT_ARGUMENT_NAMES, "The amount of revision to look at", COUNT_ARGUMENT_NAMES[1], "10"},
+		{COUNT_ARGUMENT_NAMES, "The amount of revisions to look at", COUNT_ARGUMENT_NAMES[1], "10"},
 		{NODE_TYPE_ARGUMENT_NAMES, "The minimum type of the nodes returned", NODE_TYPE_ARGUMENT_NAMES[1], "StatementItem"}
 }, args}
 {}

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -101,7 +101,7 @@ Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet)
 
 				if (arguments_.argument(SIGNIFICANT_COMMITS_ARGUMENT_NAMES[0]) == "all"
 					 || target()->isAncestorOf(changedNode))
-					result.add({{{"id", newCommitId}, {"ast", changedNode}}, "change"});
+					result.add({"change", {{"id", newCommitId}, {"ast", changedNode}}});
 			}
 		}
 	}
@@ -126,11 +126,11 @@ VersionControlQuery::VersionControlQuery(Model::Node* target, QStringList args)
 
 void VersionControlQuery::addCommitMetaInformation(TupleSet& ts, const CommitMetaData& metadata)
 {
-		ts.add({{{"id", metadata.sha1_},
+		ts.add({"commit", {{"id", metadata.sha1_},
 				  {"message", metadata.message_},
 				  {"date", metadata.dateTime_.toString("dd.MM.yyyy hh:mm")},
 				  {"commiter", metadata.committer_.name_ + " " + metadata.committer_.eMail_},
-				  {"author", metadata.author_.name_ + " " + metadata.author_.eMail_}}, "commit"});
+				  {"author", metadata.author_.name_ + " " + metadata.author_.eMail_}}});
 }
 
 QList<QString> VersionControlQuery::nodeHistory(const GitRepository* repository, const QString& startSha1,

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -101,7 +101,7 @@ Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet)
 
 				if (arguments_.argument(SIGNIFICANT_COMMITS_ARGUMENT_NAMES[0]) == "all"
 					 || target()->isAncestorOf(changedNode))
-					result.add({{"change", newCommitId}, {"ast", changedNode}});
+					result.add({{{"id", newCommitId}, {"ast", changedNode}}, "change"});
 			}
 		}
 	}
@@ -126,11 +126,11 @@ VersionControlQuery::VersionControlQuery(Model::Node* target, QStringList args)
 
 void VersionControlQuery::addCommitMetaInformation(TupleSet& ts, const CommitMetaData& metadata)
 {
-		ts.add({{"commit", metadata.sha1_},
+		ts.add({{{"id", metadata.sha1_},
 				  {"message", metadata.message_},
 				  {"date", metadata.dateTime_.toString("dd.MM.yyyy hh:mm")},
 				  {"commiter", metadata.committer_.name_ + " " + metadata.committer_.eMail_},
-				  {"author", metadata.author_.name_ + " " + metadata.author_.eMail_}});
+				  {"author", metadata.author_.name_ + " " + metadata.author_.eMail_}}, "commit"});
 }
 
 QList<QString> VersionControlQuery::nodeHistory(const GitRepository* repository, const QString& startSha1,

--- a/InformationScripting/src/queries/VersionControlQuery.h
+++ b/InformationScripting/src/queries/VersionControlQuery.h
@@ -33,6 +33,12 @@
 
 namespace FilePersistence {
 	struct CommitMetaData;
+	class GitRepository;
+}
+
+namespace Model {
+	class Node;
+	class TreeManager;
 }
 
 namespace InformationScripting {
@@ -50,10 +56,14 @@ class INFORMATIONSCRIPTING_API VersionControlQuery : public LinearQuery
 
 		static const QStringList COUNT_ARGUMENT_NAMES;
 		static const QStringList NODE_TYPE_ARGUMENT_NAMES;
+		static const QStringList SIGNIFICANT_COMMITS_ARGUMENT_NAMES;
 
 		VersionControlQuery(Model::Node* target, QStringList args);
 
 		static void addCommitMetaInformation(TupleSet& ts, const FilePersistence::CommitMetaData& metadata);
+
+		static QList<QString> nodeHistory(const FilePersistence::GitRepository* repository, const QString& startSha1,
+													 Model::Node* target, Model::TreeManager* headManager);
 };
 
 } /* namespace InformationScripting */

--- a/PythonWrapperGenerator/src/APIPrinter.cpp
+++ b/PythonWrapperGenerator/src/APIPrinter.cpp
@@ -100,7 +100,8 @@ void APIPrinter::printClass(const ClassData& cData)
 
 	QString noInit = "";
 	if (cData.abstract_) noInit = ", no_init";
-	classString += QString("class_<%1%2>(\"%3\"%4)").arg(cData.qualifiedName_, basesString, cData.className_, noInit);
+	classString += QString("class_<%1%2>(\"%3\"%4)").arg(cData.qualifiedName_.trimmed(),
+																		  basesString, cData.className_, noInit);
 
 	printPossiblyLongString(classString);
 


### PR DESCRIPTION
More fixes, and implementation of a Join query.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23discussion_r44634312%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23discussion_r44634978%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23discussion_r44635018%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23discussion_r44635374%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23discussion_r44635680%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23discussion_r44635848%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23discussion_r44636028%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23discussion_r44636277%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23discussion_r44636345%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23discussion_r44637199%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23issuecomment-156051872%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23issuecomment-156051872%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Cool.%20Thanks.%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A48%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2075e08d8ebcdb3d37bebd40222b4c5bb58c74bb18%20InformationScripting/src/queries/Join.cpp%2084%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23discussion_r44635018%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20understand%20the%20problem.%20This%20is%20provided%20by%20the%20user%2C%20so%20what%27s%20the%20issue%3F%20Why%20would%20we%20need%20more%20flexibility%20%28example%29%3F%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A14%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20and%20the%20next%20line%20belong%20to%20line%2089%20just%20below.%20And%20in%20fact%20I%20just%20realized%20that%20it%20is%20plain%20wrong.%20I%20thought%20we%20had%20to%20extract%20the%20Property%20value%20to%20do%20the%20comparison%2C%20but%20we%20can%20just%20use%20Property%3A%3Aoperator%3D%3D%20so%20it%20will%20work%20for%20any%20property%20value.%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A18%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20in%20a%20new%20commit.%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A22%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/Join.cpp%3AL1-156%22%7D%2C%20%22Pull%2075e08d8ebcdb3d37bebd40222b4c5bb58c74bb18%20InformationScripting/src/dataformat/Tuple.cpp%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/211%23discussion_r44634312%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22So%20this%20is%20nice%2C%20but%20do%20you%20still%20think%20we%20should%20support%20the%20old%20behavior%20%28not%20providing%20a%20tag%20and%20using%20the%20tag%20of%20the%20first%20part%20of%20the%20tuple%29%3F%20Are%20there%20any%20drawbacks%20to%20removing%20the%20old%20behavior%3F%20What%20are%20the%20advantages%20of%20keeping%20this%20flexibility%3F%20I%20feel%20like%20it%20might%20cause%20confusion.%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A05%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20I%20left%20the%20old%20behavior%20mostly%20that%20it%20is%20not%20a%20too%20invasive%20change.%20For%20example%20for%20ast%20nodes%20it%20makes%20sense%2C%20but%20we%20can%20also%20change%20it%20to%20ast.node%20or%20something.%20There%20are%20no%20drawbacks%20of%20removing%20the%20old%20behavior.%20I%20think%20we%20can%20change%20it%2C%20if%20you%27d%20like%20so.%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A13%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20my%20only%20concern%20is%20that%20having%20this%20flexibility%20slightly%20complicates%20our%20basic%20data%20model.%20But%20I%20am%20not%20sure%20if%20that%27s%20indeed%20a%20problem%20or%20not.%5Cr%5Cn%5Cr%5CnPerhaps%20a%20slightly%20nicer%20solution%20is%20to%20say%3A%5Cr%5Cn-%20A%20tuple%20always%20has%20a%20tag%5Cr%5Cn-%20You%20can%20either%20provided%20manually%5Cr%5Cn-%20Or%20else%20it%20gets%20automatically%20assgined%20at%20construction%20from%20the%20tag%20of%20the%20first%20tuple%20element.%20This%20is%20very%20similar%20to%20the%20current%20solution%20with%20two%20differences%3A%5Cr%5Cn%20-%20In%20the%20default%20case%2C%20we%20insist%20that%20the%20tuple%20is%20initialized%20with%20at%20least%20one%20value%2C%20so%20that%20the%20empty%20case%20at%20the%20bottom%20of%20this%20function%20falls%20out.%5Cr%5Cn%20-%20We%20change%20this%20method%20to%20always%20return%20%60tag_%60%20and%20inline%20it%2C%20and%20move%20the%20entire%20initialization%20to%20the%20initializer%20list%20in%20the%20constructors.%20This%20is%20a%20bit%20more%20explicit.%5Cr%5Cn%5Cr%5CnWhat%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A24%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sounds%20good%20to%20me.%5Cr%5CnShould%20I%20assert%20that%20the%20lists%20at%20construction%20are%20not%20empty%20or%20how%20should%20I%20handle%20this%20properly%3F%5Cr%5CnNote%20that%20this%20constructor%20can%20also%20be%20called%20from%20scripts%2C%20so%20an%20assertion%20might%20not%20be%20the%20optimal%20solution%3F%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A27%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20an%20assertion%20is%20the%20right%20thing.%20This%20is%20not%20a%20user%20error%2C%20but%20a%20programming%20error%20in%20the%20sense%20that%20one%20should%20have%20provided%20either%20a%20tag%20or%20some%20initial%20values.%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A30%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22BTW%3A%20putting%20the%20tag%20of%20a%20tuple%20at%20the%20end%20when%20constructing%20a%20new%20one%20is%20akward.%20The%20tag%20should%20be%20the%20first%20argument.%20Please%20do%20it%20like%20that%20%28you%27ll%20need%20another%202%20constructors%29.%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A31%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A41%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/dataformat/Tuple.cpp%3AL28-45%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 75e08d8ebcdb3d37bebd40222b4c5bb58c74bb18 InformationScripting/src/dataformat/Tuple.cpp 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/211#discussion_r44634312'>File: InformationScripting/src/dataformat/Tuple.cpp:L28-45</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> So this is nice, but do you still think we should support the old behavior (not providing a tag and using the tag of the first part of the tuple)? Are there any drawbacks to removing the old behavior? What are the advantages of keeping this flexibility? I feel like it might cause confusion.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Well I left the old behavior mostly that it is not a too invasive change. For example for ast nodes it makes sense, but we can also change it to ast.node or something. There are no drawbacks of removing the old behavior. I think we can change it, if you'd like so.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Well, my only concern is that having this flexibility slightly complicates our basic data model. But I am not sure if that's indeed a problem or not.
  Perhaps a slightly nicer solution is to say:
- A tuple always has a tag
- You can either provided manually
- Or else it gets automatically assgined at construction from the tag of the first tuple element. This is very similar to the current solution with two differences:
- In the default case, we insist that the tuple is initialized with at least one value, so that the empty case at the bottom of this function falls out.
- We change this method to always return `tag_` and inline it, and move the entire initialization to the initializer list in the constructors. This is a bit more explicit.
  What do you think?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Sounds good to me.
  Should I assert that the lists at construction are not empty or how should I handle this properly?
  Note that this constructor can also be called from scripts, so an assertion might not be the optimal solution?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I think an assertion is the right thing. This is not a user error, but a programming error in the sense that one should have provided either a tag or some initial values.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> BTW: putting the tag of a tuple at the end when constructing a new one is akward. The tag should be the first argument. Please do it like that (you'll need another 2 constructors).
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Fixed
- [x] <a href='#crh-comment-Pull 75e08d8ebcdb3d37bebd40222b4c5bb58c74bb18 InformationScripting/src/queries/Join.cpp 84'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/211#discussion_r44635018'>File: InformationScripting/src/queries/Join.cpp:L1-156</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I don't understand the problem. This is provided by the user, so what's the issue? Why would we need more flexibility (example)?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> This and the next line belong to line 89 just below. And in fact I just realized that it is plain wrong. I thought we had to extract the Property value to do the comparison, but we can just use Property::operator== so it will work for any property value.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Fixed in a new commit.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/211#issuecomment-156051872'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Cool. Thanks.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/211?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/211?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/211'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
