### PR TITLE
Extending changes query

### DIFF
--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -83,7 +83,7 @@ Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet input)
 		QString oldCommitId = commitIdRange[i];
 		QString newCommitId = commitIdRange[i - 1];
 
-		Diff diff = repository.diff(newCommitId, oldCommitId);
+		Diff diff = repository.diff(oldCommitId, newCommitId);
 		auto changes = diff.changes();
 
 		if (!outputNodesOnly)

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -114,7 +114,27 @@ Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet input)
 						changedNode = *ancestorIt;
 
 					if (outputNodesOnly)
+					{
 						result.add({{"ast", changedNode}});
+						switch (change->type())
+						{
+							case ChangeType::Deletion:
+								result.add({"color", {{"ast", changedNode}, {"color", QString{"red"}}}});
+								break;
+							case ChangeType::Insertion:
+								result.add({"color", {{"ast", changedNode}, {"color", QString{"blue"}}}});
+								break;
+							case ChangeType::Move:
+								result.add({"color", {{"ast", changedNode}, {"color", QString{"yellow"}}}});
+								break;
+							case ChangeType::Stationary:
+								result.add({"color", {{"ast", changedNode}, {"color", QString{"black"}}}});
+								break;
+							case ChangeType::Unclassified:
+								result.add({"color", {{"ast", changedNode}, {"color", QString{"white"}}}});
+								break;
+						}
+					}
 					else
 						result.add({"change", {{"id", newCommitId}, {"ast", changedNode}}});
 				}

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -46,6 +46,8 @@ const QStringList VersionControlQuery::COUNT_ARGUMENT_NAMES{"c", "count"};
 const QStringList VersionControlQuery::NODE_TYPE_ARGUMENT_NAMES{"t", "type"};
 const QStringList VersionControlQuery::NODES_ARGUMENTS_NAMES{"nodes"};
 const QStringList VersionControlQuery::IN_ARGUMENT_NAMES{"in"};
+const QStringList VersionControlQuery::TWO_VERSION_ARGUMENT_NAMES{"two"};
+const QStringList VersionControlQuery::TYPED_CHANGES_ARGUMENT_NAMES{"tc", "typed_changes"};
 
 Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet input)
 {
@@ -63,6 +65,12 @@ Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet input)
 	if (!adaptedRangeOptional)
 		return adaptedRangeOptional.errors()[0];
 	commitIdRange = adaptedRangeOptional.value();
+
+	// if argument is set, check that commitIdRange only contains two commitIds
+	if (arguments_.isArgumentSet(TWO_VERSION_ARGUMENT_NAMES[0]) && commitIdRange.size() > 2)
+	{
+		commitIdRange = QStringList{commitIdRange.first(), commitIdRange.last()};
+	}
 
 	QList<Model::Node*> nodesToLookAt;
 
@@ -114,8 +122,13 @@ Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet input)
 						changedNode = *ancestorIt;
 
 					if (outputNodesOnly)
-					{
 						result.add({{"ast", changedNode}});
+
+					else
+						result.add({"change", {{"id", newCommitId}, {"ast", changedNode}}});
+
+					if (arguments_.isArgumentSet(TYPED_CHANGES_ARGUMENT_NAMES[0]))
+					{
 						QString color;
 						QString change_type;
 						switch (change->type())
@@ -148,8 +161,6 @@ Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet input)
 						result.add({"color", {{"ast", changedNode}, {"color", color}}});
 						result.add({"change_typed", {{"ast", changedNode}, {"type", change_type}}});
 					}
-					else
-						result.add({"change", {{"id", newCommitId}, {"ast", changedNode}}});
 				}
 			}
 		}
@@ -162,7 +173,9 @@ void VersionControlQuery::registerDefaultQueries()
 {
 	QueryRegistry::registerQuery<VersionControlQuery>("changes",
 		std::vector<ArgumentRule>{{ArgumentRule::AtMostOneOf, {{COUNT_ARGUMENT_NAMES[1], ArgumentValue::IsSet},
-												{IN_ARGUMENT_NAMES[0], ArgumentValue::IsSet}}}});
+												{IN_ARGUMENT_NAMES[0], ArgumentValue::IsSet}}},
+										  {ArgumentRule::AtMostOneOf, {{NODES_ARGUMENTS_NAMES[0], ArgumentValue::IsSet},
+												{TYPED_CHANGES_ARGUMENT_NAMES[0], ArgumentValue::IsSet}}}});
 }
 
 VersionControlQuery::VersionControlQuery(Model::Node* target, QStringList args, std::vector<ArgumentRule> argumentRules)
