### PR TITLE
Diff visualization

### DIFF
--- a/InteractionBase/CMakeLists.txt
+++ b/InteractionBase/CMakeLists.txt
@@ -192,4 +192,4 @@ add_library(InteractionBase SHARED
 	src/handlers/HMovableItem.cpp
 )
 
-envision_plugin(InteractionBase VisualizationBase FilePersistence)
+envision_plugin(InteractionBase VisualizationBase FilePersistence VersionControlUI)

--- a/InteractionBase/src/precompiled.h
+++ b/InteractionBase/src/precompiled.h
@@ -29,6 +29,7 @@
 
 // Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
 // those headers will be included here
+#include "VersionControlUI/src/precompiled.h"
 #include "FilePersistence/src/precompiled.h"
 #include "VisualizationBase/src/precompiled.h"
 #include "ModelBase/src/precompiled.h"

--- a/ModelBase/src/model/AllTreeManagers.cpp
+++ b/ModelBase/src/model/AllTreeManagers.cpp
@@ -95,4 +95,12 @@ Node* AllTreeManagers::nodeForId(NodeIdType id) const
 	return nullptr;
 }
 
+NodeIdType AllTreeManagers::idForNode(Node* node) const
+{
+	for (auto manager : loadedManagers())
+		if (manager->nodeIdMap().containsNode(node))
+			return manager->nodeIdMap().id(node);
+	return nullptr;
+}
+
 }

