### PR TITLE
Never allow mousepresses on HighlightOverlay

### DIFF
--- a/InformationScripting/src/query_framework/HighlightOverlay.cpp
+++ b/InformationScripting/src/query_framework/HighlightOverlay.cpp
@@ -63,6 +63,7 @@ int HighlightOverlay::determineForm()
 
 void HighlightOverlay::updateGeometry(int availableWidth, int availableHeight)
 {
+	background_->setAcceptedMouseButtons(Qt::NoButton);
 	background_->setCustomSize(associatedItem()->widthInScene(), associatedItem()->heightInScene());
 	Super::updateGeometry(availableWidth, availableHeight);
 	if (hasShape())


### PR DESCRIPTION
I didn't find a better way to do this, suggestions are welcome.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/245%23issuecomment-162119721%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/245%23issuecomment-162247840%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/245%23issuecomment-162248629%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/245%23issuecomment-162248677%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/245%23issuecomment-162119721%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20should%20also%20figure%20out%20a%20good%20way%20to%20remove%20the%20highlights.%20I%20experimented%20with%20the%20code%20a%20bit%20and%20it%20was%20a%20bit%20annoying%20to%20have%20to%20execute%20another%20command%20in%20order%20to%20hide%20things.%20Or%20did%20I%20miss%20something%3F%22%2C%20%22created_at%22%3A%20%222015-12-05T00%3A50%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20that%27s%20true.%20We%20can%20either%20have%20a%20hide%20command%2C%20or%20add%20a%20button%20to%20close%20them%3F%22%2C%20%22created_at%22%3A%20%222015-12-05T21%3A11%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20I%20need%20to%20think%20of%20a%20good%20way%20to%20do%20this%2C%20somehow%20integrating%20with%20the%20existing%20ESC%20handling%20%28which%20can%20be%20improved%29.%20I%20guess%20for%20now%2C%20it%20might%20be%20nice%20to%20hide%20the%20old%20highlights%20as%20soon%20as%20open%20a%20query%20prompt%3F%20Or%20would%20you%20prefer%20a%20separate%20shortcut%3F%22%2C%20%22created_at%22%3A%20%222015-12-05T21%3A17%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sounds%20good%20for%20the%20moment.%22%2C%20%22created_at%22%3A%20%222015-12-05T21%3A18%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/245#issuecomment-162119721'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> We should also figure out a good way to remove the highlights. I experimented with the code a bit and it was a bit annoying to have to execute another command in order to hide things. Or did I miss something?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Well, that's true. We can either have a hide command, or add a button to close them?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, I need to think of a good way to do this, somehow integrating with the existing ESC handling (which can be improved). I guess for now, it might be nice to hide the old highlights as soon as open a query prompt? Or would you prefer a separate shortcut?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Sounds good for the moment.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/245?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/245?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/245'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
