### PR TITLE
Query stuff

### DIFF
--- a/InformationScripting/scripts/color.py
+++ b/InformationScripting/scripts/color.py
@@ -1,10 +1,16 @@
 # Example:
 # methods|color blue
 
-color = "red"
-if (len(Query.args)):
-    color = Query.args[0]
+import argparse
 
-for tuple in Query.input.take("ast"):
+parser = argparse.ArgumentParser()
+parser.add_argument('color', default='red', nargs='?')
+parser.add_argument('--tag', '-t', default='ast', nargs='?')
+parsedArgs = parser.parse_args(Query.args)
+
+tag = parsedArgs.tag
+color = parsedArgs.color
+
+for tuple in Query.input.take(tag):
     t = Tuple([NamedProperty("color", color), NamedProperty("ast", tuple.ast)])
     Query.result.add(t)

--- a/InformationScripting/scripts/not.py
+++ b/InformationScripting/scripts/not.py
@@ -1,0 +1,11 @@
+# This query can negate the result of a single query
+# example: methods|not ast -input -n=supports
+# returns all methods that do not have supports in the name
+
+inputCopy = Query.input
+queryName = Query.args.pop(0)
+queryFunction = getattr(Query, queryName)
+queryResult = queryFunction(Query.args, [Query.input])[0]
+
+inputCopy.remove(queryResult)
+Query.result = inputCopy

--- a/InformationScripting/src/python_bindings/BoostPythonHelpers.cpp
+++ b/InformationScripting/src/python_bindings/BoostPythonHelpers.cpp
@@ -31,6 +31,7 @@
 #include "../dataformat/Tuple.h"
 #include "../dataformat/TupleSet.h"
 