--- a/ModelBase/src/model/AllTreeManagers.h
+++ b/ModelBase/src/model/AllTreeManagers.h
@@ -73,6 +73,8 @@ class MODELBASE_API AllTreeManagers {
 
 		Node* nodeForId(NodeIdType id) const;
 
+		NodeIdType idForNode(Node* node) const;
+
 	private:
 		AllTreeManagers();
 

--- a/ModelBase/src/persistence/NodeIdMap.cpp
+++ b/ModelBase/src/persistence/NodeIdMap.cpp
@@ -28,10 +28,17 @@
 
 namespace Model {
 
-NodeIdType NodeIdMap::id(const Node* node)
+bool NodeIdMap::containsNode(const Node* node)
 {
 	QHash<const Node*, NodeIdType>::const_iterator iter{nodeToId.find(node)};
-	if ( iter != nodeToId.end() ) return *iter;
+	if ( iter != nodeToId.end() ) return true;
+	return false;
+}
+
+NodeIdType NodeIdMap::id(const Node* node)
+{
+	if (containsNode(node))
+		return *nodeToId.find(node);
 
 	NodeIdType id = generateNewId();
 	nodeToId.insert(node, id);

--- a/ModelBase/src/persistence/NodeIdMap.h
+++ b/ModelBase/src/persistence/NodeIdMap.h
@@ -44,6 +44,8 @@ class MODELBASE_API NodeIdMap {
 
 		void remove(const Node* node);
 
+		bool containsNode(const Node* node);
+
 	private:
 		QHash<const Node*, NodeIdType> nodeToId;
 		QHash<NodeIdType, const Node*> idToNode;

--- a/VersionControlUI/CMakeLists.txt
+++ b/VersionControlUI/CMakeLists.txt
@@ -14,4 +14,4 @@ add_library(VersionControlUI SHARED
 	src/DiffManager.cpp
 	test/SimpleTest.cpp
 )
-envision_plugin(VersionControlUI InteractionBase oomodel)
+envision_plugin(VersionControlUI InteractionBase OOModel)

--- a/VersionControlUI/CMakeLists.txt
+++ b/VersionControlUI/CMakeLists.txt
@@ -8,8 +8,10 @@ add_library(VersionControlUI SHARED
 	src/VersionControlUIException.h
 	src/versioncontrolui_api.h
 	src/VersionControlUIPlugin.h
+	src/DiffManager.h
 	src/VersionControlUIException.cpp
 	src/VersionControlUIPlugin.cpp
+	src/DiffManager.cpp
 	test/SimpleTest.cpp
 )
-envision_plugin(VersionControlUI InteractionBase)
+envision_plugin(VersionControlUI InteractionBase oomodel)

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -1,0 +1,300 @@
+/***********************************************************************************************************************
+ **
+ ** Copyright (c) 2011, 2016 ETH Zurich
+ ** All rights reserved.
+ **
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ ** following conditions are met:
+ **
+ **    * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ **      following disclaimer.
+ **    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ **      following disclaimer in the documentation and/or other materials provided with the distribution.
+ **    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+ **      derived from this software without specific prior written permission.
+ **
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ ** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ ** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ ** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ ** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **
+ **********************************************************************************************************************/
+
+#include "DiffManager.h"
+
+#include "VisualizationBase/src/VisualizationManager.h"
+#include "VisualizationBase/src/items/ViewItem.h"
+#include "VisualizationBase/src/nodes/ViewItemNode.h"
+#include "VisualizationBase/src/ViewItemManager.h"
+#include "VisualizationBase/src/declarative/GridLayouter.h"
+#include "VisualizationBase/src/overlays/HighlightOverlay.h"
+
+#include "FilePersistence/src/version_control/GitRepository.h"
+#include "FilePersistence/src/simple/SimpleTextFileStore.h"
+
+#include "OOModel/src/declarations/Project.h"
+#include "OOModel/src/statements/ExpressionStatement.h"
+#include "OOModel/src/expressions/EmptyExpression.h"
+
+#include "ModelBase/src/model/AllTreeManagers.h"
+#include "ModelBase/src/model/TreeManager.h"
+#include "ModelBase/src/nodes/Reference.h"
+
+
+namespace VersionControlUI
+{
+
+DiffManager::DiffManager(QString oldVersion, QString newVersion, QString project)
+{
+	_oldVersion = oldVersion;
+	_newVersion = newVersion;
+	_project = project;
+}
+
+void DiffManager::visualize()
+{
+	auto diffViewItem = Visualization::VisualizationManager::instance().mainScene()->
+			viewItems()->newViewItem("DiffView");
+
+	QString projectsDir = "projects/" + _project;
+
+	// get GitRepository
+	if (!FilePersistence::GitRepository::repositoryExists(projectsDir))
+	{
+		qDebug() << "no repository found at " + projectsDir;
+		return;
+	}
+
+	FilePersistence::GitRepository repository{projectsDir};
+
+	// load name into tree
+	std::unique_ptr<const FilePersistence::Commit> oldCommit{repository.getCommit(_oldVersion)};
+	std::unique_ptr<const FilePersistence::Commit> newCommit{repository.getCommit(_newVersion)};
+
+	auto oldFileStore = new FilePersistence::SimpleTextFileStore{
+				[this, &oldCommit](QString filename, const char*& data, int& size)
+				{ return oldCommit->getFileContent(filename, data, size, false); }
+			};
+	auto newFileStore = new FilePersistence::SimpleTextFileStore{
+			[this, &newCommit](QString filename, const char*& data, int& size)
+			{ return newCommit->getFileContent(filename, data, size, false); }
+		};
+
+	// load newer version
+	Model::TreeManager* newVersionManager = new Model::TreeManager{};
+	newVersionManager->load(newFileStore, _project, false);
+
+	// load older version
+	Model::TreeManager* oldVersionManager = new Model::TreeManager{};
+	oldVersionManager->load(oldFileStore, _project, false);
+
+	Model::Reference::resolvePending();
+
+	FilePersistence::Diff diff = repository.diff(_oldVersion, _newVersion);
+
+	auto changes = diff.changes();
+
+	const int INDEX_OF_DELETE = 0;
+	const int INDEX_OF_ADD = 1;
+	const int INDEX_OF_MOVE = 2;
+	const int INDEX_OF_MODIFY = 3;
+
+	QList<QSet<Model::NodeIdType>> nodeLists;
+	for (int i = 0; i < 4; i++)
+		nodeLists.append(QSet<Model::NodeIdType>{});
+
+	QSet<Model::NodeIdType> changedNodesToVisualize;
+
+	for (auto change : changes.values())
+	{
+		if (change->isFake() || change->onlyStructureChange()) continue;
+
+		auto id = change->nodeId();
+
+		switch (change->type())
+		{
+			case FilePersistence::ChangeType::Deletion:
+				nodeLists[INDEX_OF_DELETE].insert(id);
+				break;
+			case FilePersistence::ChangeType::Insertion:
+				nodeLists[INDEX_OF_ADD].insert(id);
+				break;
+			case FilePersistence::ChangeType::Move:
+				nodeLists[INDEX_OF_MOVE].insert(id);
+				break;
+			case FilePersistence::ChangeType::Stationary:
+				nodeLists[INDEX_OF_MODIFY].insert(id);
+				break;
+			case FilePersistence::ChangeType::Unclassified:
+				qDebug() << "Unclassified";
+				break;
+		}
+		Model::NodeIdType nodeId;
+		if (change->type() != FilePersistence::ChangeType::Deletion)
+			if (findChangedNode(newVersionManager, id, nodeId))
+				changedNodesToVisualize.insert(nodeId);
+		if (change->type() != FilePersistence::ChangeType::Insertion)
+			if (findChangedNode(oldVersionManager, id, nodeId))
+				changedNodesToVisualize.insert(nodeId);
+	}
+	//
+	for (int i = 0; i < nodeLists.size(); i++)
+		removeDirectChildrenOfNodesInContainer(&nodeLists[i]);
+
+	Visualization::VisualizationManager::instance().mainScene()->listenToTreeManager(newVersionManager);
+	Visualization::VisualizationManager::instance().mainScene()->listenToTreeManager(oldVersionManager);
+
+	diffViewItem->setMajorAxis(Visualization::GridLayouter::NoMajor);
+
+	// add nodes to visualization, if not avaible show text
+	for (auto id : changedNodesToVisualize)
+	{
+		auto oldNode = const_cast<Model::Node*>(oldVersionManager->nodeIdMap().node(id));
+		auto newNode = const_cast<Model::Node*>(newVersionManager->nodeIdMap().node(id));
+
+		// old version in left column
+		if (!oldNode)
+			oldNode = new Model::Text{"node in old version not found"};
+		diffViewItem->insertNode(oldNode, 0);
+
+		// new version in right column
+		if (!newNode)
+			newNode = new Model::Text{"node in new version not found"};
+
+		diffViewItem->insertNode(newNode, 1);
+	}
+
+	//TODO method for visualizations
+
+	// create highlights and arrows for moved nodes
+	for (auto id : nodeLists[INDEX_OF_MOVE])
+	{
+		auto oldNode = const_cast<Model::Node*>(oldVersionManager->nodeIdMap().node(id));
+		auto newNode = const_cast<Model::Node*>(newVersionManager->nodeIdMap().node(id));
+
+		diffViewItem->addArrow(oldNode, newNode, QString{"move_arrows"});
+
+		Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
+							  [oldNode, newNode, diffViewItem](){
+			auto items = diffViewItem->findAllVisualizationsOf(oldNode);
+			items.append(diffViewItem->findAllVisualizationsOf(newNode));
+			for (auto item : items)
+			{
+				auto overlay = new Visualization::HighlightOverlay{item,
+						Visualization::HighlightOverlay::itemStyles().get("move_no_bg_solid")};
+				item->addOverlay(overlay, "move_highlights");
+			}});
+	}
+
+	// create highlights for deleted nodes
+	for (auto id : nodeLists[INDEX_OF_DELETE])
+	{
+		auto oldNode = const_cast<Model::Node*>(oldVersionManager->nodeIdMap().node(id));
+
+		if (!oldNode)
+			continue;
+
+		 Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
+								[oldNode, diffViewItem](){
+			 auto oldItems =  diffViewItem->findAllVisualizationsOf(oldNode);
+			 for (auto item : oldItems)
+			 {
+				 auto overlay = new Visualization::HighlightOverlay{item,
+						 Visualization::HighlightOverlay::itemStyles().get("delete_no_bg_solid")};
+				 item->addOverlay(overlay, "delete_highlights");
+			 }});
+
+	}
+
+	// create highlights for added nodes
+	for (auto id : nodeLists[INDEX_OF_ADD])
+	{
+		auto newNode = const_cast<Model::Node*>(newVersionManager->nodeIdMap().node(id));
+
+		Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
+							  [newNode, diffViewItem](){
+			auto newItems =  diffViewItem->findAllVisualizationsOf(newNode);
+			for (auto item : newItems)
+			{
+				auto overlay = new Visualization::HighlightOverlay{item,
+						Visualization::HighlightOverlay::itemStyles().get("insert_no_bg_solid")};
+				item->addOverlay(overlay, "insert_highlights");
+			}});
+	}
+
+	// create highlights for modified nodes
+	for (auto id : nodeLists[INDEX_OF_MODIFY])
+	{
+		auto oldNode = const_cast<Model::Node*>(oldVersionManager->nodeIdMap().node(id));
+		auto newNode = const_cast<Model::Node*>(newVersionManager->nodeIdMap().node(id));
+
+		Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
+							  [oldNode, newNode, diffViewItem](){
+			auto items = diffViewItem->findAllVisualizationsOf(oldNode);
+			items.append(diffViewItem->findAllVisualizationsOf(newNode));
+			for (auto item : items)
+			{
+				auto overlay = new Visualization::HighlightOverlay{item,
+						Visualization::HighlightOverlay::itemStyles().get("modify_no_bg_solid")};
+				item->addOverlay(overlay, "modify_highlights");
+			}});
+	}
+
+	// switch to the newly created view
+	Visualization::VisualizationManager::instance().mainScene()->viewItems()->switchToView(diffViewItem);
+}
+
+/**
+ * Deletes all nodes in \a container if their direct parent is also in \container.
+ */
+template<typename Container>
+void DiffManager::removeDirectChildrenOfNodesInContainer(Container* container)
+{
+	auto it = container->begin();
+	while (it != container->end())
+	{
+		auto nodeInContainer = Model::AllTreeManagers::instance().nodeForId(*it);
+		auto parentNode = nodeInContainer->parent();
+
+		if (container->contains(Model::AllTreeManagers::instance().idForNode(parentNode)))
+			it = container->erase(it);
+		else
+			it++;
+	}
+}
+
+// TODO change method to use type<> to specify ancestor
+/**
+ * Searches in \a treeManager for a node with \a id and tries to get it's first ancestor of type OOModel::Class.
+ * Returns true if such a node was found and saved to \a resultId.
+ */
+bool DiffManager::findChangedNode(Model::TreeManager* treeManager, Model::NodeIdType id, Model::NodeIdType& resultId)
+{
+	if (auto node = const_cast<Model::Node*>(treeManager->nodeIdMap().node(id)))
+	{
+
+		Model::Node* changedNode = nullptr;
+
+		// TODO fixed type, maybe more dynamic?
+		if (auto ancestorNode = node->firstAncestorOfType<OOModel::Class>())
+		{
+			changedNode = ancestorNode;
+
+			// Ignore empty nodes
+			if (auto changedExpr = DCast<OOModel::ExpressionStatement>(changedNode))
+				if (DCast<OOModel::EmptyExpression>(changedExpr->expression()))
+					return false;
+
+			resultId = treeManager->nodeIdMap().id(changedNode);
+			return true;
+
+		}
+	}
+	return false;
+}
+
+}

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -185,7 +185,7 @@ void DiffManager::visualize()
 			for (auto item : items)
 			{
 				auto overlay = new Visualization::HighlightOverlay{item,
-						Visualization::HighlightOverlay::itemStyles().get("move_no_bg_solid")};
+						Visualization::HighlightOverlay::itemStyles().get("move_no_bg_solid_outline")};
 				item->addOverlay(overlay, "move_highlights");
 			}});
 	}
