### PR TITLE
Remove dot at end of file name in exception message

### DIFF
--- a/VisualizationBase/src/styles/StyleNode.cpp
+++ b/VisualizationBase/src/styles/StyleNode.cpp
@@ -125,7 +125,7 @@ QDomDocument StyleNode::openStyleDoc(const QString& path)
 	QDomDocument doc = QDomDocument{XML_DOM_TYPE};
 	QFile file{path};
 	if ( !file.open(QIODevice::ReadOnly) )
-		throw VisualizationException{"Could not open style file " + file.fileName() + "."};
+		throw VisualizationException{"Could not open style file " + file.fileName()};
 
 	if ( !doc.setContent(&file) || doc.isNull() )
 	{


### PR DESCRIPTION
Small fix to remove the dot at the end of the file name in the exception message to avoid confusion.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/364%23issuecomment-206835808%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/364%23issuecomment-206835808%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20for%20this.%22%2C%20%22created_at%22%3A%20%222016-04-07T12%3A00%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/364#issuecomment-206835808'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks for this.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/364?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/364?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/364'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