+#include "OOModel/src/declarations/Class.h"
 namespace InformationScripting {
 
 namespace PythonConverters {
@@ -80,9 +81,21 @@ struct QSet_to_python_set
 {
 		static PyObject* convert(QSet<T> toConvert)
 		{
-			helper::PythonSet list;
-			for (auto val : toConvert) list.add(val);
-			return python::incref(list.ptr());
+			helper::PythonSet pySet;
+			for (auto val : toConvert) pySet.add(val);
+			return python::incref(pySet.ptr());
+		}
+};
+
+// Specialization for pointer sets:
+template<class T>
+struct QSet_to_python_set<T*>
+{
+		static PyObject* convert(QSet<T*> toConvert)
+		{
+			helper::PythonSet pySet;
+			for (auto val : toConvert) pySet.add(python::ptr(val));
+			return python::incref(pySet.ptr());
 		}
 };
 
@@ -162,6 +175,7 @@ void BoostPythonHelpers::initializeConverters()
 	python::to_python_converter<QString, PythonConverters::QString_to_python_str>();
 
 	python::to_python_converter<QSet<Tuple>, PythonConverters::QSet_to_python_set<Tuple>>();
+	python::to_python_converter<QSet<OOModel::Class*>, PythonConverters::QSet_to_python_set<OOModel::Class*>>();
 
 	python::to_python_converter<QList<QString>, PythonConverters::QList_to_python_list<QString>>();
 	python::to_python_converter<QList<TupleSet>, PythonConverters::QList_to_python_list<TupleSet>>();

--- a/InformationScripting/src/python_bindings/BoostPythonHelpers.cpp
+++ b/InformationScripting/src/python_bindings/BoostPythonHelpers.cpp
@@ -32,6 +32,8 @@
 #include "../dataformat/TupleSet.h"
 
 #include "OOModel/src/declarations/Class.h"
+#include "ModelBase/src/nodes/Node.h"
+
 namespace InformationScripting {
 
 namespace PythonConverters {
@@ -180,6 +182,7 @@ void BoostPythonHelpers::initializeConverters()
 	python::to_python_converter<QList<QString>, PythonConverters::QList_to_python_list<QString>>();
 	python::to_python_converter<QList<TupleSet>, PythonConverters::QList_to_python_list<TupleSet>>();
 	python::to_python_converter<QList<NamedProperty>, PythonConverters::QList_to_python_list<NamedProperty>>();
+	python::to_python_converter<QList<Model::Node*>, PythonConverters::QList_to_python_list<Model::Node*>>();
 
 	// register the from-python converters
 	PythonConverters::QString_from_python_str();

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -108,7 +108,7 @@ Optional<TupleSet> AstQuery::baseClassesQuery(TupleSet)
 
 		addBaseEdgesFor(parentClass, namedClass, ts);
 
-		adaptOutputForRelation(ts, "base class", {"baseClass"});
+		adaptOutputForRelation(ts, "baseclass", {"baseClass"});
 	}
 	else if (arguments_.scope() == ArgumentParser::Scope::Global)
 	{
@@ -411,7 +411,7 @@ void AstQuery::addBaseEdgesFor(OOModel::Class* childClass, NamedProperty& classN
 	{
 		NamedProperty baseNode{"baseClass", base};
 		ts.add({baseNode});
-		ts.add({"base class", {{classNode}, {baseNode}}});
+		ts.add({"baseclass", {{classNode}, {baseNode}}});
 		addBaseEdgesFor(base, baseNode, ts);
 	}
 }

--- a/InformationScripting/src/queries/AstQuery.cpp
+++ b/InformationScripting/src/queries/AstQuery.cpp
@@ -58,7 +58,7 @@ AstQuery::AstQuery(Model::Node* target, QStringList args, ExecuteFunction exec, 
 		 {NAME_ARGUMENT_NAMES, "Name of a symbol", NAME_ARGUMENT_NAMES[1]},
 		 {ADD_AS_NAMES, "Add as relation or nodes", ADD_AS_NAMES[1], "relation"},
 		 {ATTRIBUTE_NAME_NAMES, "Attribute to search from", ATTRIBUTE_NAME_NAMES[1]}
-		}, args}, exec_{exec}
+		}, args, true}, exec_{exec}
 {
 	for (const auto& rule : argumentRules)
 		rule.check(arguments_);
@@ -91,8 +91,7 @@ void AstQuery::registerDefaultQueries()
 		ArgumentParser::setArgTo(args, NODETYPE_ARGUMENT_NAMES, "Method");});
 	QueryRegistry::registerAlias("toClass", "toParent", [](QStringList& args) {
 		ArgumentParser::setArgTo(args, NODETYPE_ARGUMENT_NAMES, "Class");});
-	QueryRegistry::registerAlias("filter", "ast", [](QStringList& args) {
-		ArgumentParser::setArgTo(args, ArgumentParser::SCOPE_ARGUMENT_NAMES, "of");});
+	QueryRegistry::registerAlias("filter", "ast", [](QStringList& args) {args << "-input";});
 }
 
 Optional<TupleSet> AstQuery::baseClassesQuery(TupleSet)

--- a/InformationScripting/src/queries/ScriptQuery.cpp
+++ b/InformationScripting/src/queries/ScriptQuery.cpp
@@ -102,6 +102,10 @@ Optional<TupleSet> ScriptQuery::executeLinear(TupleSet input)
 			queriesDict[query] = python::make_function(queryMethod, call_policies, func_sig());
 		}
 
+		// Per default exec_file does not set argv, thus we set it here manually.
+		wchar_t* argv[] = {Py_DecodeLocale(scriptPath_.toLatin1().data(), nullptr)};
+		PySys_SetArgv(1, argv);
+
 		exec_file(scriptPath_.toLatin1().data(), main_namespace, main_namespace);
 		// Workaround to get output
 		sys.attr("stdout").attr("flush")();

