### PR TITLE
Fixed nodesGetter

### DIFF
--- a/VisualizationBase/src/items/ViewItem.cpp
+++ b/VisualizationBase/src/items/ViewItem.cpp
@@ -466,13 +466,19 @@ QVector<QVector<Model::Node*>> ViewItem::nodesGetter()
 			return nodes_;
 
 		int numCols = nodes_.size();
-		int numRows = nodes_.first().size();
 
-		QVector<QVector<Model::Node*>> rowMajorNodes{numRows, QVector<Model::Node*>{numCols}};
+		// find largest col vector
+		auto largestCol = std::max_element(nodes_.begin(), nodes_.end(), [](auto const& lhs, auto const& rhs) {
+				return lhs.size() < rhs.size();
+		});
+
+		int maxColSize = largestCol->size();
+
+		QVector<QVector<Model::Node*>> rowMajorNodes{maxColSize, QVector<Model::Node*>{numCols}};
 
 		for (int col = 0; col < numCols; ++col)
-			for (int row = 0; row < numRows; ++row)
-				rowMajorNodes[row][col] = nodes_[col][row];
+			for (int row = 0; row < maxColSize; ++row)
+				rowMajorNodes[row][col] = row < nodes_[col].size() ? nodes_[col][row] : nullptr;
 
 		return rowMajorNodes;
 	}


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/363%23issuecomment-206276503%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/363%23issuecomment-206279309%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/363%23issuecomment-206276503%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks.%5Cr%5Cn%5Cr%5CnJust%20a%20small%20comment%3A%20in%20general%20when%20you%20make%20commits%2C%20please%20think%20more%20carefully%20about%20the%20commit%20message%20and%20try%20to%20make%20it%20as%20descriptive%20as%20possible.%5Cr%5Cn%5Cr%5Cn%5C%22Fixed%20nodesGetter%5C%22%20could%20mean%20anything%5Cr%5Cn%5Cr%5Cn%5C%22Fix%20nodesGetter%20to%20correctly%20handle%20variable%20row%20sizes%20when%20using%20RowMajor%5C%22%20is%20a%20much%20more%20descriptive%20message.%20And%20it%20could%20be%20made%20even%20shorter%20without%20loosing%20any%20information%3A%5Cr%5Cn%5Cr%5Cn%5C%22Handle%20variable%20row%20sizes%20in%20nodesGetter%20when%20using%20RowMajor%5C%22%5Cr%5Cn%5Cr%5CnAlso%20please%20note%20that%20in%20general%20the%20commit%20message%20style%20in%20Envision%20says%20that%20commits%20should%20be%20in%20present%20tense%20%28fix%2C%20instead%20of%20fixed%29.%22%2C%20%22created_at%22%3A%20%222016-04-06T10%3A01%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20I%27ll%20keep%20that%20in%20mind%20next%20time.%22%2C%20%22created_at%22%3A%20%222016-04-06T10%3A04%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/363#issuecomment-206276503'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks.
  Just a small comment: in general when you make commits, please think more carefully about the commit message and try to make it as descriptive as possible.
  "Fixed nodesGetter" could mean anything
  "Fix nodesGetter to correctly handle variable row sizes when using RowMajor" is a much more descriptive message. And it could be made even shorter without loosing any information:
  "Handle variable row sizes in nodesGetter when using RowMajor"
  Also please note that in general the commit message style in Envision says that commits should be in present tense (fix, instead of fixed).
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> OK, I'll keep that in mind next time.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/363?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/363?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/363'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