@@ -204,7 +204,7 @@ void DiffManager::visualize()
 			 for (auto item : oldItems)
 			 {
 				 auto overlay = new Visualization::HighlightOverlay{item,
-						 Visualization::HighlightOverlay::itemStyles().get("delete_no_bg_solid")};
+						 Visualization::HighlightOverlay::itemStyles().get("delete_no_bg_solid_outline")};
 				 item->addOverlay(overlay, "delete_highlights");
 			 }});
 
@@ -221,7 +221,7 @@ void DiffManager::visualize()
 			for (auto item : newItems)
 			{
 				auto overlay = new Visualization::HighlightOverlay{item,
-						Visualization::HighlightOverlay::itemStyles().get("insert_no_bg_solid")};
+						Visualization::HighlightOverlay::itemStyles().get("insert_dotted_bg_solid_outline")};
 				item->addOverlay(overlay, "insert_highlights");
 			}});
 	}
@@ -239,7 +239,7 @@ void DiffManager::visualize()
 			for (auto item : items)
 			{
 				auto overlay = new Visualization::HighlightOverlay{item,
-						Visualization::HighlightOverlay::itemStyles().get("modify_no_bg_solid")};
+						Visualization::HighlightOverlay::itemStyles().get("modify_no_bg_solid_outline")};
 				item->addOverlay(overlay, "modify_highlights");
 			}});
 	}

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -1,0 +1,51 @@
+/***********************************************************************************************************************
+ **
+ ** Copyright (c) 2011, 2016 ETH Zurich
+ ** All rights reserved.
+ **
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ ** following conditions are met:
+ **
+ **    * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ **      following disclaimer.
+ **    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ **      following disclaimer in the documentation and/or other materials provided with the distribution.
+ **    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+ **      derived from this software without specific prior written permission.
+ **
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ ** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ ** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ ** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ ** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **
+ **********************************************************************************************************************/
+
+#pragma once
+
+#include "versioncontrolui_api.h"
+
+#include "ModelBase/src/model/TreeManager.h"
+
+namespace VersionControlUI {
+
+class VERSIONCONTROLUI_API DiffManager
+{
+	public:
+		DiffManager(QString oldVersion, QString newVersion, QString project);
+		void visualize();
+
+	private:
+		template<typename Container>
+		void removeDirectChildrenOfNodesInContainer(Container* container);
+		bool findChangedNode(Model::TreeManager* treeManager, Model::NodeIdType id, Model::NodeIdType& resultId);
+
+		QString _newVersion;
+		QString _oldVersion;
+		QString _project;
+};
+
+}