@@ -170,7 +183,12 @@ VersionControlQuery::VersionControlQuery(Model::Node* target, QStringList args, 
 		{COUNT_ARGUMENT_NAMES, "The amount of revisions to look at", COUNT_ARGUMENT_NAMES[1], "10"},
 		{NODE_TYPE_ARGUMENT_NAMES, "The minimum type of the nodes returned", NODE_TYPE_ARGUMENT_NAMES[1], "StatementItem"},
 		QCommandLineOption{NODES_ARGUMENTS_NAMES},
-		{IN_ARGUMENT_NAMES, "Specific commits to look at, either a single one or a range with ..", IN_ARGUMENT_NAMES[0]}
+		{IN_ARGUMENT_NAMES, "Specific commits to look at, either a single one or a range with ..", IN_ARGUMENT_NAMES[0]},
+		QCommandLineOption{TWO_VERSION_ARGUMENT_NAMES, "Only use the first and last commit to compute the changes"},
+		QCommandLineOption{TYPED_CHANGES_ARGUMENT_NAMES, 	"Add the type (Delete, Insertion, Move, Stationary, "
+																			"Unclassified) of the changes to the result and define a "
+																			"color for the nodes according to the type"}
+
 }, args, true}
 {
 	for (const auto& rule : argumentRules)

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -116,34 +116,37 @@ Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet input)
 					if (outputNodesOnly)
 					{
 						result.add({{"ast", changedNode}});
+						QString color;
+						QString change_type;
 						switch (change->type())
 						{
 							case ChangeType::Deletion:
-								result.add({"color", {{"ast", changedNode}, {"color", QString{"red"}}}});
-								result.add({"change", {{"id", newCommitId}, {"ast", changedNode},
-															  {"type", QString{"Delete"}}}});
+								color = "red";
+								change_type = "Delete";
 								break;
 							case ChangeType::Insertion:
-								result.add({"color", {{"ast", changedNode}, {"color", QString{"blue"}}}});
-								result.add({"change", {{"id", newCommitId}, {"ast", changedNode},
-															  {"type", QString{"Insertion"}}}});
+								color = "blue";
+								change_type = "Insertion";
 								break;
 							case ChangeType::Move:
-								result.add({"color", {{"ast", changedNode}, {"color", QString{"yellow"}}}});
-								result.add({"change", {{"id", newCommitId}, {"ast", changedNode},
-															  {"type", QString{"Move"}}}});
+								color = "yellow";
+								change_type = "Move";
 								break;
 							case ChangeType::Stationary:
-								result.add({"color", {{"ast", changedNode}, {"color", QString{"black"}}}});
-								result.add({"change", {{"id", newCommitId}, {"ast", changedNode},
-															  {"type", QString{"Stationary"}}}});
+								color = "black";
+								change_type = "Stationary";
 								break;
 							case ChangeType::Unclassified:
-								result.add({"color", {{"ast", changedNode}, {"color", QString{"white"}}}});
-								result.add({"change", {{"id", newCommitId}, {"ast", changedNode},
-															  {"type", QString{"Unclassified"}}}});
+								color = "white";
+								change_type = "Unclassified";
 								break;
+							default:
+								// TODO throw exception?
+								color = "";
+								change_type = "unhandled_type";
 						}
+						result.add({"color", {{"ast", changedNode}, {"color", color}}});
+						result.add({"change_typed", {{"ast", changedNode}, {"type", change_type}}});
 					}
 					else
 						result.add({"change", {{"id", newCommitId}, {"ast", changedNode}}});

