### PR TITLE
WIP: Cpp Import/Export

### DIFF
--- a/CppExport/src/visitors/DeclarationVisitor.cpp
+++ b/CppExport/src/visitors/DeclarationVisitor.cpp
@@ -499,8 +499,10 @@ SourceFragment* DeclarationVisitor::compositeNodeComments(Model::CompositeNode* 
 	if (auto commentNode = DCast<Comments::CommentNode>(compositeNode->comment()))
 	{
 		auto commentFragment = new CompositeFragment{commentNode->lines(), style};
+		*commentFragment << "/**";
 		for (auto line : *(commentNode->lines()))
-			*commentFragment << line;
+			*commentFragment << " * " + line->get();
+		*commentFragment << " */";
 		return commentFragment;
 	}
 

--- a/CppExport/src/visitors/ElementVisitor.cpp
+++ b/CppExport/src/visitors/ElementVisitor.cpp
@@ -121,6 +121,11 @@ SourceFragment* ElementVisitor::visit(CatchClause* catchClause)
 SourceFragment* ElementVisitor::visit(Enumerator* enumerator)
 {
 	auto fragment = new CompositeFragment{enumerator};
+
+	auto commentNode = DCast<Comments::CommentNode>(enumerator->comment());
+	if (commentNode && commentNode->lines()->size() > 1)
+		*fragment << DeclarationVisitor::compositeNodeComments(enumerator, "declarationComment");
+
 	*fragment << enumerator->name();
 	if (auto value = enumerator->value())
 		*fragment << " = " << expression(value);
@@ -130,7 +135,8 @@ SourceFragment* ElementVisitor::visit(Enumerator* enumerator)
 		if (parentList->last() != enumerator)
 			*fragment << ",";
 
-	*fragment << DeclarationVisitor::compositeNodeComments(enumerator, "");
+	if (commentNode && commentNode->lines()->size() == 1)
+		*fragment << "/**< " + commentNode->lines()->first()->get() + " */";
 
 	return fragment;
 }

--- a/CppExport/src/visitors/StatementVisitor.cpp
+++ b/CppExport/src/visitors/StatementVisitor.cpp
@@ -264,7 +264,7 @@ SourceFragment* StatementVisitor::visit(OOModel::CommentStatementItem* statement
 {
 	auto fragment = new CompositeFragment{statement, "sections"};
 	for (auto line : *statement->commentNode()->lines())
-		*fragment << line;
+		*fragment << "// " + line->get();
 	return fragment;
 }
 

--- a/CppImport/src/ClangHelpers.h
+++ b/CppImport/src/ClangHelpers.h
@@ -181,12 +181,12 @@ inline NodeType* ClangHelpers::createNamedNode(clang::NamedDecl* namedDecl, Cons
 	 */
 	if (auto compositeNode = DCast<Model::CompositeNode>(namedNode))
 		if (auto commentForDeclaration = namedDecl->getASTContext().getRawCommentForDeclNoCache(namedDecl))
-		{
-			auto lines = QString::fromStdString(commentForDeclaration->getRawText(*sourceManager_).str()).split('\n');
-			for (auto i = 0; i < lines.length(); i++)
-				lines[i] = lines[i].trimmed();
-			compositeNode->setComment(new Comments::CommentNode{lines.join('\n')});
-		}
+			for (Comment* comment : comments_)
+				if (comment->rawComment() == commentForDeclaration && !comment->node())
+				{
+					comment->setNode(namedNode);
+					compositeNode->setComment(new Comments::CommentNode{comment->text()});
+				}
 	return namedNode;
 }
 

--- a/CppImport/src/Comment.cpp
+++ b/CppImport/src/Comment.cpp
@@ -80,7 +80,7 @@ QString Comment::text()
 	auto lines = text_.split('\n');
 	if (!lines.first().startsWith("/*"))
 	{
-		QRegularExpression singleLineRegex{"^\\s*//\\s*([^\\s].*)$"};
+		static QRegularExpression singleLineRegex{"^\\s*//\\s*([^\\s].*)$"};
 		for (auto i = 0; i < lines.size(); i++)
 		{
 			auto match = singleLineRegex.match(lines[i]);
@@ -89,18 +89,18 @@ QString Comment::text()
 	}
 	else
 	{
-		QRegularExpression firstLineRegex{"^/\\*+<?\\s?(.*)$"};
+		static QRegularExpression firstLineRegex{"^/\\*+<?\\s?(.*)$"};
 		auto match = firstLineRegex.match(lines.first());
 		if (match.hasMatch()) lines[0] = match.captured(1);
 
-		QRegularExpression middleLineRegex{"^\\s*\\*\\s(.*)$"};
+		static QRegularExpression middleLineRegex{"^\\s*\\*\\s(.*)$"};
 		for (auto i = 1; i < lines.size(); i++)
 		{
 			match = middleLineRegex.match(lines[i]);
 			if (match.hasMatch()) lines[i] = match.captured(1);
 		}
 
-		QRegularExpression lastLineRegex{"^(.*)\\*/\\s*$"};
+		static QRegularExpression lastLineRegex{"^(.*)\\*/\\s*$"};
 		match = lastLineRegex.match(lines.last());
 		if (match.hasMatch())
 		{

--- a/CppImport/src/Comment.cpp
+++ b/CppImport/src/Comment.cpp
@@ -80,7 +80,7 @@ QString Comment::text()
 	auto lines = text_.split('\n');
 	if (!lines.first().startsWith("/*"))
 	{
-		static QRegularExpression singleLineRegex{"^\\s*//\\s*([^\\s].*)$"};
+		static QRegularExpression singleLineRegex{"^\\s*//\\s?(.*)$"};
 		for (auto i = 0; i < lines.size(); i++)
 		{
 			auto match = singleLineRegex.match(lines[i]);

--- a/CppImport/src/Comment.cpp
+++ b/CppImport/src/Comment.cpp
@@ -100,7 +100,7 @@ QString Comment::text()
 			if (match.hasMatch()) lines[i] = match.captured(1);
 		}
 
-		static QRegularExpression lastLineRegex{"^(.*)\\*/\\s*$"};
+		static QRegularExpression lastLineRegex{"(.*(^|[^\\*]))\\*+/\\s*$"};
 		match = lastLineRegex.match(lines.last());
 		if (match.hasMatch())
 		{

--- a/CppImport/src/Comment.cpp
+++ b/CppImport/src/Comment.cpp
@@ -80,7 +80,7 @@ QString Comment::text()
 	auto lines = text_.split('\n');
 	if (!lines.first().startsWith("/*"))
 	{
-		QRegularExpression singleLineRegex{"^\\s*//\\s*([^\\s].*)$", QRegularExpression::DotMatchesEverythingOption};
+		QRegularExpression singleLineRegex{"^\\s*//\\s*([^\\s].*)$"};
 		for (auto i = 0; i < lines.size(); i++)
 		{
 			auto match = singleLineRegex.match(lines[i]);
@@ -89,18 +89,18 @@ QString Comment::text()
 	}
 	else
 	{
-		QRegularExpression firstLineRegex{"^/\\*+<?\\s?(.*)$", QRegularExpression::DotMatchesEverythingOption};
+		QRegularExpression firstLineRegex{"^/\\*+<?\\s?(.*)$"};
 		auto match = firstLineRegex.match(lines.first());
 		if (match.hasMatch()) lines[0] = match.captured(1);
 
-		QRegularExpression middleLineRegex{"^\\s*\\*\\s(.*)$", QRegularExpression::DotMatchesEverythingOption};
+		QRegularExpression middleLineRegex{"^\\s*\\*\\s(.*)$"};
 		for (auto i = 1; i < lines.size(); i++)
 		{
 			match = middleLineRegex.match(lines[i]);
 			if (match.hasMatch()) lines[i] = match.captured(1);
 		}
 
-		QRegularExpression lastLineRegex{"^(.*)\\*/\\s*$", QRegularExpression::DotMatchesEverythingOption};
+		QRegularExpression lastLineRegex{"^(.*)\\*/\\s*$"};
 		match = lastLineRegex.match(lines.last());
 		if (match.hasMatch())
 		{


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/310%23discussion_r52727014%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/310%23discussion_r52727358%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/310%23issuecomment-183281469%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20b9729bb5ba9e96b53c2d98bc160755528748d42e%20CppImport/src/Comment.cpp%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/310%23discussion_r52727014%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20the%20second%20%60%5C%5Cs%2A%60%20%3F%20Shouldn%27t%20that%20be%20just%20%60%5C%5Cs%3F%60%20And%20why%20not%20simply%20%60%28.%2A%29%24%60%20afterwards%3F%5Cr%5Cn%5Cr%5CnAnd%20do%20you%20need%20the%20%60DotMatchesEverythingOption%60%3F%20Isn%27t%20that%20just%20in%20the%20case%20where%20you%20want%20the%20%60.%60%20to%20match%20new%20lines%3F%20Do%20we%20care%20about%20that%3F%22%2C%20%22created_at%22%3A%20%222016-02-12T10%3A45%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppImport/src/Comment.cpp%3AL78-119%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/310%23issuecomment-183281469%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222016-02-12T11%3A14%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6049349%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/patrick-luethi%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20b9729bb5ba9e96b53c2d98bc160755528748d42e%20CppImport/src/Comment.cpp%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/310%23discussion_r52727358%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20am%20not%20sure%20this%20handles%20the%20%60%2A%2A%2A%2A%2A%2A%2A%2A%2A%2A/%60%20case.%20We%20need%20to%20have%20%60%5C%5C%5C%5C%2A%2B%60%20but%20for%20this%20to%20work%20it%20needs%20to%20be%20preceeded%20by%20something%20that%20is%20not%20a%20%60%2A%60.%20Could%20you%20adjust%20the%20regex%20accordingly%3F%22%2C%20%22created_at%22%3A%20%222016-02-12T10%3A48%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CppImport/src/Comment.cpp%3AL78-119%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull b9729bb5ba9e96b53c2d98bc160755528748d42e CppImport/src/Comment.cpp 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/310#discussion_r52727014'>File: CppImport/src/Comment.cpp:L78-119</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> why the second `\s*` ? Shouldn't that be just `\s?` And why not simply `(.*)$` afterwards?
  And do you need the `DotMatchesEverythingOption`? Isn't that just in the case where you want the `.` to match new lines? Do we care about that?
- [ ] <a href='#crh-comment-Pull b9729bb5ba9e96b53c2d98bc160755528748d42e CppImport/src/Comment.cpp 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/310#discussion_r52727358'>File: CppImport/src/Comment.cpp:L78-119</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I am not sure this handles the `**********/` case. We need to have `\\*+` but for this to work it needs to be preceeded by something that is not a `*`. Could you adjust the regex accordingly?
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/310#issuecomment-183281469'>General Comment</a></b>
- <a href='https://github.com/patrick-luethi'><img border=0 src='https://avatars.githubusercontent.com/u/6049349?v=3' height=16 width=16'></a> done

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/310?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/310?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/310'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
