### PR TITLE
Call SetUpdateNeeded in addArrow and setScale

### DIFF
--- a/VisualizationBase/src/items/Item.cpp
+++ b/VisualizationBase/src/items/Item.cpp
@@ -183,6 +183,8 @@ void Item::setScale(qreal newScale)
 		if (isSensitiveToScale()) setUpdateNeeded(StandardUpdate);
 		else
 		{
+			if (parent()) parent()->setUpdateNeeded(StandardUpdate);
+
 			QList<Item*> stack = childItems();
 			while (!stack.empty())
 			{

--- a/VisualizationBase/src/items/ViewItem.cpp
+++ b/VisualizationBase/src/items/ViewItem.cpp
@@ -192,6 +192,7 @@ void ViewItem::addArrow(Model::Node *from, Model::Node *to, QString layer,
 						ViewItemNode *fromParent, ViewItemNode *toParent)
 {
 	arrowsToAdd_.append(ArrowToAdd{fromParent, from, toParent, to, layer});
+	setUpdateNeeded(StandardUpdate);
 }
 
 QList<QPair<Item*, Item*>> ViewItem::arrowsForLayer(QString layer)


### PR DESCRIPTION
Call in addArrow is needed to have the arrows drawn immediately.
Call in setScale is needed in order to resize the parent component correctly.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/367?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/367'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