--- a/VersionControlUI/styles/item/HighlightOverlay/default
+++ b/VersionControlUI/styles/item/HighlightOverlay/default
@@ -1,0 +1,40 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#3cffc0c0</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		<cornerRadius>3</cornerRadius>
+		<outline>
+			<width>3.0</width>
+			<style>2</style>
+			<color>#c00000</color>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+	</shape>
+	
+	<background prototypes="item/Item/default"/>
+	
+	<info prototypes="item/Text/default">
+		<shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#fff5f5f5</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		
+		<outline>
+			<width>0</width>
+			<style>0</style>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+		</shape>
+	</info>
+	<excludeHighlightedChildren>false</excludeHighlightedChildren>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/delete
+++ b/VersionControlUI/styles/item/HighlightOverlay/delete
@@ -1,0 +1,40 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#88ff0000</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		<cornerRadius>3</cornerRadius>
+		<outline>
+			<width>3.0</width>
+			<style>2</style>
+			<color>#ffff0000</color>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+	</shape>
+	
+	<background prototypes="item/Item/default"/>
+	
+	<info prototypes="item/Text/default">
+		<shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#fff5f5f5</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		
+		<outline>
+			<width>0</width>
+			<style>0</style>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+		</shape>
+	</info>
+	<excludeHighlightedChildren>true</excludeHighlightedChildren>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/delete_no_bg_solid_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/delete_no_bg_solid_outline
@@ -1,0 +1,40 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>0</style>
+			<color>#88ff0000</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		<cornerRadius>3</cornerRadius>
+		<outline>
+			<width>10.0</width>
+			<style>1</style>
+			<color>#ffff0000</color>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+	</shape>
+	
+	<background prototypes="item/Item/default"/>
+	
+	<info prototypes="item/Text/default">
+		<shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#fff5f5f5</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		
+		<outline>
+			<width>0</width>
+			<style>0</style>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+		</shape>
+	</info>
+	<excludeHighlightedChildren>true</excludeHighlightedChildren>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/insert
+++ b/VersionControlUI/styles/item/HighlightOverlay/insert
@@ -1,0 +1,40 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#5000ff00</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		<cornerRadius>3</cornerRadius>
+		<outline>
+			<width>3.0</width>
+			<style>2</style>
+			<color>#ff00ff00</color>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+	</shape>
+	
+	<background prototypes="item/Item/default"/>
+	
+	<info prototypes="item/Text/default">
+		<shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#fff5f5f5</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		
+		<outline>
+			<width>0</width>
+			<style>0</style>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+		</shape>
+	</info>
+	<excludeHighlightedChildren>true</excludeHighlightedChildren>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/insert_dotted_bg_solid_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/insert_dotted_bg_solid_outline
@@ -1,0 +1,10 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/HighlightOverlay/insert_no_bg_solid_outline">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>4</style>
+			<color>#5000ff00</color>
+		</backgroundBrush>
+	</shape>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/insert_no_bg
+++ b/VersionControlUI/styles/item/HighlightOverlay/insert_no_bg
@@ -1,0 +1,40 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>0</style>
+			<color>#5000ff00</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		<cornerRadius>3</cornerRadius>
+		<outline>
+			<width>6.0</width>
+			<style>2</style>
+			<color>#ff00ff00</color>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+	</shape>
+	
+	<background prototypes="item/Item/default"/>
+	
+	<info prototypes="item/Text/default">
+		<shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#fff5f5f5</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		
+		<outline>
+			<width>0</width>
+			<style>0</style>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+		</shape>
+	</info>
+	<excludeHighlightedChildren>true</excludeHighlightedChildren>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/insert_no_bg_solid_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/insert_no_bg_solid_outline
@@ -1,0 +1,40 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>0</style>
+			<color>#5000ff00</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		<cornerRadius>3</cornerRadius>
+		<outline>
+			<width>10.0</width>
+			<style>1</style>
+			<color>#ff00ff00</color>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+	</shape>
+	
+	<background prototypes="item/Item/default"/>
+	
+	<info prototypes="item/Text/default">
+		<shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#fff5f5f5</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		
+		<outline>
+			<width>0</width>
+			<style>0</style>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+		</shape>
+	</info>
+	<excludeHighlightedChildren>true</excludeHighlightedChildren>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/modify
+++ b/VersionControlUI/styles/item/HighlightOverlay/modify
@@ -1,0 +1,40 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#88ffff00</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		<cornerRadius>3</cornerRadius>
+		<outline>
+			<width>3.0</width>
+			<style>2</style>
+			<color>#ffffff00</color>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+	</shape>
+	
+	<background prototypes="item/Item/default"/>
+	
+	<info prototypes="item/Text/default">
+		<shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#fff5f5f5</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		
+		<outline>
+			<width>0</width>
+			<style>0</style>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+		</shape>
+	</info>
+	<excludeHighlightedChildren>true</excludeHighlightedChildren>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/modify_no_bg_solid_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/modify_no_bg_solid_outline
@@ -1,0 +1,40 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>0</style>
+			<color>#88ffff00</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		<cornerRadius>3</cornerRadius>
+		<outline>
+			<width>10.0</width>
+			<style>1</style>
+			<color>#ffe6e600</color> 
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+	</shape>
+	
+	<background prototypes="item/Item/default"/>
+	
+	<info prototypes="item/Text/default">
+		<shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#fff5f5f5</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		
+		<outline>
+			<width>0</width>
+			<style>0</style>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+		</shape>
+	</info>
+	<excludeHighlightedChildren>true</excludeHighlightedChildren>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/move
+++ b/VersionControlUI/styles/item/HighlightOverlay/move
@@ -1,0 +1,40 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#880000ff</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		<cornerRadius>3</cornerRadius>
+		<outline>
+			<width>3.0</width>
+			<style>2</style>
+			<color>#ff0000ff</color>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+	</shape>
+	
+	<background prototypes="item/Item/default"/>
+	
+	<info prototypes="item/Text/default">
+		<shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#fff5f5f5</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		
+		<outline>
+			<width>0</width>
+			<style>0</style>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+		</shape>
+	</info>
+	<excludeHighlightedChildren>true</excludeHighlightedChildren>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/move_no_bg_solid_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/move_no_bg_solid_outline
@@ -1,0 +1,40 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>0</style>
+			<color>#880000ff</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		<cornerRadius>3</cornerRadius>
+		<outline>
+			<width>10.0</width>
+			<style>1</style>
+			<color>#ff0000ff</color>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+	</shape>
+	
+	<background prototypes="item/Item/default"/>
+	
+	<info prototypes="item/Text/default">
+		<shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#fff5f5f5</color>
+		</backgroundBrush>
+		<cornerType>0</cornerType>
+		
+		<outline>
+			<width>0</width>
+			<style>0</style>
+			<capStyle>0</capStyle>
+			<joinStyle>0</joinStyle>
+		</outline>
+		</shape>
+	</info>
+	<excludeHighlightedChildren>true</excludeHighlightedChildren>
+</style>

--- a/VersionControlUI/versioncontrolui.plugin
+++ b/VersionControlUI/versioncontrolui.plugin
@@ -4,5 +4,6 @@
 		<dependency pluginid="logger" version="0" />
 		<dependency pluginid="selftest" version="0" />
 		<dependency pluginid="interactionbase" version="1" />
