### PR TITLE
WIP: Cpp Export

### DIFF
--- a/CppExport/src/exporter/CppExporter.cpp
+++ b/CppExport/src/exporter/CppExporter.cpp
@@ -136,7 +136,7 @@ Export::FragmentLayouter CppExporter::layouter()
 						  | Export::FragmentLayouter::NewLineBeforePostfix, "{", "\n", "}");
 	result.addRule("space", Export::FragmentLayouter::SpaceAtEnd, "", " ", "");
 	result.addRule("comma", Export::FragmentLayouter::SpaceAfterSeparator, "", ",", "");
-	result.addRule("baseClasses", Export::FragmentLayouter::SpaceAfterSeparator, "public: ", ",", "");
+	result.addRule("baseClasses", Export::FragmentLayouter::SpaceAfterSeparator, " : public ", ",", "");
 	result.addRule("initializerList", Export::FragmentLayouter::SpaceAfterSeparator, "{", ",", "}");
 	result.addRule("argsList", Export::FragmentLayouter::SpaceAfterSeparator, "(", ",", ")");
 	result.addRule("typeArgsList", Export::FragmentLayouter::SpaceAfterSeparator, "<", ",", ">");

--- a/CppExport/src/visitors/header_visitors/DeclarationVisitorHeader.cpp
+++ b/CppExport/src/visitors/header_visitors/DeclarationVisitorHeader.cpp
@@ -233,6 +233,9 @@ SourceFragment* DeclarationVisitorHeader::visit(Method* method)
 	notAllowed(method->subDeclarations());
 	notAllowed(method->memberInitializers());
 
+	if (method->modifiers()->isSet(Modifier::Override))
+		*fragment << " " << new TextFragment(method->modifiers(), "override");
+
 	*fragment << ";";
 
 	return fragment;
@@ -273,8 +276,6 @@ SourceFragment* DeclarationVisitorHeader::printAnnotationsAndModifiers(Declarati
 
 	if (declaration->modifiers()->isSet(Modifier::Virtual))
 		*header << new TextFragment(declaration->modifiers(), "virtual");
-	if (declaration->modifiers()->isSet(Modifier::Override))
-		*header << new TextFragment(declaration->modifiers(), "override");
 	if (declaration->modifiers()->isSet(Modifier::Inline))
 		*header << new TextFragment(declaration->modifiers(), "inline");
 

--- a/CppExport/src/visitors/header_visitors/DeclarationVisitorHeader.cpp
+++ b/CppExport/src/visitors/header_visitors/DeclarationVisitorHeader.cpp
@@ -211,11 +211,7 @@ SourceFragment* DeclarationVisitorHeader::visit(Method* method)
 			*fragment << "void ";
 	}
 
-	if (method->methodKind() == Method::MethodKind::Destructor)
-	{
-		if (!method->name().startsWith("~"))
-			*fragment << "~";
-	}
+	if (method->methodKind() == Method::MethodKind::Destructor && !method->name().startsWith("~")) *fragment << "~";
 	*fragment << method->nameNode();
 
 	if (!method->typeArguments()->isEmpty())

--- a/CppExport/src/visitors/header_visitors/DeclarationVisitorHeader.cpp
+++ b/CppExport/src/visitors/header_visitors/DeclarationVisitorHeader.cpp
@@ -135,6 +135,7 @@ SourceFragment* DeclarationVisitorHeader::visit(Class* classs)
 		*fragment << list(classs->typeArguments(), ElementVisitorHeader(data()), "typeArgsList");
 
 	if (!classs->baseClasses()->isEmpty())
+		// TODO: inheritance modifiers like private, virtual... (not only public)
 		*fragment << list(classs->baseClasses(), ExpressionVisitorHeader(data()), "baseClasses");
 
 	notAllowed(classs->friends());

