### PR TITLE
vera++ Ignore license not found in precompiled.cpp files

### DIFF
--- a/checkers/vera++-check-dir
+++ b/checkers/vera++-check-dir
@@ -35,6 +35,7 @@ find "$1" -path "$1"/qt -prune -o -name '*.h' -print -o -name '*.cpp' -print \
 | vera++ $RULES $PARAMS --error 2>&1\
 | grep -v "keyword 'delete' not followed by a single space" \
 | grep -v "/AstApi_Generated\.cpp.*source file is too long" \
+| grep -v "precompiled_cpp\.cpp:.* no copyright notice found" \
 | grep -v "/declarative/AnchorLayoutFormElement\.h.*using namespace not allowed in header file" 1>&2
 
 if (($? > 0)); then


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/349%23issuecomment-198249906%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/349%23issuecomment-198257148%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/349%23issuecomment-198257749%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/349%23issuecomment-198259461%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/349%23issuecomment-198260202%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/349%23issuecomment-198497355%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/349%23issuecomment-198877992%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/349%23issuecomment-198881398%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/349%23issuecomment-198978746%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/349%23issuecomment-198249906%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20please%20explain%2C%20why%20you%20feel%20we%20need%20this%3F%22%2C%20%22created_at%22%3A%20%222016-03-18T08%3A25%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Because%20vera%2B%2B%20complained%20that%20the%20license%20is%20missing%20in%20these%20files%2C%20and%20AFAIK%20they%20are%20generated%20so%20it%20doesn%27t%20make%20sense%20to%20check%20the%20license%20in%20those%20files%3F%22%2C%20%22created_at%22%3A%20%222016-03-18T08%3A41%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22They%20are%20generated%2C%20but%20it%20never%20complained%20to%20me.%20That%27s%20strange.%20What%20do%20you%20do%20to%20actually%20get%20this%20error%3F%22%2C%20%22created_at%22%3A%20%222016-03-18T08%3A44%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%27s%20true%20I%20never%20had%20this%20on%20my%20home%20machine.%20On%20my%20laptop%20it%20was%20more%20or%20less%20the%20first%20time%20I%20tried%20to%20compile%20it%20and%20it%20would%20complain.%20So%20maybe%20it%20only%20appears%20on%20fresh%20installs%3F%22%2C%20%22created_at%22%3A%20%222016-03-18T08%3A47%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20must%20be%20something%20else%2C%20as%20I%27ve%20done%20a%20bunch%20of%20fresh%20installs%20on%20my%20own%20and%20also%20for%20students.%20We%27ve%20used%20vera%2B%2B%20for%20a%20few%20years%20now.%5Cr%5Cn%5Cr%5CnCould%20it%20be%20that%20your%20laptop%20has%20a%20very%20new%20version%20of%20vera%2B%2B%20that%20changed%20the%20behavior%3F%22%2C%20%22created_at%22%3A%20%222016-03-18T08%3A48%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20I%20just%20checked%20again%2C%20this%20is%20the%20error%20message%3A%5Cr%5Cn%60/home/luke/Programming/Envision/InformationScripting/precompiled_cpp.cpp%3A1%3A%20error%3A%20no%20copyright%20notice%20found%5Cr%5CnInformationScripting/CMakeFiles/InformationScripting.dir/build.make%3A1687%3A%20recipe%20for%20target%20%27InformationScripting/libInformationScripting.so%27%20failed%5Cr%5CnCMakeFiles/Makefile2%3A3453%3A%20recipe%20for%20target%20%27InformationScripting/CMakeFiles/InformationScripting.dir/all%27%20failed%5Cr%5CnMakefile%3A127%3A%20recipe%20for%20target%20%27all%27%20failed%5Cr%5Cnmake%5B2%5D%3A%20%2A%2A%2A%20%5BInformationScripting/libInformationScripting.so%5D%20Error%201%5Cr%5Cnmake%5B1%5D%3A%20%2A%2A%2A%20%5BInformationScripting/CMakeFiles/InformationScripting.dir/all%5D%20Error%202%5Cr%5Cnmake%3A%20%2A%2A%2A%20%5Ball%5D%20Error%202%5Cr%5Cn19%3A56%3A36%3A%20The%20process%20%5C%22/usr/bin/make%5C%22%20exited%20with%20code%202.%5Cr%5CnError%20while%20building/deploying%20project%20Project%20%28kit%3A%20Clang%29%60%5Cr%5Cn%5Cr%5Cn%60vera%2B%2B%20--version%5Cr%5Cn1.2.1%5Cr%5Cn%60%22%2C%20%22created_at%22%3A%20%222016-03-18T19%3A04%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20I%20see%20the%20problem.%20You%20must%20have%20run%20CMake%20directly%20in%20Envision%27s%20folder%20and%20so%20all%20the%20generated%20CMake%20files%20ended%20up%20in%20there%20and%20vera%2B%2B%20checks%20them%20as%20well.%20I%20think%20we%20should%20discourage%20in-source-builds%20%28is%20the%20that%20right%20opposite%20of%20out-of-source%20build%3F%29%20since%20they%20are%20generally%20messy%2C%20so%20I%20guess%20we%20shouldn%27t%20make%20the%20error%20go%20away.%20Or%20do%20you%20think%20that%20this%20is%20not%20right%3F%5Cr%5Cn%5Cr%5CnIn%20the%20ideal%20case%20we%20would%20prevent%20in-source-builds%20altogether.%22%2C%20%22created_at%22%3A%20%222016-03-20T09%3A11%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20just%20pushed%20a%20change%20that%20prevents%20in-source-builds.%20It%20seems%20like%20there%20is%20on%20way%20to%20do%20this%20without%20generating%20any%20files%20%28see%20the%20changed%20%60CMakeFiles.txt%60%20for%20more%20info%29%20but%20I%20think%20the%20current%20version%20is%20OK.%20Let%20me%20know%20what%20you%20think.%22%2C%20%22created_at%22%3A%20%222016-03-20T09%3A26%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ugh%20ohh%2C%20sorry%20for%20that.%20I%20probably%20have%20run%20cmake%20previously%20in%20the%20source%20directory%2C%20so%20the%20generated%20precompiled%20files%20and%20a%20bunch%20of%20other%20stuff%20remained%20in%20the%20source%20directory.%20After%20removing%20everything%2C%20vera%2B%2B%20didn%27t%20complain%2C%20without%20this%20patch.%22%2C%20%22created_at%22%3A%20%222016-03-20T18%3A19%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/349#issuecomment-198249906'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Could you please explain, why you feel we need this?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Because vera++ complained that the license is missing in these files, and AFAIK they are generated so it doesn't make sense to check the license in those files?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> They are generated, but it never complained to me. That's strange. What do you do to actually get this error?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> That's true I never had this on my home machine. On my laptop it was more or less the first time I tried to compile it and it would complain. So maybe it only appears on fresh installs?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> It must be something else, as I've done a bunch of fresh installs on my own and also for students. We've used vera++ for a few years now.
  Could it be that your laptop has a very new version of vera++ that changed the behavior?
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> So I just checked again, this is the error message:
  `/home/luke/Programming/Envision/InformationScripting/precompiled_cpp.cpp:1: error: no copyright notice found
  InformationScripting/CMakeFiles/InformationScripting.dir/build.make:1687: recipe for target 'InformationScripting/libInformationScripting.so' failed
  CMakeFiles/Makefile2:3453: recipe for target 'InformationScripting/CMakeFiles/InformationScripting.dir/all' failed
  Makefile:127: recipe for target 'all' failed
  make[2]: *** [InformationScripting/libInformationScripting.so] Error 1
  make[1]: *** [InformationScripting/CMakeFiles/InformationScripting.dir/all] Error 2
  make: *** [all] Error 2
  19:56:36: The process "/usr/bin/make" exited with code 2.
  Error while building/deploying project Project (kit: Clang)`
  `vera++ --version
  1.2.1
  `
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> OK, I see the problem. You must have run CMake directly in Envision's folder and so all the generated CMake files ended up in there and vera++ checks them as well. I think we should discourage in-source-builds (is the that right opposite of out-of-source build?) since they are generally messy, so I guess we shouldn't make the error go away. Or do you think that this is not right?
  In the ideal case we would prevent in-source-builds altogether.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I just pushed a change that prevents in-source-builds. It seems like there is on way to do this without generating any files (see the changed `CMakeFiles.txt` for more info) but I think the current version is OK. Let me know what you think.
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> Ugh ohh, sorry for that. I probably have run cmake previously in the source directory, so the generated precompiled files and a bunch of other stuff remained in the source directory. After removing everything, vera++ didn't complain, without this patch.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/349?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/349?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/349'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