--- a/InformationScripting/src/queries/TagQuery.cpp
+++ b/InformationScripting/src/queries/TagQuery.cpp
@@ -63,7 +63,7 @@ TagQuery::TagQuery(Model::Node* target, QStringList args, ExecuteFunction exec, 
 			QCommandLineOption{ADD_ARGUMENT_NAMES},
 			QCommandLineOption{REMOVE_ARGUMENT_NAMES},
 			{PERSISTENT_ARGUMENT_NAMES, "Wether the change is persistent, default = yes", PERSISTENT_ARGUMENT_NAMES[1], "yes"}
-}, args}, exec_{exec}
+}, args, true}, exec_{exec}
 {
 	persistent_ = arguments_.argument(PERSISTENT_ARGUMENT_NAMES[1]) == "yes";
 	for (const auto& rule : argumentRules)

--- a/InformationScripting/src/query_framework/ArgumentParser.h
+++ b/InformationScripting/src/query_framework/ArgumentParser.h
@@ -46,7 +46,7 @@ class INFORMATIONSCRIPTING_API ArgumentParser
 		enum class Scope : int {Local, Global, Input};
 
 		ArgumentParser(std::initializer_list<QCommandLineOption> options,
-								  const QStringList& args);
+								  const QStringList& args, bool addScopeArguments = false);
 
 		static void setArgTo(QStringList& args, const QStringList& argNames, const QString& type);
 
@@ -57,7 +57,8 @@ class INFORMATIONSCRIPTING_API ArgumentParser
 
 		QString queryName() const;
 
-		static const QStringList SCOPE_ARGUMENT_NAMES;
+		static const QStringList GLOBAL_SCOPE_ARGUMENT_NAMES;
+		static const QStringList INPUT_SCOPE_ARGUMENT_NAMES;
 	private:
 		std::unique_ptr<QCommandLineParser> argParser_{};
 		Scope scope_{};

--- a/InformationScripting/src/query_prompt/parsing/QueryBuilder.h
+++ b/InformationScripting/src/query_prompt/parsing/QueryBuilder.h
@@ -59,6 +59,20 @@ class INFORMATIONSCRIPTING_API QueryBuilder : public Model::Visitor<QueryBuilder
 
 		static void connectQueriesWith(CompositeQuery* composite, CompositeQuery* queries,
 										Query* connectionQuery, Query* outputQuery = nullptr);
+
+		/**
+		 * Connects \a left with \a right queries in the \a composite, using a union operator specified in \a op.
+		 *
+		 * Note that \a left and \a right have to be previously added to \a composite.
+		 */
+		static void connectAsUnion(CompositeQuery* composite, CompositeQuery* left, Query* right, OperatorQueryNode* op);
+
+		/**
+		 * Connects \a left with \a right queries in the \a composite, building a split operation.
+		 *
+		 * Note that \a left and \a right have to be previously added to \a composite.
+		 */
+		static void connectAsSplit(CompositeQuery* composite, Query* left, CompositeQuery* right);
 };
 
 } /* namespace InformationScripting */


### PR DESCRIPTION
Various fixes and improvements
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/220%23discussion_r45622354%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/220%23discussion_r45624678%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/220%23discussion_r45624932%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2039483516d7b9d04c73d458c646758382e53be7bb%20InformationScripting/scripts/not.py%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/220%23discussion_r45622354%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20confused.%20Isn%27t%20this%20the%20same%20as%3A%5Cr%5Cn%60methods%20%7C-%20ast%20-input%20-n%3Dsupports%60%22%2C%20%22created_at%22%3A%20%222015-11-23T16%3A14%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20but%20the%20same%20as%20%60%60%60methods%20%7C-%20methods%20-n%20supports%60%60%60%5Cr%5Cn%5Cr%5CnIt%20is%20more%20syntactic%20sugar.%22%2C%20%22created_at%22%3A%20%222015-11-23T16%3A29%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22ok%22%2C%20%22created_at%22%3A%20%222015-11-23T16%3A31%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/scripts/not.py%3AL1-12%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 39483516d7b9d04c73d458c646758382e53be7bb InformationScripting/scripts/not.py 2'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/220#discussion_r45622354'>File: InformationScripting/scripts/not.py:L1-12</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I'm confused. Isn't this the same as:
  `methods |- ast -input -n=supports`
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> No but the same as `methods |- methods -n supports`
  It is more syntactic sugar.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> ok

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/220?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/220?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/220'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