--- a/CppExport/src/visitors/header_visitors/DeclarationVisitorHeader.cpp
+++ b/CppExport/src/visitors/header_visitors/DeclarationVisitorHeader.cpp
@@ -197,12 +197,8 @@ SourceFragment* DeclarationVisitorHeader::visit(Method* method)
 	if (method->results()->size() > 1)
 		error(method->results(), "Cannot have more than one return value in C++");
 
-	if (method->methodKind() == Method::MethodKind::Destructor)
-	{
-		if (!method->name().startsWith("~"))
-			*fragment << "~";
-	}
-	else if (method->methodKind() != Method::MethodKind::Constructor)
+	if (method->methodKind() != Method::MethodKind::Constructor &&
+		 method->methodKind() != Method::MethodKind::Destructor)
 	{
 		if (!method->results()->isEmpty())
 			*fragment << expression(method->results()->at(0)->typeExpression()) << " ";
@@ -210,6 +206,11 @@ SourceFragment* DeclarationVisitorHeader::visit(Method* method)
 			*fragment << "void ";
 	}
 
+	if (method->methodKind() == Method::MethodKind::Destructor)
+	{
+		if (!method->name().startsWith("~"))
+			*fragment << "~";
+	}
 	*fragment << method->nameNode();
 
 	if (!method->typeArguments()->isEmpty())

--- a/CppExport/src/visitors/header_visitors/DeclarationVisitorHeader.h
+++ b/CppExport/src/visitors/header_visitors/DeclarationVisitorHeader.h
@@ -55,7 +55,7 @@ class CPPEXPORT_API DeclarationVisitorHeader : public Visitor {
 		Export::SourceFragment* visit(OOModel::VariableDeclaration* vd);
 
 		Export::SourceFragment* visit(OOModel::ExplicitTemplateInstantiation* eti);
-		Export::SourceFragment* visit(OOModel::TypeAlias* ta);
+		Export::SourceFragment* visit(OOModel::TypeAlias* typeAlias);
 
 		Export::SourceFragment* printAnnotationsAndModifiers(OOModel::Declaration* declaration);
 

--- a/CppExport/src/visitors/header_visitors/ExpressionVisitorHeader.cpp
+++ b/CppExport/src/visitors/header_visitors/ExpressionVisitorHeader.cpp
@@ -77,7 +77,7 @@ SourceFragment* ExpressionVisitorHeader::visit(Expression* expression)
 		}
 		*fragment << " " << visit(e->typeExpression());
 	}
-	else if (DCast<AutoTypeExpression>(expression)) *fragment << "auto";
+	else if (auto e = DCast<AutoTypeExpression>(expression)) *fragment << new TextFragment(e, "auto");
 	else if (auto e = DCast<FunctionTypeExpression>(expression))
 	{
 		*fragment << list(e->results(), ExpressionVisitorHeader(data())) << " "

--- a/CppExport/src/visitors/header_visitors/ExpressionVisitorHeader.cpp
+++ b/CppExport/src/visitors/header_visitors/ExpressionVisitorHeader.cpp
@@ -28,6 +28,9 @@
 #include "../../CppExportException.h"
 #include "VisitorDefs.h"
 
+#include "OOModel/src/types/PointerType.h"
+#include "OOModel/src/types/SymbolProviderType.h"
+
 using namespace Export;
 using namespace OOModel;
 

--- a/CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp
+++ b/CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp
@@ -178,21 +178,25 @@ SourceFragment* DeclarationVisitorSource::visit(Method* method)
 	return fragment;
 }
 
