### PR TITLE
added handling do delete unnecessary files during save

### DIFF
--- a/Export/CMakeLists.txt
+++ b/Export/CMakeLists.txt
@@ -41,4 +41,4 @@ add_library(Export SHARED
 	src/ExportMapContainer.cpp
 	src/ExportError.cpp
 )
-envision_plugin(Export ModelBase)
+envision_plugin(Export FilePersistence)

--- a/Export/src/precompiled.h
+++ b/Export/src/precompiled.h
@@ -29,6 +29,7 @@
 
 // Include here the precompiled headers of other plug-ins that use this plug-in uses. Only the "public" part of
 // those headers will be included here
+#include "FilePersistence/src/precompiled.h"
 #include "ModelBase/src/precompiled.h"
 #include "Logger/src/precompiled.h"
 #include "SelfTest/src/precompiled.h"

--- a/Export/src/writer/Exporter.cpp
+++ b/Export/src/writer/Exporter.cpp
@@ -159,6 +159,9 @@ void Exporter::deleteObsoletePreviousExports()
 {
 	if (span_ != ExportSpan::AllFiles) return;
 
+	// Whatever is left needs to be *carefully* deleted:
+	// Delete all files
+	// Delete any remaining *empty* directories
 	FilePersistence::FileUtil::deleteUnnecessaryFiles(previousExports_, currentExports_);
 
 }

--- a/FilePersistence/CMakeLists.txt
+++ b/FilePersistence/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(FilePersistence SHARED
 	src/version_control/GitPiecewiseLoader.h
 	src/version_control/LinkedChangesSet.h
 	src/version_control/Diff3Parse.h
+	src/utils/FileUtil.h
 	test/VCTestProject.h
 	src/simple/GenericPersistentUnit.cpp
 	src/simple/GenericTree.cpp

--- a/FilePersistence/src/FilePersistencePlugin.h
+++ b/FilePersistence/src/FilePersistencePlugin.h
@@ -34,6 +34,10 @@ namespace Core {
 	class EnvisionManager;
 }
 
+namespace Logger {
+	class Log;
+}
+
 namespace FilePersistence {
 
 class FILEPERSISTENCE_API FilePersistencePlugin : public QObject, public Core::EnvisionPlugin
@@ -51,6 +55,8 @@ class FILEPERSISTENCE_API FilePersistencePlugin : public QObject, public Core::E
 		 * Currently arguments don't work but multiple tests do.
 		 */
 		virtual void selfTest(QString testArgs) override;
+
+		static Logger::Log& log();
 };
 
 }

--- a/FilePersistence/src/precompiled.h
+++ b/FilePersistence/src/precompiled.h
@@ -43,7 +43,7 @@
 #include <QtCore/QDateTime>
 #include <QtCore/QTimeZone>
 #include <QtCore/QStack>
-
+#include <set>
 
 #if defined(FilePersistence_EXPORTS)
 // Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
@@ -52,7 +52,6 @@
 
 #include <QtCore/QFile>
 
-#include <set>
 #include <iostream>
 #include <git2.h>
 

--- a/FilePersistence/src/precompiled.h
+++ b/FilePersistence/src/precompiled.h
@@ -52,9 +52,9 @@
 
 #include <QtCore/QFile>
 
+#include <set>
 #include <iostream>
 #include <git2.h>
-
 
 #endif
 

--- a/FilePersistence/src/simple/SimpleTextFileStore.cpp
+++ b/FilePersistence/src/simple/SimpleTextFileStore.cpp
@@ -31,6 +31,7 @@
 #include "GenericTree.h"
 #include "Parser.h"
 #include "../FilePersistenceException.h"
+#include "../utils/FileUtil.h"
 
 #include "ModelBase/src/model/TreeManager.h"
 #include "ModelBase/src/nodes/Node.h"
@@ -118,6 +119,8 @@ void SimpleTextFileStore::saveTree(Model::TreeManager* manager, const QString &n
 		genericTree_ = new GenericTree{name};
 		saveNewPersistenceUnit(manager->root(), name);
 
+		FileUtil::deleteUnnecessaryFiles(oldFiles_, newFiles_);
+
 		SAFE_DELETE(genericTree_);
 	}
 	catch (Model::ModelException& e)
@@ -190,6 +193,8 @@ void SimpleTextFileStore::saveNewPersistenceUnit(const Model::Node *node, const 
 	genericNode_ = genericTree_->newPersistentUnit(puName).newNode();
 	saveNodeDirectly(node, name);
 	writeGenericNodeToFile(genericNode_, parentAbsoluteDirectory, relativeFileName, {});
+
+	newFiles_.insert(QString{parentAbsoluteDirectory + '/' + relativeFileName});
 
 	treeDirs_.pop();
 
@@ -350,6 +355,7 @@ Model::LoadedNode SimpleTextFileStore::loadNewPersistenceUnit(const QString& nam
 	else
 	{
 		QString absoluteFilePath = treeDirs_.top().absoluteFilePath(relativeFilePath);
+		oldFiles_.insert(absoluteFilePath);
 		genericNode_ = Parser::load(absoluteFilePath, true, genericTree_->newPersistentUnit(name));
 		treeDirs_.push(QFileInfo{absoluteFilePath}.absoluteDir());
 	}

--- a/FilePersistence/src/simple/SimpleTextFileStore.h
+++ b/FilePersistence/src/simple/SimpleTextFileStore.h
@@ -161,6 +161,9 @@ class FILEPERSISTENCE_API SimpleTextFileStore : public Model::PersistentStore
 		 * If false, no additional persistent units will be generated.
 		 */
 		static const bool GENERATE_PUS;
+
+		std::set<QString> oldFiles_;
+		std::set<QString> newFiles_;
 };
 
 }


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/360%23issuecomment-205240704%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/360%23issuecomment-205242627%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/360%23issuecomment-205261329%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/360%23issuecomment-205240704%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Now%20that%20the%20Export%20plug-in%20depends%20on%20FilePersistence%2C%20you%20need%20to%20add%20the%20corresponding%20dependencies%20in%20the%20CMakeLists.txt%20and%20precompiled.headers%20file.%5Cr%5Cn%5Cr%5Cnin%20CMakeLists%20change%20%60envision_plugin%28Export%20ModelBase%29%60%20to%20%60envision_plugin%28Export%20FilePersistence%29%60%2C%20since%20the%20latter%20depends%20on%20ModelBase%20it%20will%20be%20automatically%20included.%5Cr%5Cn%5Cr%5Cnin%20precompiled.h%20just%20add%20FilePersistence%22%2C%20%22created_at%22%3A%20%222016-04-04T10%3A56%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Cool%2C%20this%20looks%20good%20to%20me.%20Did%20you%20try%20it%20out%3F%22%2C%20%22created_at%22%3A%20%222016-04-04T10%3A59%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20I%20tried%20it%20for%20saving/loading.%20But%20not%20for%20the%20Exporter.%22%2C%20%22created_at%22%3A%20%222016-04-04T11%3A47%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/360#issuecomment-205240704'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Now that the Export plug-in depends on FilePersistence, you need to add the corresponding dependencies in the CMakeLists.txt and precompiled.headers file.
  in CMakeLists change `envision_plugin(Export ModelBase)` to `envision_plugin(Export FilePersistence)`, since the latter depends on ModelBase it will be automatically included.
  in precompiled.h just add FilePersistence
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Cool, this looks good to me. Did you try it out?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Yes I tried it for saving/loading. But not for the Exporter.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/360?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/360?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/360'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