+		<dependency pluginid="oomodel" version="1" />
 	</dependencies>
 </plugin>


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59022325%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59022463%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59022550%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59022668%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59022784%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59022911%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59023198%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59023220%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59023506%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59023514%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59024272%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59024712%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59025055%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59025182%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59025283%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59026860%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59027097%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59027628%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59027954%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59028407%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59028561%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59028671%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59029182%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59029513%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59030041%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59030438%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59030496%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59030842%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59030942%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59031154%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59031340%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59031843%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59032070%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59032581%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59033271%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59033338%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59033607%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59033985%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59034243%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.cpp%2053%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59031154%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20not%20the%20right%20way%20to%20initialize%20fields%2C%20you%20should%20use%20the%20proper%20syntax%3A%5Cr%5Cn%60DiffManager%3A%3ADiffManager%28...%29%20%3A%20_oldVersion%7BoldVersion%7D%2C%20....%20%7B%20/%2Abody%2C%20which%20is%20empty%20in%20this%20case%2A/%7D%60%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A18%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL1-301%22%7D%2C%20%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.cpp%2075%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59032070%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22All%20this%20commit%2C%20store%20and%20manager%20stuff%20is%20repetitive%2C%20can%27t%20we%20abstract%20it%20to%20reduce%20duplication%3F%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A24%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL1-301%22%7D%2C%20%22Pull%20bd7bdc60cb64d8895568056831cf2e64f6cc23d5%20OOInteraction/src/commands/CSceneHandlerItemTest.cpp%20189%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59027097%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Same%20as%20above%2C%20this%20%60for%60%20loop%20and%20the%20three%20after%20it%20have%20identical%20structure%2C%20so%20you%20should%20abstract%20them%20into%20a%20common%20function/lambda%20if%20you%20plan%20on%20using%20this%20test%20command%20any%20further.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A51%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20OOInteraction/src/commands/CSceneHandlerItemTest.cpp%3AL209-300%22%7D%2C%20%22Pull%201a9e2e282d27dd03566520f0642c81a5206dbfa0%20VersionControlUI/styles/item/HighlightOverlay/insert%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59028671%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22So%20all%20these%20styles%2C%20are%20very%20very%20similar.%20Please%20reduce%20them%20to%20the%20bare%20essentials%2C%20by%20using%20prototypes.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A01%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/styles/item/HighlightOverlay/insert%3AL1-41%22%7D%2C%20%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.h%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59030496%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22the%20%60_%60%20goes%20at%20the%20end%20not%20at%20the%20beginning.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A13%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.h%3AL1-52%22%7D%2C%20%22Pull%20bd7bdc60cb64d8895568056831cf2e64f6cc23d5%20OOInteraction/src/commands/CSceneHandlerItemTest.cpp%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59025182%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20don%27t%20commit%20these%20kinds%20of%20attributes%2C%20just%20keep%20them%20for%20local%20testing.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A37%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20OOInteraction/src/commands/CSceneHandlerItemTest.cpp%3AL56-189%22%7D%2C%20%22Pull%20f1f9f516313b371e4d2e75e94e225db347edfaab%20ModelBase/src/persistence/NodeIdMap.cpp%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59024712%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20did%20you%20change%20the%20implementation%20of%20%60id%60%3F%20Is%20it%20to%20reduce%20code%20duplication%3F%20That%27s%20what%20you%20should%20do%20in%20general%2C%20but%20only%20if%20the%20behavior%20stays%20the%20same.%20In%20your%20implementation%20of%20%60id%60%20we%20perform%20the%20search%20twice%20unnecessarily%3A%20once%20in%20the%20%60containsNode%60%20method%20and%20once%20again%20by%20calling%20%60find%60.%5Cr%5Cn%5Cr%5CnPlease%20restore%20the%20old%20implementation.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A33%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ModelBase/src/persistence/NodeIdMap.cpp%3AL28-45%22%7D%2C%20%22Pull%20bd7bdc60cb64d8895568056831cf2e64f6cc23d5%20OOInteraction/src/commands/CSceneHandlerItemTest.cpp%20206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59027628%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ideally%2C%20instead%20of%20manually%20providing%20a%20color%2C%20use%20a%20predefined%20style.%5Cr%5Cn%5Cr%5CnOnly%20fix%20if%20you%20plan%20on%20using%20the%20test%20command%20more.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A55%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20OOInteraction/src/commands/CSceneHandlerItemTest.cpp%3AL209-300%22%7D%2C%20%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.cpp%20275%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59033607%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Instead%20of%20returning%20the%20Id%2C%20can%27t%20you%20directly%20return%20the%20node%20itself%3F%20That%20way%20you%20can%20return%20nullptr%20if%20nothing%20was%20found%2C%20and%20you%20don%27t%20need%20the%20last%20argument.%5Cr%5Cn%5Cr%5CnIs%20there%20some%20reason%20why%20returning%20the%20ID%20is%20better%3F%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A33%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL1-301%22%7D%2C%20%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.cpp%20272%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59033338%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22its%20%28not%20it%27s%29%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A32%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL1-301%22%7D%2C%20%22Pull%201a9e2e282d27dd03566520f0642c81a5206dbfa0%20VersionControlUI/styles/item/HighlightOverlay/delete%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59028561%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60prototypes%60%20is%20a%20list%20of%20one%20or%20more%20file%20names%20that%20contain%20properties.%20The%20search%20for%20a%20file%20is%20done%20first%20relative%20to%20the%20current%20file%2C%20and%20if%20that%20fails%2C%20then%20starting%20from%20the%20%60styles%60%20directory.%5Cr%5Cn%5Cr%5CnHere%20you%20can%20use%20just%20the%20name%20of%20another%20file%20in%20this%20directory.%20When%20I%20say%20this%20directory%2C%20I%20mean%20the%20HighlightOverlay%20directory%20as%20it%20will%20exist%20once%20you%20run%20%60make%20install%60.%20So%20also%20files%20that%20will%20be%20coppied%20here%20from%20other%20plug-ins%20can%20be%20used%20%28in%20particular%20%60default%60%20from%20VisualizationBase%29%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A01%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/styles/item/HighlightOverlay/delete%3AL1-41%22%7D%2C%20%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.h%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59030942%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Minimal%20interface%2C%20I%20like%20it.%20We%27ll%20probably%20need%20to%20extend%20it%20in%20the%20future%2C%20but%20it%27s%20always%20good%20to%20start%20small.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A16%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.h%3AL1-52%22%7D%2C%20%22Pull%20f1f9f516313b371e4d2e75e94e225db347edfaab%20ModelBase/src/persistence/NodeIdMap.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59024272%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20should%20be%20called%20contains%20%28no%20need%20for%20node%2C%20since%20it%27s%20clear%20from%20the%20argument%20type%29%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A30%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ModelBase/src/persistence/NodeIdMap.h%3AL44-52%22%7D%2C%20%22Pull%2047c4aed9c57ca42467666f39d941752bf5ad3819%20InteractionBase/src/commands/CDiff.cpp%20209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59030041%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20already%20used%20to%20work%20before.%20Ideally%20don%27t%20remove%20existing%20functionality.%20Just%20use%20the%20%60name%60%20argument.%5Cr%5Cn%5Cr%5CnIf%20you%20want%20to%20locally%20have%20a%20fixed%20version%2C%20then%20don%27t%20commit%20that%20code.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A11%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InteractionBase/src/commands/CDiff.cpp%3AL62-77%22%7D%2C%20%22Pull%20bd7bdc60cb64d8895568056831cf2e64f6cc23d5%20OOInteraction/src/commands/CSceneHandlerItemTest.cpp%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59025283%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20doesn%27t%20really%20matter%20for%20the%20test%20command%2C%20but%20in%20general%20there%20are%20ways%20to%20return%20errors%20from%20commands.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A38%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20OOInteraction/src/commands/CSceneHandlerItemTest.cpp%3AL56-189%22%7D%2C%20%22Pull%20806b09db3c4755603569f87ef51c429fdac9f7af%20VersionControlUI/CMakeLists.txt%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59022325%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Each%20commit%20should%20at%20a%20minimum%20compile%20on%20its%20own.%20Here%20you%20add%20some%20source%20files%20in%20the%20CMakeLists.txt%20but%20don%27t%20add%20the%20actual%20files%20to%20the%20commit.%20This%20will%20fail%20to%20compile.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A14%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20commit%20is%20supposed%20to%20add%20a%20dependency%2C%20but%20you%20are%20adding%20here%20additional%20source%20files.%20This%20is%20not%20right%2C%20adding%20these%20files%20should%20have%20been%20done%20in%20a%20different%20commit%20or%20you%20should%20have%20named%20the%20commit%20appropriately.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A16%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20case%20you%20don%27t%20know%2C%20in%20git%20gui%20you%20can%20select%20entire%20files%20for%20commit%2C%20but%20you%20can%20also%20select%20just%20a%20few%20lines%20from%20a%20file%20and%20commit%20those.%20You%20should%20use%20this%20if%20a%20file%20contains%20multiple%20unrelated%20changes.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A18%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/CMakeLists.txt%3AL8-18%22%7D%2C%20%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.cpp%2060%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59031843%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20general%2C%20to%20make%20things%20easier%20to%20understand%2C%20try%20to%20keep%20related%20functionality%20as%20close%20as%20possible.%5Cr%5Cn%5Cr%5CnHere%20you%20create%20a%20new%20%60diffView%60%20but%20you%20don%27t%20use%20it%20for%20many%20lines%20after%20this.%20As%20a%20general%20rule%2C%20push%20lines%20of%20code%20as%20further%20down%20as%20possible.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A22%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL1-301%22%7D%2C%20%22Pull%20806b09db3c4755603569f87ef51c429fdac9f7af%20VersionControlUI/CMakeLists.txt%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59022550%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20talked%20about%20keeping%20the%20VersionControl%20UI%20at%20the%20generic%20level.%20Why%20did%20you%20introduce%20a%20dependency%20on%20oomodel%3F%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A16%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20as%20a%20general%20rule%20a%20commit%20should%20be%20a%20more%20complete%20entity.%20Here%20you%27re%20adding%20a%20dependency%20but%20it%20is%20totally%20not%20obvious%20why%20we%20need%20this%20dependency.%20It%20should%20have%20been%20done%20in%20a%20commit%20that%20also%20introduces%20a%20use%20of%20something%20that%27s%20in%20oomodel.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A17%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20DiffManager%20the%20method%20firstAncestorOfType%3COOModel%3A%3AClass%3E%20is%20used%20at%20the%20moment.%20To%20test%20visualization%20of%20the%20differences%20until%20there%20is%20maybe%20a%20more%20generic%20way%20to%20decide%20which%20context%20to%20show.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A24%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20see.%20So%20a%20better%20%2A%2Atemporary%2A%2A%20solution%20is%20not%20include%20these%20dependencies%20at%20all.%20They%20are%20not%20really%20needed%20unless%20you%20want%20to%20compile%20on%20Windows%20or%20unless%20you%20need%20the%20dependencies%20during%20initialization.%5Cr%5Cn%5Cr%5CnI%20would%20remove%20the%20dependencies%20and%20put%20a%20%60//TODO%20Remove%20this/make%20it%20more%20abstract%60%20right%20where%20you%20use%20%60Class%60%20and%20add%20an%20extra%20comment%20explaining%20that%20we%20shouldn%27t%20have%20a%20dependency%20on%20OOModel.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A05%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/CMakeLists.txt%3AL8-18%22%7D%2C%20%22Pull%2047c4aed9c57ca42467666f39d941752bf5ad3819%20InteractionBase/src/commands/CDiff.cpp%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59029513%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Don%27t%20commit%20function%20attributes.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A07%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InteractionBase/src/commands/CDiff.cpp%3AL50-59%22%7D%2C%20%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.cpp%20283%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59033985%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Yes%2C%20I%20agree%20with%20your%20comment%20on%20the%20line%20above.%20Why%20not%20use%20the%20overload%20of%20%60firstAncestorOfType%60%20that%20takes%20a%20%60SymbolMatcher%60%20%28use%20a%20string%20in%20your%20case%29%20and%20have%20a%20field%20that%20specifies%20what%20to%20look%20for.%20This%20way%20you%20don%27t%20have%20a%20direct%20dependency%20on%20OOModel%20and%20you%20could%20let%20someone%20else%20set%20that%20field%20%28e.g.%20a%20higher%20level%29%20as%20they%20see%20fit.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A36%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL1-301%22%7D%2C%20%22Pull%200bc632736807f436c4ef89277ad940bcbeaab74a%20InteractionBase/CMakeLists.txt%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59022911%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20should%20interaction%20base%20depend%20on%20versioncontrol%20ui.%20This%20feels%20very%20broken.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A19%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20CDiff%20command%20calls%20DiffManager.%20Is%20this%20dependency%20not%20needed%20in%20that%20case%3F%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A21%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20doubly%20broken%20since%20version%20control%20UI%20also%20depends%20on%20interaction%20base.%20This%20is%20a%20circular%20dependency%20%21%21%21%5Cr%5Cn%5Cr%5CnYou%20would%20have%20noticed%20that%20if%20you%20correctly%20added%20the%20dependency%20here%2C%20by%20also%20including%20it%20in%20the%20%60.plugin%60%20file.%20Then%20neither%20of%20those%20plugins%20would%20have%20loaded%20and%20you%20would%20have%20gotten%20an%20error%20message.%20The%20code%20works%20right%20now%20on%20a%20system%20like%20linux%2C%20which%20has%20relaxed%20requirements%20for%20dependencies%2C%20but%20you%20wouldn%27t%20be%20able%20to%20compile%20it%20on%20windows%20for%20example.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A21%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20correct%20thing%20to%20do%20is%20to%20move%20the%20%60CDiff%60%20command%20in%20this%20plug-in.%20So%20please%20do%20that.%5Cr%5Cn%5Cr%5CnRegardless%20of%20what%20is%20the%20correct%20resolution%20of%20this%20specific%20problem%2C%20please%20be%20more%20meticulous%20in%20the%20future.%20You%20should%20always%20think%20carefully%20what%20you%27re%20building%20and%20what%20dependencies%20there%20are.%20Introducing%20a%20circular%20dependency%20should%20never%20happen.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A24%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InteractionBase/CMakeLists.txt%3AL192-196%22%7D%2C%20%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.h%2043%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59030438%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20general%20you%20should%20not%20use%20templates%20if%20not%20needed.%20Does%20this%20method%20really%20need%20to%20have%20a%20templated%20Container%3F%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A13%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.h%3AL1-52%22%7D%2C%20%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.cpp%20288%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59034243%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22errrr%20%3F%20You%20know%20for%20a%20fact%20that%20changed%20node%20is%20of%20type%20%60Class%60.%20Why%20are%20you%20casting%20it%20to%20%60ExpressionStatement%60%3F%20This%20will%20always%20fail.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A37%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL1-301%22%7D%2C%20%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.cpp%20261%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59033271%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20algorithm%20is%20only%20correct%2C%20if%20you%20guarantee%20that%20you%20explore%20nodes%20from%20the%20leaves%20towards%20the%20root.%20Otherwise%5Cr%5Cnif%20A%2C%20B%2C%20and%20C%20are%20in%20the%20container%20and%20A%20is%20a%20parent%20of%20B%20is%20a%20parent%20of%20C%2C%20you%20might%20first%20explore%20B%20and%20then%20remove%20it%20because%20A%20is%20in%20there%2C%20and%20then%20if%20you%20explore%20C%20you%20will%20not%20remove%20it.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A31%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL1-301%22%7D%2C%20%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.cpp%20174%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59031340%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%20four%20loops%20are%20very%20similar%20to%20each%20other%2C%20please%20abstract%20them%20into%20a%20method/lambda%20to%20remove%20code%20duplication.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A19%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL1-301%22%7D%2C%20%22Pull%20f1f9f516313b371e4d2e75e94e225db347edfaab%20ModelBase/src/persistence/NodeIdMap.cpp%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59025055%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20not%20just%20replace%20the%20entire%20method%20body%20with%20one%20line%3A%5Cr%5Cn%60return%20nodeToId.contains%28node%29%3B%60%5Cr%5Cn%5Cr%5CnSince%20it%27s%20so%20short%2C%20you%20might%20as%20well%20inline%20this%20directly%20in%20the%20.h%20file.%5Cr%5Cn%5Cr%5CnIn%20general%2C%20the%20mark%20of%20a%20good%20programmer%20is%20that%20they%20know%20their%20libraries%20well.%20I%20suppose%20Qt%20is%20new%20for%20you%2C%20so%20every%20time%20you%20want%20to%20use%20an%20unfamiliar%20Qt%20class%2C%20make%20sure%20to%20look%20up%20its%20APIs%20to%20know%20what%27s%20available.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A36%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ModelBase/src/persistence/NodeIdMap.cpp%3AL28-45%22%7D%2C%20%22Pull%201a9e2e282d27dd03566520f0642c81a5206dbfa0%20VersionControlUI/styles/item/HighlightOverlay/default%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59027954%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20style%20and%20all%20the%20others%20you%20added%20seem%20to%20be%20mostly%20a%20copy%20of%20the%20%60default%60%20highlight%20style.%5Cr%5Cn%5Cr%5CnChange%20the%20%60prototypes%60%20here%20to%20%60%5C%22default%5C%22%60%20and%20remove%20all%20the%20properties%20which%20are%20identical%20to%20the%20default%20style.%20That%20will%20give%20you%20a%20much%20more%20easy%20to%20read%20%20style%20file%20and%20it%20will%20tell%20you%20exactly%20how%20it%27s%20different%20to%20the%20default.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A57%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20you%20called%20this%20style%20default.%20You%20should%20not%20do%20that.%20A%20default%20style%20already%20exists%20in%20VisualizationBase%20and%20it%20will%20be%20coppied%20to%20HighlightOverlay%20directory%20when%20you%20run%20%60make%20install%60.%20So%20basically%20here%20you%20should%20only%20define%20styles%20specifically%20for%20use%20of%20version%20control%20and%20you%20should%20name%20them%20accordingly.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A00%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/styles/item/HighlightOverlay/default%3AL1-41%22%7D%2C%20%22Pull%2047c4aed9c57ca42467666f39d941752bf5ad3819%20InteractionBase/src/commands/CDiff.cpp%20210%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59030842%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20what%20happens%20to%20the%20DiffManager%20at%20the%20end%20of%20this%20method%3F%20It%20will%20be%20destroyed.%20We%20should%20probably%20make%20that%20class%20a%20singleton%20or%20something.%20Think%20about%20a%20good%20design.%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A16%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20InteractionBase/src/commands/CDiff.cpp%3AL62-77%22%7D%2C%20%22Pull%209bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1%20VersionControlUI/src/DiffManager.cpp%20252%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59032581%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20always%20put%20all%20doxygen%20in%20the%20.h%20file%20%28also%20of%20private%20methods%29%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A27%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL1-301%22%7D%2C%20%22Pull%20bd7bdc60cb64d8895568056831cf2e64f6cc23d5%20OOInteraction/src/commands/CSceneHandlerItemTest.cpp%20130%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/365%23discussion_r59026860%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20%60if%60%20is%20very%20similar%20to%20the%20one%20below.%20You%20could%20easily%20create%20a%20method%20%28or%20a%20lambda%29%20that%20unifies%20their%20behavior.%5Cr%5Cn%5Cr%5CnIn%20general%20you%20should%20always%20avoid%20code%20duplication.%20In%20this%20particular%20case%2C%20since%20this%20is%20in%20the%20test%20command%2C%20you%20can%20leave%20it%20as%20it%20is%2C%20if%20you%20don%27t%20plan%20on%20using%20it%20any%20more%2C%20but%20otherwise%20please%20reduce%20duplication.%22%2C%20%22created_at%22%3A%20%222016-04-08T13%3A49%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20OOInteraction/src/commands/CSceneHandlerItemTest.cpp%3AL56-189%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 806b09db3c4755603569f87ef51c429fdac9f7af VersionControlUI/CMakeLists.txt 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59022325'>File: VersionControlUI/CMakeLists.txt:L8-18</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Each commit should at a minimum compile on its own. Here you add some source files in the CMakeLists.txt but don't add the actual files to the commit. This will fail to compile.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This commit is supposed to add a dependency, but you are adding here additional source files. This is not right, adding these files should have been done in a different commit or you should have named the commit appropriately.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> In case you don't know, in git gui you can select entire files for commit, but you can also select just a few lines from a file and commit those. You should use this if a file contains multiple unrelated changes.
- [ ] <a href='#crh-comment-Pull 806b09db3c4755603569f87ef51c429fdac9f7af VersionControlUI/CMakeLists.txt 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59022550'>File: VersionControlUI/CMakeLists.txt:L8-18</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> We talked about keeping the VersionControl UI at the generic level. Why did you introduce a dependency on oomodel?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> So as a general rule a commit should be a more complete entity. Here you're adding a dependency but it is totally not obvious why we need this dependency. It should have been done in a commit that also introduces a use of something that's in oomodel.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> In DiffManager the method firstAncestorOfTypeOOModel::Class is used at the moment. To test visualization of the differences until there is maybe a more generic way to decide which context to show.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I see. So a better **temporary** solution is not include these dependencies at all. They are not really needed unless you want to compile on Windows or unless you need the dependencies during initialization.
  I would remove the dependencies and put a `//TODO Remove this/make it more abstract` right where you use `Class` and add an extra comment explaining that we shouldn't have a dependency on OOModel.