+SourceFragment* DeclarationVisitorSource::visit(VariableDeclaration* variableDeclaration)
 SourceFragment* DeclarationVisitorSource::visit(VariableDeclaration* vd)
 {
-	auto fragment = new CompositeFragment(vd);
-	if (vd->initialValue())
-	{
-		*fragment << expression(vd->typeExpression()) << " ";
+	auto fragment = new CompositeFragment(variableDeclaration);
+	bool isField = DCast<Field>(variableDeclaration);
 
-		if (DCast<Field>(vd))
-			if (auto parentClass = vd->firstAncestorOfType<Class>())
+	if (!isField || variableDeclaration->modifiers()->isSet(Modifier::Static))
+	{
+		*fragment << expression(variableDeclaration->typeExpression()) << " ";
+
+		if (isField)
+			if (auto parentClass = variableDeclaration->firstAncestorOfType<Class>())
 				*fragment << parentClass->name() << "::";
 
-		*fragment << vd->nameNode();
-		*fragment << " = " << expression(vd->initialValue());
+		*fragment << variableDeclaration->nameNode();
+		if (variableDeclaration->initialValue())
+			*fragment << " = " << expression(variableDeclaration->initialValue());
 
-		if (!DCast<Expression>(vd->parent())) *fragment << ";";
+		if (!DCast<Expression>(variableDeclaration->parent())) *fragment << ";";
 	}
 	return fragment;
 }

--- a/CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp
+++ b/CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp
@@ -151,11 +151,8 @@ SourceFragment* DeclarationVisitorSource::visit(Method* method)
 	if (auto parentClass = method->firstAncestorOfType<Class>())
 		*fragment << parentClass->name() << "::";
 
-	if (method->methodKind() == Method::MethodKind::Destructor)
-	{
-		if (!method->name().startsWith("~"))
-			*fragment << "~";
-	}
+
+	if (method->methodKind() == Method::MethodKind::Destructor && !method->name().startsWith("~")) *fragment << "~";
 	*fragment << method->nameNode();
 
 	if (!method->typeArguments()->isEmpty())

--- a/CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp
+++ b/CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp
@@ -135,7 +135,6 @@ SourceFragment* DeclarationVisitorSource::visit(Class* classs)
 SourceFragment* DeclarationVisitorSource::visit(Method* method)
 {
 	auto fragment = new CompositeFragment(method);
-	*fragment << printAnnotationsAndModifiers(method);
 
 	if (method->results()->size() > 1)
 		error(method->results(), "Cannot have more than one return value in C++");
@@ -184,7 +183,6 @@ SourceFragment* DeclarationVisitorSource::visit(VariableDeclaration* vd)
 	auto fragment = new CompositeFragment(vd);
 	if (vd->initialValue())
 	{
-		*fragment << printAnnotationsAndModifiers(vd);
 		*fragment << expression(vd->typeExpression()) << " ";
 
 		if (DCast<Field>(vd))
@@ -202,38 +200,11 @@ SourceFragment* DeclarationVisitorSource::visit(VariableDeclaration* vd)
 SourceFragment* DeclarationVisitorSource::visit(NameImport* nameImport)
 {
 	auto fragment = new CompositeFragment(nameImport);
-	*fragment << printAnnotationsAndModifiers(nameImport);
-
 	notAllowed(nameImport->annotations());
 
 	*fragment << "import " << expression(nameImport->importedName());
 	if (nameImport->importAll()) *fragment << ".*";
 	*fragment << ";";
-
-	return fragment;
-}
-
-SourceFragment* DeclarationVisitorSource::printAnnotationsAndModifiers(Declaration* declaration)
-{
-	auto fragment = new CompositeFragment(declaration, "vertical");
-	if (!declaration->annotations()->isEmpty()) // avoid an extra new line if there are no annotations
-		*fragment << list(declaration->annotations(), StatementVisitorSource(data()), "vertical");
-	auto header = fragment->append(new CompositeFragment(declaration, "space"));
-
-	if (declaration->modifiers()->isSet(Modifier::Static))
-		*header << new TextFragment(declaration->modifiers(), "static");
-
-	if (declaration->modifiers()->isSet(Modifier::Final))
-		*header << new TextFragment(declaration->modifiers(), "final");
-	if (declaration->modifiers()->isSet(Modifier::Abstract))
-		*header << new TextFragment(declaration->modifiers(), "abstract");
-
-	if (declaration->modifiers()->isSet(Modifier::Virtual))
-		*header << new TextFragment(declaration->modifiers(), "virtual");
-	if (declaration->modifiers()->isSet(Modifier::Override))
-		*header << new TextFragment(declaration->modifiers(), "override");
-	if (declaration->modifiers()->isSet(Modifier::Inline))
-		*header << new TextFragment(declaration->modifiers(), "inline");
 
 	return fragment;
 }
@@ -244,10 +215,10 @@ SourceFragment* DeclarationVisitorSource::visit(ExplicitTemplateInstantiation* e
 	return new TextFragment(eti);
 }
 
-SourceFragment* DeclarationVisitorSource::visit(TypeAlias* ta)
+SourceFragment* DeclarationVisitorSource::visit(TypeAlias* typeAlias)
 {
-	notAllowed(ta);
-	return new TextFragment(ta);
+	auto fragment = new CompositeFragment(typeAlias);
+	*fragment << "using " << typeAlias->nameNode() << " = " << expression(typeAlias->typeExpression()) << ";";
+	return fragment;
 }
-
 }

--- a/CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp
+++ b/CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp
@@ -163,6 +163,9 @@ SourceFragment* DeclarationVisitorSource::visit(Method* method)
 
 	*fragment << list(method->arguments(), ElementVisitorSource(data()), "argsList");
 
+	if (!method->memberInitializers()->isEmpty())
+		*fragment << " : " << list(method->memberInitializers(), ElementVisitorSource(data()));
+
 	if (!method->throws()->isEmpty())
 	{
 		*fragment << " throw (";

--- a/CppExport/src/visitors/source_visitors/DeclarationVisitorSource.h
+++ b/CppExport/src/visitors/source_visitors/DeclarationVisitorSource.h
@@ -55,9 +55,7 @@ class CPPEXPORT_API DeclarationVisitorSource : public Visitor {
 		Export::SourceFragment* visit(OOModel::VariableDeclaration* vd);
 
 		Export::SourceFragment* visit(OOModel::ExplicitTemplateInstantiation* eti);
-		Export::SourceFragment* visit(OOModel::TypeAlias* ta);
-
-		Export::SourceFragment* printAnnotationsAndModifiers(OOModel::Declaration* declaration);
+		Export::SourceFragment* visit(OOModel::TypeAlias* typeAlias);
 
 		Export::SourceFragment* visitTopLevelClass(OOModel::Class* classs);
 };

--- a/CppExport/src/visitors/source_visitors/ElementVisitorSource.cpp
+++ b/CppExport/src/visitors/source_visitors/ElementVisitorSource.cpp
@@ -89,7 +89,8 @@ SourceFragment* ElementVisitorSource::visit(Enumerator* enumerator)
 SourceFragment* ElementVisitorSource::visit(MemberInitializer* memberInitializer)
 {
 	auto fragment = new CompositeFragment(memberInitializer);
-	*fragment << list(memberInitializer->arguments(), ExpressionVisitorSource(data()));
+	*fragment << expression(memberInitializer->memberReference())
+				 << list(memberInitializer->arguments(), ExpressionVisitorSource(data()), "initializerList");
 	return fragment;
 }
 

--- a/CppExport/src/visitors/source_visitors/ElementVisitorSource.cpp
+++ b/CppExport/src/visitors/source_visitors/ElementVisitorSource.cpp
@@ -88,8 +88,9 @@ SourceFragment* ElementVisitorSource::visit(Enumerator* enumerator)
 
 SourceFragment* ElementVisitorSource::visit(MemberInitializer* memberInitializer)
 {
-	notAllowed(memberInitializer);
-	return new TextFragment(memberInitializer);
+	auto fragment = new CompositeFragment(memberInitializer);
+	*fragment << list(memberInitializer->arguments(), ExpressionVisitorSource(data()));
+	return fragment;
 }
 
 }

--- a/CppExport/src/visitors/source_visitors/ExpressionVisitorSource.cpp
+++ b/CppExport/src/visitors/source_visitors/ExpressionVisitorSource.cpp
@@ -28,6 +28,9 @@
 #include "../../CppExportException.h"
 #include "VisitorDefs.h"
 
+#include "OOModel/src/types/PointerType.h"
+#include "OOModel/src/types/SymbolProviderType.h"
+
 using namespace Export;
 using namespace OOModel;
 
@@ -58,7 +61,7 @@ SourceFragment* ExpressionVisitorSource::visit(Expression* expression)
 			case PrimitiveTypeExpression::PrimitiveTypes::UNSIGNED_LONG: notAllowed(e); break;
 			case PrimitiveTypeExpression::PrimitiveTypes::FLOAT: *fragment << "float"; break;
 			case PrimitiveTypeExpression::PrimitiveTypes::DOUBLE: *fragment << "double"; break;
-			case PrimitiveTypeExpression::PrimitiveTypes::BOOLEAN: *fragment << "boolean"; break;
+			case PrimitiveTypeExpression::PrimitiveTypes::BOOLEAN: *fragment << "bool"; break;
 			case PrimitiveTypeExpression::PrimitiveTypes::CHAR: *fragment << "char"; break;
 			case PrimitiveTypeExpression::PrimitiveTypes::VOID: *fragment << "void"; break;
 			default: error(e, "Unkown primitive type");
@@ -74,8 +77,12 @@ SourceFragment* ExpressionVisitorSource::visit(Expression* expression)
 		}
 		*fragment << " " << visit(e->typeExpression());
 	}