--- a/InformationScripting/src/queries/VersionControlQuery.cpp
+++ b/InformationScripting/src/queries/VersionControlQuery.cpp
@@ -120,18 +120,28 @@ Optional<TupleSet> VersionControlQuery::executeLinear(TupleSet input)
 						{
 							case ChangeType::Deletion:
 								result.add({"color", {{"ast", changedNode}, {"color", QString{"red"}}}});
+								result.add({"change", {{"id", newCommitId}, {"ast", changedNode},
+															  {"type", QString{"Delete"}}}});
 								break;
 							case ChangeType::Insertion:
 								result.add({"color", {{"ast", changedNode}, {"color", QString{"blue"}}}});
+								result.add({"change", {{"id", newCommitId}, {"ast", changedNode},
+															  {"type", QString{"Insertion"}}}});
 								break;
 							case ChangeType::Move:
 								result.add({"color", {{"ast", changedNode}, {"color", QString{"yellow"}}}});
+								result.add({"change", {{"id", newCommitId}, {"ast", changedNode},
+															  {"type", QString{"Move"}}}});
 								break;
 							case ChangeType::Stationary:
 								result.add({"color", {{"ast", changedNode}, {"color", QString{"black"}}}});
+								result.add({"change", {{"id", newCommitId}, {"ast", changedNode},
+															  {"type", QString{"Stationary"}}}});
 								break;
 							case ChangeType::Unclassified:
 								result.add({"color", {{"ast", changedNode}, {"color", QString{"white"}}}});
+								result.add({"change", {{"id", newCommitId}, {"ast", changedNode},
+															  {"type", QString{"Unclassified"}}}});
 								break;
 						}
 					}

--- a/InformationScripting/src/queries/VersionControlQuery.h
+++ b/InformationScripting/src/queries/VersionControlQuery.h
@@ -58,6 +58,8 @@ class INFORMATIONSCRIPTING_API VersionControlQuery : public LinearQuery
 		static const QStringList NODE_TYPE_ARGUMENT_NAMES;
 		static const QStringList NODES_ARGUMENTS_NAMES;
 		static const QStringList IN_ARGUMENT_NAMES;
+		static const QStringList TWO_VERSION_ARGUMENT_NAMES;
+		static const QStringList TYPED_CHANGES_ARGUMENT_NAMES;
 
 		VersionControlQuery(Model::Node* target, QStringList args, std::vector<ArgumentRule> argumentRules);
 

--- a/InformationScripting/src/query_framework/QueryResultVisualizer.cpp
+++ b/InformationScripting/src/query_framework/QueryResultVisualizer.cpp
@@ -121,6 +121,22 @@ Optional<int> QueryResultVisualizer::visualize(const TupleSet& ts)
 		}
 	}
 
+	for (auto changeTuple : ts.tuples("change"))
+	{
+		Model::Node* node = changeTuple["ast"];
+		qDebug() << node->typeName();
+		if (node->typeName() != "Class" && node->typeName() != "Method" && node->typeName() != "ExpressionStatement")
+			continue;
+		auto nodeVisualizationIt = Visualization::Item::nodeItemsMap().find(node);
+		while (nodeVisualizationIt != Visualization::Item::nodeItemsMap().end() && nodeVisualizationIt.key() == node)
+		{
+			auto item = *nodeVisualizationIt++;
+			auto overlay = item->overlay<HighlightOverlay>();
+
+			overlay->setText(changeTuple["type"].toString());
+		};
+	}
+
 	auto htmlTuples = ts.tuples("html");
 	if (htmlTuples.size()) {
 		QString htmlContent = (*htmlTuples.begin())["html"];

--- a/InformationScripting/src/query_framework/QueryResultVisualizer.cpp
+++ b/InformationScripting/src/query_framework/QueryResultVisualizer.cpp
@@ -29,6 +29,10 @@
 #include "ModelBase/src/nodes/Node.h"
 
 #include "OOModel/src/declarations/Declaration.h"
+#include "OOModel/src/declarations/Method.h"
+#include "OOModel/src/declarations/Class.h"
+#include	"OOModel/src/statements/Statement.h"
+#include	"OOModel/src/expressions/Expression.h"
 
 #include "VisualizationBase/src/Scene.h"
 #include "VisualizationBase/src/items/Item.h"
@@ -121,20 +125,23 @@ Optional<int> QueryResultVisualizer::visualize(const TupleSet& ts)
 		}
 	}
 
