### PR TITLE
Rename methods to avoid lexical overlap with stdio macros

### DIFF
--- a/Core/src/global.cpp
+++ b/Core/src/global.cpp
@@ -26,23 +26,23 @@
 
 #include "precompiled.h"
 
-QString SystemCommandResult::stdoutOneLine() const {
-	Q_ASSERT(stdout_.size() == 1);
-	return stdout_.first();
+QString SystemCommandResult::standardoutOneLine() const {
+	Q_ASSERT(standardout_.size() == 1);
+	return standardout_.first();
 }
 
 SystemCommandResult::operator QString() const
 {
 	Q_ASSERT(exitCode() == 0);
-	Q_ASSERT(stderr_.size() == 0);
-	return stdoutOneLine();
+	Q_ASSERT(standarderr_.size() == 0);
+	return standardoutOneLine();
 }
 
 SystemCommandResult::operator QStringList() const
 {
 	Q_ASSERT(exitCode() == 0);
-	Q_ASSERT(stderr_.size() == 0);
-	return stdout_;
+	Q_ASSERT(standarderr_.size() == 0);
+	return standardout_;
 }
 
 SystemCommandResult runSystemCommand(const QString& program, const QStringList& arguments,
@@ -60,10 +60,10 @@ SystemCommandResult runSystemCommand(const QString& program, const QStringList& 
 	result.exitCode_ = process.exitCode();
 
 	auto EOLRegex = QRegularExpression("(\\r\\n|\\r|\\n)");
-	result.stdout_ = QString(process.readAllStandardOutput()).split(EOLRegex);
-	if (!result.stdout_.isEmpty() && result.stdout_.last().isEmpty())  result.stdout_.removeLast();
-	result.stderr_ = QString(process.readAllStandardError()).split(EOLRegex);
-	if (!result.stderr_.isEmpty() && result.stderr_.last().isEmpty())  result.stderr_.removeLast();
+	result.standardout_ = QString(process.readAllStandardOutput()).split(EOLRegex);
+	if (!result.standardout_.isEmpty() && result.standardout_.last().isEmpty())  result.standardout_.removeLast();
+	result.standarderr_ = QString(process.readAllStandardError()).split(EOLRegex);
+	if (!result.standarderr_.isEmpty() && result.standarderr_.last().isEmpty())  result.standarderr_.removeLast();
 
 	return result;
 }

--- a/Core/src/global.h
+++ b/Core/src/global.h
@@ -63,9 +63,9 @@ inline OnScopeExit::~OnScopeExit() { functionToCall_(); }
 class SystemCommandResult {
 	public:
 		int exitCode() const;
-		QStringList stdout() const;
-		QString stdoutOneLine() const;
-		QStringList stderr() const;
+		QStringList standardout() const;
+		QString standardoutOneLine() const;
+		QStringList standarderr() const;
 
 		operator QString() const;
 		operator QStringList() const;
@@ -75,13 +75,13 @@ class SystemCommandResult {
 																  const QString& workingDirectory);
 
 		int exitCode_{};
-		QStringList stdout_;
-		QStringList stderr_;
+		QStringList standardout_;
+		QStringList standarderr_;
 };
 
 inline int SystemCommandResult::exitCode() const { return exitCode_; }
-inline QStringList SystemCommandResult::stdout() const { return stdout_; }
-inline QStringList SystemCommandResult::stderr() const { return stderr_; }
+inline QStringList SystemCommandResult::standardout() const { return standardout_; }
+inline QStringList SystemCommandResult::standarderr() const { return standarderr_; }
 
 SystemCommandResult runSystemCommand(const QString& program, const QStringList& arguments = {},
 												 const QString& workingDirectory = {});

--- a/FilePersistence/src/version_control/GitPiecewiseLoader.cpp
+++ b/FilePersistence/src/version_control/GitPiecewiseLoader.cpp
@@ -40,12 +40,12 @@ NodeData GitPiecewiseLoader::loadNodeData(Model::NodeIdType id)
 	auto result = runSystemCommand("git", {"grep", "-G", regEx, revision_}, workDir_);
 
 	Q_ASSERT(result.exitCode() == 0);
-	Q_ASSERT(!result.stdout().isEmpty());
+	Q_ASSERT(!result.standardout().isEmpty());
 
-	Q_ASSERT(result.stdout().size() == 1 ||
-				result.stdout().size() == 2);
+	Q_ASSERT(result.standardout().size() == 1 ||
+				result.standardout().size() == 2);
 
-	for (auto line : result.stdout())
+	for (auto line : result.standardout())
 	{
 		if (!isPersistenceUnit(line))
 			return parseGrepLine(line);
@@ -59,11 +59,11 @@ QList<NodeData> GitPiecewiseLoader::loadNodeChildrenData(Model::NodeIdType id)
 	auto result = runSystemCommand("git", {"grep", "-G", regEx, revision_}, workDir_);
 
 	Q_ASSERT(result.exitCode() == 0 || result.exitCode() == 1);
-	Q_ASSERT(result.stderr().isEmpty());
+	Q_ASSERT(result.standarderr().isEmpty());
 
 	QList<NodeData> children;
 
-	for (auto line : result.stdout())
+	for (auto line : result.standardout())
 	{
 		if (!isPersistenceUnit(line))
 		{


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/276?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/276'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