-	else if (auto e = DCast<AutoTypeExpression>(expression)) notAllowed(e);
-	else if (auto e = DCast<FunctionTypeExpression>(expression)) notAllowed(e);
+	else if (DCast<AutoTypeExpression>(expression)) *fragment << "auto";
+	else if (auto e = DCast<FunctionTypeExpression>(expression))
+	{
+		*fragment << list(e->results(), ExpressionVisitorSource(data())) << " "
+					 << list(e->arguments(), ExpressionVisitorSource(data()), "argsList");
+	}
 
 	// Operators ========================================================================================================
 
@@ -143,8 +150,8 @@ SourceFragment* ExpressionVisitorSource::visit(Expression* expression)
 			case UnaryOperation::NOT: *fragment << "!" << visit(e->operand()); break;
 			case UnaryOperation::COMPLEMENT: *fragment << "~" << visit(e->operand()); break;
 			case UnaryOperation::PARENTHESIS: *fragment << "(" << visit(e->operand()) << ")"; break;
-			case UnaryOperation::DEREFERENCE: notAllowed(e); break;
-			case UnaryOperation::ADDRESSOF: notAllowed(e); break;
+			case UnaryOperation::DEREFERENCE: *fragment << "*" << visit(e->operand()); break;
+			case UnaryOperation::ADDRESSOF: *fragment << "&" << visit(e->operand()); break;
 			default: error(e, "Unkown unary operator type");
 		}
 	}