-	for (auto changeTuple : ts.tuples("change"))
+	for (auto changeTuple : ts.tuples("change_typed"))
 	{
 		Model::Node* node = changeTuple["ast"];
-		qDebug() << node->typeName();
-		if (node->typeName() != "Class" && node->typeName() != "Method" && node->typeName() != "ExpressionStatement")
-			continue;
-		auto nodeVisualizationIt = Visualization::Item::nodeItemsMap().find(node);
-		while (nodeVisualizationIt != Visualization::Item::nodeItemsMap().end() && nodeVisualizationIt.key() == node)
-		{
-			auto item = *nodeVisualizationIt++;
-			auto overlay = item->overlay<HighlightOverlay>();
 
-			overlay->setText(changeTuple["type"].toString());
-		};
+		// TODO check what is really needed
+		if (DCast<OOModel::Class>(node) || DCast<OOModel::Method>(node) || DCast<OOModel::Expression>(node)
+			 || DCast<OOModel::Statement>(node) || DCast<OOModel::Declaration>(node))
+		{
+			auto nodeVisualizationIt = Visualization::Item::nodeItemsMap().find(node);
+			while (nodeVisualizationIt != Visualization::Item::nodeItemsMap().end() && nodeVisualizationIt.key() == node)
+			{
+				auto item = *nodeVisualizationIt++;
+				auto overlay = item->overlay<HighlightOverlay>();
+
+				overlay->setText(changeTuple["type"].toString());
+			};
+		}
 	}
 
 	auto htmlTuples = ts.tuples("html");