- [ ] <a href='#crh-comment-Pull 0bc632736807f436c4ef89277ad940bcbeaab74a InteractionBase/CMakeLists.txt 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59022911'>File: InteractionBase/CMakeLists.txt:L192-196</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why should interaction base depend on versioncontrol ui. This feels very broken.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> The CDiff command calls DiffManager. Is this dependency not needed in that case?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This is doubly broken since version control UI also depends on interaction base. This is a circular dependency !!!
  You would have noticed that if you correctly added the dependency here, by also including it in the `.plugin` file. Then neither of those plugins would have loaded and you would have gotten an error message. The code works right now on a system like linux, which has relaxed requirements for dependencies, but you wouldn't be able to compile it on windows for example.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> The correct thing to do is to move the `CDiff` command in this plug-in. So please do that.
  Regardless of what is the correct resolution of this specific problem, please be more meticulous in the future. You should always think carefully what you're building and what dependencies there are. Introducing a circular dependency should never happen.
- [ ] <a href='#crh-comment-Pull f1f9f516313b371e4d2e75e94e225db347edfaab ModelBase/src/persistence/NodeIdMap.h 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59024272'>File: ModelBase/src/persistence/NodeIdMap.h:L44-52</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> this should be called contains (no need for node, since it's clear from the argument type)
- [ ] <a href='#crh-comment-Pull f1f9f516313b371e4d2e75e94e225db347edfaab ModelBase/src/persistence/NodeIdMap.cpp 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59024712'>File: ModelBase/src/persistence/NodeIdMap.cpp:L28-45</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why did you change the implementation of `id`? Is it to reduce code duplication? That's what you should do in general, but only if the behavior stays the same. In your implementation of `id` we perform the search twice unnecessarily: once in the `containsNode` method and once again by calling `find`.
  Please restore the old implementation.
- [ ] <a href='#crh-comment-Pull f1f9f516313b371e4d2e75e94e225db347edfaab ModelBase/src/persistence/NodeIdMap.cpp 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59025055'>File: ModelBase/src/persistence/NodeIdMap.cpp:L28-45</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why not just replace the entire method body with one line:
  `return nodeToId.contains(node);`
  Since it's so short, you might as well inline this directly in the .h file.
  In general, the mark of a good programmer is that they know their libraries well. I suppose Qt is new for you, so every time you want to use an unfamiliar Qt class, make sure to look up its APIs to know what's available.
- [ ] <a href='#crh-comment-Pull bd7bdc60cb64d8895568056831cf2e64f6cc23d5 OOInteraction/src/commands/CSceneHandlerItemTest.cpp 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59025182'>File: OOInteraction/src/commands/CSceneHandlerItemTest.cpp:L56-189</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please don't commit these kinds of attributes, just keep them for local testing.
- [ ] <a href='#crh-comment-Pull bd7bdc60cb64d8895568056831cf2e64f6cc23d5 OOInteraction/src/commands/CSceneHandlerItemTest.cpp 35'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59025283'>File: OOInteraction/src/commands/CSceneHandlerItemTest.cpp:L56-189</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> It doesn't really matter for the test command, but in general there are ways to return errors from commands.
- [ ] <a href='#crh-comment-Pull bd7bdc60cb64d8895568056831cf2e64f6cc23d5 OOInteraction/src/commands/CSceneHandlerItemTest.cpp 130'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59026860'>File: OOInteraction/src/commands/CSceneHandlerItemTest.cpp:L56-189</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This `if` is very similar to the one below. You could easily create a method (or a lambda) that unifies their behavior.
  In general you should always avoid code duplication. In this particular case, since this is in the test command, you can leave it as it is, if you don't plan on using it any more, but otherwise please reduce duplication.
- [ ] <a href='#crh-comment-Pull bd7bdc60cb64d8895568056831cf2e64f6cc23d5 OOInteraction/src/commands/CSceneHandlerItemTest.cpp 189'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59027097'>File: OOInteraction/src/commands/CSceneHandlerItemTest.cpp:L209-300</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Same as above, this `for` loop and the three after it have identical structure, so you should abstract them into a common function/lambda if you plan on using this test command any further.
- [ ] <a href='#crh-comment-Pull bd7bdc60cb64d8895568056831cf2e64f6cc23d5 OOInteraction/src/commands/CSceneHandlerItemTest.cpp 206'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59027628'>File: OOInteraction/src/commands/CSceneHandlerItemTest.cpp:L209-300</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Ideally, instead of manually providing a color, use a predefined style.
  Only fix if you plan on using the test command more.
- [ ] <a href='#crh-comment-Pull 1a9e2e282d27dd03566520f0642c81a5206dbfa0 VersionControlUI/styles/item/HighlightOverlay/default 2'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59027954'>File: VersionControlUI/styles/item/HighlightOverlay/default:L1-41</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This style and all the others you added seem to be mostly a copy of the `default` highlight style.
  Change the `prototypes` here to `"default"` and remove all the properties which are identical to the default style. That will give you a much more easy to read  style file and it will tell you exactly how it's different to the default.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Oh, you called this style default. You should not do that. A default style already exists in VisualizationBase and it will be coppied to HighlightOverlay directory when you run `make install`. So basically here you should only define styles specifically for use of version control and you should name them accordingly.
- [ ] <a href='#crh-comment-Pull 1a9e2e282d27dd03566520f0642c81a5206dbfa0 VersionControlUI/styles/item/HighlightOverlay/delete 2'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59028561'>File: VersionControlUI/styles/item/HighlightOverlay/delete:L1-41</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `prototypes` is a list of one or more file names that contain properties. The search for a file is done first relative to the current file, and if that fails, then starting from the `styles` directory.
  Here you can use just the name of another file in this directory. When I say this directory, I mean the HighlightOverlay directory as it will exist once you run `make install`. So also files that will be coppied here from other plug-ins can be used (in particular `default` from VisualizationBase)
- [ ] <a href='#crh-comment-Pull 1a9e2e282d27dd03566520f0642c81a5206dbfa0 VersionControlUI/styles/item/HighlightOverlay/insert 1'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59028671'>File: VersionControlUI/styles/item/HighlightOverlay/insert:L1-41</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> So all these styles, are very very similar. Please reduce them to the bare essentials, by using prototypes.
- [ ] <a href='#crh-comment-Pull 47c4aed9c57ca42467666f39d941752bf5ad3819 InteractionBase/src/commands/CDiff.cpp 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59029513'>File: InteractionBase/src/commands/CDiff.cpp:L50-59</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Don't commit function attributes.
- [ ] <a href='#crh-comment-Pull 47c4aed9c57ca42467666f39d941752bf5ad3819 InteractionBase/src/commands/CDiff.cpp 209'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59030041'>File: InteractionBase/src/commands/CDiff.cpp:L62-77</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This already used to work before. Ideally don't remove existing functionality. Just use the `name` argument.
  If you want to locally have a fixed version, then don't commit that code.
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.h 43'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59030438'>File: VersionControlUI/src/DiffManager.h:L1-52</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> In general you should not use templates if not needed. Does this method really need to have a templated Container?
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.h 46'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59030496'>File: VersionControlUI/src/DiffManager.h:L1-52</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> the `_` goes at the end not at the beginning.
- [ ] <a href='#crh-comment-Pull 47c4aed9c57ca42467666f39d941752bf5ad3819 InteractionBase/src/commands/CDiff.cpp 210'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59030842'>File: InteractionBase/src/commands/CDiff.cpp:L62-77</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, what happens to the DiffManager at the end of this method? It will be destroyed. We should probably make that class a singleton or something. Think about a good design.
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.h 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59030942'>File: VersionControlUI/src/DiffManager.h:L1-52</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Minimal interface, I like it. We'll probably need to extend it in the future, but it's always good to start small.
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.cpp 53'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59031154'>File: VersionControlUI/src/DiffManager.cpp:L1-301</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This is not the right way to initialize fields, you should use the proper syntax:
  `DiffManager::DiffManager(...) : _oldVersion{oldVersion}, .... { /*body, which is empty in this case*/}`
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.cpp 174'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59031340'>File: VersionControlUI/src/DiffManager.cpp:L1-301</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> These four loops are very similar to each other, please abstract them into a method/lambda to remove code duplication.
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.cpp 60'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59031843'>File: VersionControlUI/src/DiffManager.cpp:L1-301</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> In general, to make things easier to understand, try to keep related functionality as close as possible.
  Here you create a new `diffView` but you don't use it for many lines after this. As a general rule, push lines of code as further down as possible.
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.cpp 75'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59032070'>File: VersionControlUI/src/DiffManager.cpp:L1-301</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> All this commit, store and manager stuff is repetitive, can't we abstract it to reduce duplication?
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.cpp 252'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59032581'>File: VersionControlUI/src/DiffManager.cpp:L1-301</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please always put all doxygen in the .h file (also of private methods)
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.cpp 261'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59033271'>File: VersionControlUI/src/DiffManager.cpp:L1-301</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This algorithm is only correct, if you guarantee that you explore nodes from the leaves towards the root. Otherwise
  if A, B, and C are in the container and A is a parent of B is a parent of C, you might first explore B and then remove it because A is in there, and then if you explore C you will not remove it.
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.cpp 272'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59033338'>File: VersionControlUI/src/DiffManager.cpp:L1-301</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> its (not it's)
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.cpp 275'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59033607'>File: VersionControlUI/src/DiffManager.cpp:L1-301</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Instead of returning the Id, can't you directly return the node itself? That way you can return nullptr if nothing was found, and you don't need the last argument.
  Is there some reason why returning the ID is better?
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.cpp 283'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59033985'>File: VersionControlUI/src/DiffManager.cpp:L1-301</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Yes, I agree with your comment on the line above. Why not use the overload of `firstAncestorOfType` that takes a `SymbolMatcher` (use a string in your case) and have a field that specifies what to look for. This way you don't have a direct dependency on OOModel and you could let someone else set that field (e.g. a higher level) as they see fit.
- [ ] <a href='#crh-comment-Pull 9bae92fbb5d61b4b09e6ba0b53f0ef0e463f81d1 VersionControlUI/src/DiffManager.cpp 288'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/365#discussion_r59034243'>File: VersionControlUI/src/DiffManager.cpp:L1-301</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> errrr ? You know for a fact that changed node is of type `Class`. Why are you casting it to `ExpressionStatement`? This will always fail.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/365?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/365?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/365'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