@@ -207,7 +214,15 @@ SourceFragment* ExpressionVisitorSource::visit(Expression* expression)
 	}
 	else if (auto e = DCast<ReferenceExpression>(expression))
 	{
-		if (e->prefix()) *fragment << visit(e->prefix()) << ".";
+		if (e->prefix())
+		{
+			if (dynamic_cast<PointerType*>(e->prefix()->type()))
+				*fragment << visit(e->prefix()) << "->";
+			else if (dynamic_cast<SymbolProviderType*>(e->prefix()->type()))
+				*fragment << visit(e->prefix()) << "::";
+			else
+				*fragment << visit(e->prefix()) << ".";
+		}
 		*fragment << e->name();
 		if (!e->typeArguments()->isEmpty()) *fragment << list(e->typeArguments(), this, "typeArgsList");
 	}

--- a/CppExport/src/visitors/source_visitors/ExpressionVisitorSource.cpp
+++ b/CppExport/src/visitors/source_visitors/ExpressionVisitorSource.cpp
@@ -77,7 +77,7 @@ SourceFragment* ExpressionVisitorSource::visit(Expression* expression)
 		}
 		*fragment << " " << visit(e->typeExpression());
 	}
-	else if (DCast<AutoTypeExpression>(expression)) *fragment << "auto";
+	else if (auto e = DCast<AutoTypeExpression>(expression)) *fragment << new TextFragment(e, "auto");
 	else if (auto e = DCast<FunctionTypeExpression>(expression))
 	{
 		*fragment << list(e->results(), ExpressionVisitorSource(data())) << " "

--- a/CppImport/src/visitors/ClangAstVisitor.cpp
+++ b/CppImport/src/visitors/ClangAstVisitor.cpp
@@ -439,6 +439,7 @@ bool ClangAstVisitor::WalkUpFromTypedefNameDecl(clang::TypedefNameDecl* typedefD
 		ooTypeAlias->setTypeExpression(utils_->translateQualifiedType(typedefDecl->getUnderlyingType(),
 																						  typedefDecl->getLocStart()));
 		ooTypeAlias->setName(QString::fromStdString(typedefDecl->getNameAsString()));
+		ooTypeAlias->modifiers()->set(utils_->translateAccessSpecifier(typedefDecl->getAccess()));
 		if (auto itemList = DCast<OOModel::StatementItemList>(ooStack_.top()))
 			itemList->append(new OOModel::DeclarationStatement(ooTypeAlias));
 		else if (auto declaration = DCast<OOModel::Declaration>(ooStack_.top()))

--- a/CppImport/src/visitors/ClangAstVisitor.cpp
+++ b/CppImport/src/visitors/ClangAstVisitor.cpp
@@ -1141,6 +1141,8 @@ void ClangAstVisitor::TraverseFunction(clang::FunctionDecl* functionDecl, OOMode
 		ooFunction->modifiers()->set(OOModel::Modifier::Inline);
 	if (functionDecl->isVirtualAsWritten())
 		ooFunction->modifiers()->set(OOModel::Modifier::Virtual);
+	if (functionDecl->hasAttr<clang::OverrideAttr>())
+		ooFunction->modifiers()->set(OOModel::Modifier::Override);
 }
 
 OOModel::Class*ClangAstVisitor::createClass(clang::CXXRecordDecl* recordDecl)


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/225%23discussion_r45908558%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/225%23discussion_r45909415%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/225%23discussion_r45909574%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/225%23discussion_r45909808%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/225%23discussion_r45910153%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/225%23discussion_r45910277%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20486fde80058a4ce4212f1a1a073ec7512d77295e%20CppExport/src/visitors/source_visitors/ElementVisitorSource.cpp%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/225%23discussion_r45910153%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Erm%2C%20a%20member%20initializer%20also%20has%20a%20name%2C%20we%20need%20to%20print%20the%20whole%20thing.%20Use%20the%20newer%20syntax%2C%20%60%7B%20..%7D%60%20instead%20of%20%60%28%20...%20%29%60%22%2C%20%22created_at%22%3A%20%222015-11-25T19%3A34%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppExport/src/visitors/source_visitors/ElementVisitorSource.cpp%3AL88-97%22%7D%2C%20%22Pull%20486fde80058a4ce4212f1a1a073ec7512d77295e%20CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/225%23discussion_r45909415%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Where%20did%20all%20the%20code%20before%20this%20line%20go%3F%20We%27ll%20still%20to%20handle%20some%20of%20those%20cases%20%28e.g.%20enums%2C%20even%20though%20they%20work%20very%20differently%20compared%20to%20java%29.%22%2C%20%22created_at%22%3A%20%222015-11-25T19%3A27%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp%3AL121-130%22%7D%2C%20%22Pull%20486fde80058a4ce4212f1a1a073ec7512d77295e%20CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp%2086%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/225%23discussion_r45909574%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Merge%20this%20into%20the%20condition%20above.%22%2C%20%22created_at%22%3A%20%222015-11-25T19%3A29%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp%3AL135-162%22%7D%2C%20%22Pull%20486fde80058a4ce4212f1a1a073ec7512d77295e%20CppExport/src/visitors/source_visitors/ExpressionVisitorSource.cpp%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/225%23discussion_r45910277%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22At%20some%20point%20we%20should%20really%20consider%20having%20a%20single%20expression%20visitor%2C%20since%20these%20things%20are%20unlikely%20to%20be%20different%20for%20the%20different%20cases.%22%2C%20%22created_at%22%3A%20%222015-11-25T19%3A34%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppExport/src/visitors/source_visitors/ExpressionVisitorSource.cpp%3AL61-68%22%7D%2C%20%22Pull%20486fde80058a4ce4212f1a1a073ec7512d77295e%20CppExport/src/exporter/CppExporter.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/225%23discussion_r45908558%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Not%20all%20inheritance%20is%20public%20in%20C%2B%2B.%20You%20don%27t%20need%20to%20fix%20this%20now%2C%20but%20you%20should%20start%20a%20list%20of%20things%20that%20we%20don%27t%20yet%20support%20in%20Envision%20and%20which%20we%27ll%20need%20to%20implement.%20Here%20is%20the%20first%20entry%3A%5Cr%5Cn-%20Inheritance%20modifiers%20%28private%2C%20public%2C%20virtual%20...%29%22%2C%20%22created_at%22%3A%20%222015-11-25T19%3A20%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppExport/src/exporter/CppExporter.cpp%3AL136-143%22%7D%2C%20%22Pull%20486fde80058a4ce4212f1a1a073ec7512d77295e%20CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp%20116%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/225%23discussion_r45909808%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20do%20we%20only%20print%20this%20if%20the%20variable%20has%20an%20initial%20value%3F%20What%20it%20if%20doesn%27t%3F%22%2C%20%22created_at%22%3A%20%222015-11-25T19%3A31%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp%3AL184-209%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 486fde80058a4ce4212f1a1a073ec7512d77295e CppExport/src/exporter/CppExporter.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/225#discussion_r45908558'>File: CppExport/src/exporter/CppExporter.cpp:L136-143</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Not all inheritance is public in C++. You don't need to fix this now, but you should start a list of things that we don't yet support in Envision and which we'll need to implement. Here is the first entry:
- Inheritance modifiers (private, public, virtual ...)
- [x] <a href='#crh-comment-Pull 486fde80058a4ce4212f1a1a073ec7512d77295e CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp 52'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/225#discussion_r45909415'>File: CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp:L121-130</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Where did all the code before this line go? We'll still to handle some of those cases (e.g. enums, even though they work very differently compared to java).
- [x] <a href='#crh-comment-Pull 486fde80058a4ce4212f1a1a073ec7512d77295e CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp 86'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/225#discussion_r45909574'>File: CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp:L135-162</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Merge this into the condition above.
- [x] <a href='#crh-comment-Pull 486fde80058a4ce4212f1a1a073ec7512d77295e CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp 116'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/225#discussion_r45909808'>File: CppExport/src/visitors/source_visitors/DeclarationVisitorSource.cpp:L184-209</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why do we only print this if the variable has an initial value? What it if doesn't?
- [x] <a href='#crh-comment-Pull 486fde80058a4ce4212f1a1a073ec7512d77295e CppExport/src/visitors/source_visitors/ElementVisitorSource.cpp 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/225#discussion_r45910153'>File: CppExport/src/visitors/source_visitors/ElementVisitorSource.cpp:L88-97</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Erm, a member initializer also has a name, we need to print the whole thing. Use the newer syntax, `{ ..}` instead of `( ... )`
- [x] <a href='#crh-comment-Pull 486fde80058a4ce4212f1a1a073ec7512d77295e CppExport/src/visitors/source_visitors/ExpressionVisitorSource.cpp 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/225#discussion_r45910277'>File: CppExport/src/visitors/source_visitors/ExpressionVisitorSource.cpp:L61-68</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> At some point we should really consider having a single expression visitor, since these things are unlikely to be different for the different cases.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/225?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/225?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/225'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