--- a/InformationScripting/src/query_framework/QueryResultVisualizer.cpp
+++ b/InformationScripting/src/query_framework/QueryResultVisualizer.cpp
@@ -129,7 +129,7 @@ Optional<int> QueryResultVisualizer::visualize(const TupleSet& ts)
 	{
 		Model::Node* node = changeTuple["ast"];
 
-		// TODO check what is really needed
+		// TODO check what should be annotated
 		if (DCast<OOModel::Class>(node) || DCast<OOModel::Method>(node) || DCast<OOModel::Expression>(node)
 			 || DCast<OOModel::Statement>(node) || DCast<OOModel::Declaration>(node))
 		{

--- a/InformationScripting/src/query_framework/QueryResultVisualizer.cpp
+++ b/InformationScripting/src/query_framework/QueryResultVisualizer.cpp
@@ -31,8 +31,8 @@
 #include "OOModel/src/declarations/Declaration.h"
 #include "OOModel/src/declarations/Method.h"
 #include "OOModel/src/declarations/Class.h"
-#include	"OOModel/src/statements/Statement.h"
-#include	"OOModel/src/expressions/Expression.h"
+#include "OOModel/src/statements/Statement.h"
+#include "OOModel/src/expressions/Expression.h"
 
 #include "VisualizationBase/src/Scene.h"
 #include "VisualizationBase/src/items/Item.h"


### PR DESCRIPTION
WIP / TODO:
- maybe find better name for the flags
- should -two behaviour be default?
- maybe -tc should be additional option for -nodes flag?
- improve visualization for change_typed in QueryResultVisualizer.cpp
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/350%23discussion_r57123157%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/350%23discussion_r57123187%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/350%23discussion_r57123662%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/350%23discussion_r57123790%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/350%23discussion_r57124050%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/350%23discussion_r57124180%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%208feaaf45b052cee1288bbbe005b82871629549de%20InformationScripting/src/queries/VersionControlQuery.cpp%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/350%23discussion_r57123157%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20in%20general%20it%27s%20not%20that%20great%20if%20this%20query%20does%20too%20much.%20In%20particular%20we%20should%20probably%20make%20it%20just%20output%20the%20type%20of%20change%20as%20string%2C%20and%20leave%20coloring%20to%20another%20query.%22%2C%20%22created_at%22%3A%20%222016-03-23T08%3A27%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/VersionControlQuery.cpp%3AL114-141%22%7D%2C%20%22Pull%208b7d1acec5dba06b92dbfc7a505a9b25b6755f0f%20InformationScripting/src/queries/VersionControlQuery.cpp%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/350%23discussion_r57124180%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22no%20parenthesis%22%2C%20%22created_at%22%3A%20%222016-03-23T08%3A37%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/VersionControlQuery.cpp%3AL66-78%22%7D%2C%20%22Pull%206c9a918f73abb0e85b7f709c8ba1d822d0825b8b%20InformationScripting/src/query_framework/QueryResultVisualizer.cpp%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/350%23discussion_r57123790%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22fix%20spacing%22%2C%20%22created_at%22%3A%20%222016-03-23T08%3A33%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/query_framework/QueryResultVisualizer.cpp%3AL29-39%22%7D%2C%20%22Pull%20438f8f92074f2ea56689a9cb8bb0ac44209acd84%20InformationScripting/src/query_framework/QueryResultVisualizer.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/350%23discussion_r57123662%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20shouldn%27t%20really%20be%20here%2C%20the%20visualizer%20should%20be%20more%20generic.%5Cr%5Cn%5Cr%5CnThat%20also%20applies%20to%20the%20%60calls%60%20handling%20above.%22%2C%20%22created_at%22%3A%20%222016-03-23T08%3A32%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/query_framework/QueryResultVisualizer.cpp%3AL121-143%22%7D%2C%20%22Pull%208feaaf45b052cee1288bbbe005b82871629549de%20InformationScripting/src/queries/VersionControlQuery.cpp%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/350%23discussion_r57123187%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20could%20put%20the%20color%20first%20and%20leave%20the%20tuple%20tag%20implicit.%22%2C%20%22created_at%22%3A%20%222016-03-23T08%3A28%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/VersionControlQuery.cpp%3AL114-141%22%7D%2C%20%22Pull%206c9a918f73abb0e85b7f709c8ba1d822d0825b8b%20InformationScripting/src/queries/VersionControlQuery.cpp%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/350%23discussion_r57124050%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20be%20guarded%20by%20a%20flag.%22%2C%20%22created_at%22%3A%20%222016-03-23T08%3A36%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InformationScripting/src/queries/VersionControlQuery.cpp%3AL116-153%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 8feaaf45b052cee1288bbbe005b82871629549de InformationScripting/src/queries/VersionControlQuery.cpp 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/350#discussion_r57123157'>File: InformationScripting/src/queries/VersionControlQuery.cpp:L114-141</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, in general it's not that great if this query does too much. In particular we should probably make it just output the type of change as string, and leave coloring to another query.
- [ ] <a href='#crh-comment-Pull 8feaaf45b052cee1288bbbe005b82871629549de InformationScripting/src/queries/VersionControlQuery.cpp 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/350#discussion_r57123187'>File: InformationScripting/src/queries/VersionControlQuery.cpp:L114-141</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> We could put the color first and leave the tuple tag implicit.
- [ ] <a href='#crh-comment-Pull 438f8f92074f2ea56689a9cb8bb0ac44209acd84 InformationScripting/src/query_framework/QueryResultVisualizer.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/350#discussion_r57123662'>File: InformationScripting/src/query_framework/QueryResultVisualizer.cpp:L121-143</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This shouldn't really be here, the visualizer should be more generic.
  That also applies to the `calls` handling above.
- [ ] <a href='#crh-comment-Pull 6c9a918f73abb0e85b7f709c8ba1d822d0825b8b InformationScripting/src/query_framework/QueryResultVisualizer.cpp 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/350#discussion_r57123790'>File: InformationScripting/src/query_framework/QueryResultVisualizer.cpp:L29-39</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> fix spacing
- [ ] <a href='#crh-comment-Pull 6c9a918f73abb0e85b7f709c8ba1d822d0825b8b InformationScripting/src/queries/VersionControlQuery.cpp 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/350#discussion_r57124050'>File: InformationScripting/src/queries/VersionControlQuery.cpp:L116-153</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This should be guarded by a flag.
- [ ] <a href='#crh-comment-Pull 8b7d1acec5dba06b92dbfc7a505a9b25b6755f0f InformationScripting/src/queries/VersionControlQuery.cpp 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/350#discussion_r57124180'>File: InformationScripting/src/queries/VersionControlQuery.cpp:L66-78</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> no parenthesis

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/350?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/350?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/350'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
