### PR TITLE
Gm diff manager

### DIFF
--- a/FilePersistence/src/version_control/GitRepository.cpp
+++ b/FilePersistence/src/version_control/GitRepository.cpp
@@ -601,8 +601,6 @@ bool GitRepository::isValidRevisionString(QString revision) const
 	if (errorCode == GIT_EAMBIGUOUS)
 		isValid = false;
 
-	checkError(errorCode);
-
 	git_object_free(obj);
 
 	return isValid;
@@ -1069,6 +1067,11 @@ git_commit* GitRepository::parseCommit(QString revision) const
 
 	// clean up
 	git_object_free(obj);
+}
+
+int GitRepository::getMinPrefixLength()
+{
+	return GIT_OID_MINPREFIXLEN;
 }
 
 QString GitRepository::oidToQString(const git_oid* oid) const

--- a/FilePersistence/src/version_control/GitRepository.cpp
+++ b/FilePersistence/src/version_control/GitRepository.cpp
@@ -318,8 +318,8 @@ CommitGraph GitRepository::commitGraph(QString startRevision, QString endRevisio
 
 const Commit* GitRepository::getCommit(QString revision) const
 {
-	Q_ASSERT(revision.compare(WORKDIR) != 0);
-	Q_ASSERT(revision.compare(INDEX) != 0);
+	Q_ASSERT(revision != WORKDIR);
+	Q_ASSERT(revision != INDEX);
 
 	int errorCode = 0;
 
@@ -346,9 +346,9 @@ const Commit* GitRepository::getCommit(QString revision) const
 
 const CommitFile* GitRepository::getCommitFile(QString revision, QString relativePath) const
 {
-	if (revision.compare(WORKDIR) == 0)
+	if (revision == WORKDIR)
 		return getCommitFileFromWorkdir(relativePath);
-	else if (revision.compare(INDEX) == 0)
+	else if (revision == INDEX)
 		return getCommitFileFromIndex(relativePath);
 	else
 		return getCommitFileFromTree(revision, relativePath);
@@ -358,7 +358,7 @@ CommitMetaData GitRepository::getCommitInformation(QString revision) const
 {
 	CommitMetaData info;
 
-	if (revision.compare(WORKDIR) != 0 && revision.compare(INDEX) != 0)
+	if (revision != WORKDIR && revision != INDEX)
 	{
 		git_commit* gitCommit = parseCommit(revision);
 
@@ -396,7 +396,7 @@ CommitMetaData GitRepository::getCommitInformation(QString revision) const
 
 QString GitRepository::getSHA1(QString revision) const
 {
-	if (revision.compare(WORKDIR) != 0 && revision.compare(INDEX) != 0)
+	if (revision != WORKDIR && revision != INDEX)
 	{
 		git_commit* gitCommit = parseCommit(revision);
 		const git_oid* oid = git_commit_id(gitCommit);
@@ -413,7 +413,7 @@ QString GitRepository::getSHA1(QString revision) const
 
 void GitRepository::checkout(QString revision, bool force)
 {
-	if (revision.compare(WORKDIR) != 0)
+	if (revision != WORKDIR)
 	{
 		git_checkout_options options;
 		git_checkout_init_options(&options, GIT_CHECKOUT_OPTIONS_VERSION);
@@ -421,7 +421,7 @@ void GitRepository::checkout(QString revision, bool force)
 		options.checkout_strategy = force ? GIT_CHECKOUT_FORCE : GIT_CHECKOUT_SAFE;
 
 		int errorCode = 0;
-		if (revision.compare(INDEX) == 0)
+		if (revision == INDEX)
 			errorCode = git_checkout_index(repository_, nullptr, &options);
 		else
 		{
@@ -641,6 +641,8 @@ void GitRepository::loadGenericTree(const std::shared_ptr<GenericTree>& tree, co
 
 	SAFE_DELETE(commit);
 }
+
+int GitRepository::getMinPrefixLength() { return GIT_OID_MINPREFIXLEN; }
 
 void GitRepository::writeRevisionIntoIndex(QString revision)
 {
@@ -978,8 +980,8 @@ const CommitFile* GitRepository::getCommitFileFromIndex(QString relativePath) co
 
 const CommitFile* GitRepository::getCommitFileFromTree(QString revision, QString relativePath) const
 {
-	Q_ASSERT(revision.compare(WORKDIR) != 0);
-	Q_ASSERT(revision.compare(INDEX) != 0);
+	Q_ASSERT(revision != WORKDIR);
+	Q_ASSERT(revision != INDEX);
 
 	int errorCode = 0;
 
@@ -1069,11 +1071,6 @@ git_commit* GitRepository::parseCommit(QString revision) const
 	git_object_free(obj);
 }
 
-int GitRepository::getMinPrefixLength()
-{
-	return GIT_OID_MINPREFIXLEN;
-}
-
 QString GitRepository::oidToQString(const git_oid* oid) const
 {
 	char sha1[GIT_OID_HEXSZ + 1]{0};
@@ -1085,7 +1082,7 @@ QString GitRepository::oidToQString(const git_oid* oid) const
 
 void GitRepository::findPersistentUnitDeclarations(GenericNode* node, IdToGenericNodeHash& declarations)
 {
-	if (node->type().compare(GenericNode::PERSISTENT_UNIT_TYPE) == 0)
+	if (node->type() == GenericNode::PERSISTENT_UNIT_TYPE)
 		declarations.insert(node->id(), node);
 	else
 		for (GenericNode* child : node->children())

--- a/FilePersistence/src/version_control/GitRepository.h
+++ b/FilePersistence/src/version_control/GitRepository.h
@@ -89,6 +89,8 @@ class FILEPERSISTENCE_API GitRepository
 
 		void loadGenericTree(const std::shared_ptr<GenericTree>& tree, const QString version);
 
+		static int getMinPrefixLength();
+
 	private:
 		friend class Merge;
 

--- a/InteractionBase/src/vis/TextAndDescription.cpp
+++ b/InteractionBase/src/vis/TextAndDescription.cpp
@@ -76,6 +76,7 @@ void TextAndDescription::determineChildren()
 	{
 		descriptionVis_->setStyle( &style()->description() );
 		descriptionVis_->setText(description_);
+		descriptionVis_->setTextFormat(Qt::RichText);
 	}
 }
 

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -196,6 +196,8 @@ bool DiffManager::findChangedNode(Model::TreeManager* treeManager, Model::NodeId
 void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem,
 														 QList<ChangeWithNodes> changesWithNodes)
 {
+	QString arrowLayer = "move_arrows";
+	diffViewItem->setArrowStyle(arrowLayer, "thick");
 	for (auto change : changesWithNodes)
 	{
 		QString highlightOverlayStyle;
@@ -217,7 +219,7 @@ void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem
 
 				// add arrow for the moved node
 				diffViewItem->addArrow(const_cast<Model::Node*>(change.oldNode_),
-											  const_cast<Model::Node*>(change.newNode_), QString{"move_arrows"});
+											  const_cast<Model::Node*>(change.newNode_), arrowLayer);
 				break;
 			case FilePersistence::ChangeType::Stationary:
 				highlightOverlayName = "modify_highlights";

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -196,6 +196,7 @@ bool DiffManager::findChangedNode(Model::TreeManager* treeManager, Model::NodeId
 void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem,
 														 QList<ChangeWithNodes> changesWithNodes)
 {
+	static const QString arrowLayer = "move_arrows";
 	QString arrowLayer = "move_arrows";
 	diffViewItem->setArrowStyle(arrowLayer, "thick");
 	for (auto change : changesWithNodes)

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -197,7 +197,6 @@ void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem
 														 QList<ChangeWithNodes> changesWithNodes)
 {
 	static const QString arrowLayer = "move_arrows";
-	QString arrowLayer = "move_arrows";
 	diffViewItem->setArrowStyle(arrowLayer, "thick");
 	for (auto change : changesWithNodes)
 	{

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -271,6 +271,16 @@ void DiffManager::visualizeChangedNodes(Model::TreeManager* oldVersionManager,
 Model::TreeManager* DiffManager::createTreeManagerFromVersion(FilePersistence::GitRepository& repository,
 																				  QString version)
 {
+	if (version == FilePersistence::GitRepository::WORKDIR)
+	{
+		auto fileStore = new FilePersistence::SimpleTextFileStore {"projects/"};
+		Model::TreeManager* versionTreeManager = new Model::TreeManager{};
+		versionTreeManager->load(fileStore, project_, false);
+
+		return versionTreeManager;
+
+	}
+
 	std::unique_ptr<const FilePersistence::Commit> commit{repository.getCommit(version)};
 
 	auto fileStore = new FilePersistence::SimpleTextFileStore {

--- a/VersionControlUI/src/commands/CDiff.cpp
+++ b/VersionControlUI/src/commands/CDiff.cpp
@@ -137,14 +137,14 @@ QList<Interaction::CommandSuggestion*> CDiff::suggest(Visualization::Item*, Visu
 			// analyze the first token
 			auto firstTokenSuggestion = commitsWithDescriptionsStartingWith(firstVersionToken, target);
 
-			// if first token is too short throw error
+			// if first token is too short signal an error
 			if (firstVersionToken.length() < GitRepository::getMinPrefixLength())
 				suggestDescription = "<i>length of first argument must be at least " +
 						QString::number(GitRepository::getMinPrefixLength())+"</i>";
 			else if (firstTokenSuggestion.size() > 1)
 				suggestDescription = "<i>ambiguous</i>";
 			else if (firstTokenSuggestion.size() == 0)
-				suggestDescription = "<i>no match</i>";
+				suggestDescription = "<i>no matching commit id</i>";
 			else
 				// add found description of first token
 				suggestDescription = firstTokenSuggestion.first().second;

--- a/VersionControlUI/src/commands/CDiff.cpp
+++ b/VersionControlUI/src/commands/CDiff.cpp
@@ -28,12 +28,7 @@
 
 #include "ModelBase/src/model/TreeManager.h"
 
-#include "VisualizationBase/src/items/RootItem.h"
 #include "VisualizationBase/src/items/Item.h"
-#include "VisualizationBase/src/VisualizationManager.h"
-#include "VisualizationBase/src/overlays/SelectionOverlay.h"
-#include "VisualizationBase/src/overlays/OverlayAccessor.h"
-#include "VisualizationBase/src/CustomSceneEvent.h"
 
 #include "FilePersistence/src/simple/SimpleTextFileStore.h"
 #include "FilePersistence/src/version_control/GitRepository.h"
@@ -45,50 +40,152 @@ using namespace FilePersistence;
 
 namespace VersionControlUI {
 
-static const QString overlayGroupName{"DiffHighlights"};
+CDiff::CDiff() : Command{"diff"} {}
 
-CDiff::CDiff() : CommandWithFlags{"diff", {{"project"}}, true, false}
-{}
+bool CDiff::canInterpret(Visualization::Item*, Visualization::Item* target,
+		const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& )
+{
+	QString managerName = target->node()->manager()->name();
 
-Interaction::CommandResult* CDiff::executeNamed(Visualization::Item*, Visualization::Item* target,
-											  const std::unique_ptr<Visualization::Cursor>&,
-											  const QString& name, const QStringList&)
+	QStringList commandTokensCopy = commandTokens;
+
+	// get GitRepository
+	QString path{"projects/" + managerName};
+
+	if (GitRepository::repositoryExists(path))
+	{
+		GitRepository repository{path};
+
+		// if there are no tokens we are unable to interpret the command
+		if (commandTokensCopy.isEmpty())
+			return false;
+
+		// check that command name starts with the characters of the first token
+		if (!name().startsWith(commandTokensCopy.takeFirst()))
+			return false;
+
+		// if there is an additional version specified, check that it is a valid commit
+		if (!commandTokensCopy.isEmpty() && !repository.isValidRevisionString(commandTokensCopy.takeFirst()))
+			return false;
+
+		// check the same if there is a second version specified
+		if (!commandTokensCopy.isEmpty() && !repository.isValidRevisionString(commandTokensCopy.takeFirst()))
+			return false;
+
+		return true;
+	}
+	else return false;
+}
+
+Interaction::CommandResult* CDiff::execute(Visualization::Item*, Visualization::Item* target,
+				const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& )
 {
 	auto scene = target->scene();
 	scene->clearFocus();
 	scene->clearSelection();
 	scene->setMainCursor(nullptr);
 
-	Model::TreeManager* headManager = target->node()->manager();
-	QString managerName = headManager->name();
+	QString managerName = target->node()->manager()->name();
 
-	// TODO add functionality to specify two versions
-	VersionControlUI::DiffManager diffManager{name, "HEAD", managerName, Model::SymbolMatcher{"Class"}};
+
+	// TODO restrict versions to versionA always be older?
+	// TODO diff with no versions should compare HEAD to workingDir if possible
+	// try to get the versions
+	QString versionA = commandTokens.value(1, "HEAD");
+	QString versionB = commandTokens.value(2, "HEAD");
+
+	VersionControlUI::DiffManager diffManager{versionA, versionB, managerName, Model::SymbolMatcher{"Class"}};
 	diffManager.visualize();
 
 	return new Interaction::CommandResult{};
 }
 
-QStringList CDiff::possibleNames(Visualization::Item*, Visualization::Item* target,
-											const std::unique_ptr<Visualization::Cursor>&)
+QList<Interaction::CommandSuggestion*> CDiff::suggest(Visualization::Item*, Visualization::Item* target,
+		const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>&)
 {
-	Model::TreeManager* headManager = target->node()->manager();
-	QString managerName = headManager->name();
+	QStringList tokensSoFar = textSoFar.split(" ");
+
+	QList<Interaction::CommandSuggestion*> suggestions;
+	QString commandName = name();
+
+	// no suggestions for that many tokens
+	if (tokensSoFar.size() > 3)
+		return {};
+
+	// check that the command name starts with the characters of the first token
+	if (name().startsWith(tokensSoFar.takeFirst()))
+	{
+		// no additional versions specified
+		if (tokensSoFar.isEmpty())
+		{
+			// TODO implement this behavior
+			suggestions.append(new Interaction::CommandSuggestion{name(), "diff working directory against head"});
+			return suggestions;
+		}
+
+		QString firstVersionToken = tokensSoFar.takeFirst();
+		QString secondVersionToken = "";
+		bool secondVersionAvailable = !tokensSoFar.isEmpty();
+		if (secondVersionAvailable) secondVersionToken = tokensSoFar.takeFirst();
+
+
+		for (auto firstTokenEntry : commitsWithDescriptionsStartingWith(firstVersionToken, target))
+		{
+			QString suggestCommand = commandName + " " + firstTokenEntry.first;
+			QString suggestDescription = firstTokenEntry.second;
+
+			if (secondVersionAvailable)
+			{
+				// if firstVersionToken is empty and we are handling the second token we suggest
+				// nothing to avoid too many suggestions
+				if (firstVersionToken.isEmpty()) return {};
+
+				for (auto secondTokenEntry : commitsWithDescriptionsStartingWith(secondVersionToken, target))
+				{
+					QString suggestCommandTwoVersion = suggestCommand + " " + secondTokenEntry.first;
+					QString suggestDescriptionTwoVersion = suggestDescription + "<br>" + secondTokenEntry.second;
+					suggestions.append(new Interaction::CommandSuggestion{suggestCommandTwoVersion, suggestDescriptionTwoVersion});
+				}
+			}
+			else
+				suggestions.append(new Interaction::CommandSuggestion{suggestCommand, suggestDescription});
+		}
+
+		return suggestions;
+	}
+	else return {};
+}
+
+
+QList<QPair<QString, QString>> CDiff::commitsWithDescriptions(Visualization::Item* target)
+{
+	// every string starts with ""
+	return commitsWithDescriptionsStartingWith("", target);
+}
+
+QList<QPair<QString, QString>> CDiff::commitsWithDescriptionsStartingWith(QString partialCommitId,
+																								  Visualization::Item* target)
+{
+	QString managerName = target->node()->manager()->name();
 
 	// get GitRepository
-	QString path{"projects/"};
-	path.append(managerName);
+	QString path{"projects/" + managerName};
 
-	QStringList names;
+	QList<QPair<QString, QString>> commitsWithDescriptions;
 	if (GitRepository::repositoryExists(path))
 	{
 		GitRepository repository{path};
 
-		names.append(repository.localBranches());
-		names.append(repository.tags());
-		names.append(repository.revisions());
+		for (auto rev : repository.revisions())
+			if (rev.startsWith(partialCommitId))
+				commitsWithDescriptions.append({rev, repository.getCommitInformation(rev).message_});
+
+		// TODO find clean way to make localBranches and tags also available
+		//commitsWithDescriptions.append(repository.localBranches());
+		//commitsWithDescriptions.append(repository.tags());
 	}
-	return names;
+	return commitsWithDescriptions;
 }
+
 
 }

--- a/VersionControlUI/src/commands/CDiff.h
+++ b/VersionControlUI/src/commands/CDiff.h
@@ -32,19 +32,22 @@
 
 namespace VersionControlUI {
 
-class VERSIONCONTROLUI_API CDiff : public Interaction::CommandWithFlags
+class VERSIONCONTROLUI_API CDiff : public Interaction::Command
 {
 	public:
 		CDiff();
+		virtual bool canInterpret(Visualization::Item* source, Visualization::Item* target,
+				const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& cursor) override;
+		virtual Interaction::CommandResult* execute(Visualization::Item* source, Visualization::Item* target,
+				const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& cursor) override;
 
-	protected:
-		virtual Interaction::CommandResult* executeNamed(Visualization::Item* source, Visualization::Item* target,
-				const std::unique_ptr<Visualization::Cursor>& cursor,
-				const QString& name, const QStringList& attributes) override;
+		virtual QList<Interaction::CommandSuggestion*> suggest(Visualization::Item* source, Visualization::Item* target,
+				const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>& cursor) override;
 
-		virtual QStringList possibleNames(Visualization::Item* source, Visualization::Item* target,
-													 const std::unique_ptr<Visualization::Cursor>& cursor) override;
-
+	private:
+		QList<QPair<QString, QString>> commitsWithDescriptions(Visualization::Item* target);
+		QList<QPair<QString, QString>> commitsWithDescriptionsStartingWith(QString partialCommitId,
+																								 Visualization::Item* target);
 };
 
 }

--- a/VersionControlUI/src/commands/CDiff.h
+++ b/VersionControlUI/src/commands/CDiff.h
@@ -45,9 +45,17 @@ class VERSIONCONTROLUI_API CDiff : public Interaction::Command
 				const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>& cursor) override;
 
 	private:
-		QList<QPair<QString, QString>> commitsWithDescriptions(Visualization::Item* target);
+		/**
+		 * Returns the unambigous prefixes of commits and their description that start with \a partialCommitId.
+		 */
 		QList<QPair<QString, QString>> commitsWithDescriptionsStartingWith(QString partialCommitId,
 																								 Visualization::Item* target);
+
+		// TODO maybe move function to an appropriate util class?
+		/**
+		 * Returns for each entry in \a strings the corresponding unambigous prefix with minimum length \a minPrefixLength
+		 */
+		static QStringList unambiguousShortestPrefixesPerString(const QStringList& strings, const int minPrefixLength);
 };
 
 }

--- a/VersionControlUI/src/precompiled.h
+++ b/VersionControlUI/src/precompiled.h
@@ -46,6 +46,8 @@
 // Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
 // plug-ins which depend on this one will not include these headers.
 
+#include <QtCore/QRegularExpression>
+
 
 #endif
 

--- a/VersionControlUI/styles/item/HighlightOverlay/delete_light_bg_solid_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/delete_light_bg_solid_outline
@@ -1,0 +1,15 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#20ff0000</color>
+		</backgroundBrush>
+		<outline>
+			<width>10.0</width>
+			<style>1</style>
+			<color>#ffff0000</color>
+		</outline>
+	</shape>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/insert
+++ b/VersionControlUI/styles/item/HighlightOverlay/insert
@@ -4,12 +4,12 @@
 		Box
 		<backgroundBrush>
 			<style>1</style>
-			<color>#5000ff00</color>
+			<color>#50009900</color>
 		</backgroundBrush>
 		<outline>
 			<width>3.0</width>
 			<style>2</style>
-			<color>#ff00ff00</color>
+			<color>#ff009900</color>
 		</outline>
 	</shape>
 </style>

--- a/VersionControlUI/styles/item/HighlightOverlay/insert_dotted_bg_solid_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/insert_dotted_bg_solid_outline
@@ -4,12 +4,12 @@
 		Box
 		<backgroundBrush>
 			<style>7</style>
-			<color>#8800ff00</color>
+			<color>#88009900</color>
 		</backgroundBrush>
 		<outline>
 			<width>10.0</width>
 			<style>1</style>
-			<color>#ff00ff00</color>
+			<color>#ff009900</color>
 		</outline>
 	</shape>
 </style>

--- a/VersionControlUI/styles/item/HighlightOverlay/insert_light_bg_solid_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/insert_light_bg_solid_outline
@@ -1,0 +1,15 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#20009900</color>
+		</backgroundBrush>
+		<outline>
+			<width>10.0</width>
+			<style>1</style>
+			<color>#ff009900</color>
+		</outline>
+	</shape>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/insert_no_bg_solid_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/insert_no_bg_solid_outline
@@ -4,12 +4,12 @@
 		Box
 		<backgroundBrush>
 			<style>0</style>
-			<color>#5000ff00</color>
+			<color>#50009900</color>
 		</backgroundBrush>
 		<outline>
 			<width>10.0</width>
 			<style>1</style>
-			<color>#ff00ff00</color>
+			<color>#ff009900</color>
 		</outline>
 	</shape>
 </style>

--- a/VersionControlUI/styles/item/HighlightOverlay/modify_light_bg_solid_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/modify_light_bg_solid_outline
@@ -1,0 +1,15 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#20ffff00</color>
+		</backgroundBrush>
+		<outline>
+			<width>10.0</width>
+			<style>1</style>
+			<color>#ffe6e600</color> 
+		</outline>
+	</shape>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/move_light_bg_solid_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/move_light_bg_solid_outline
@@ -1,0 +1,15 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#200000ff</color>
+		</backgroundBrush>
+		<outline>
+			<width>10.0</width>
+			<style>1</style>
+			<color>#ff0000ff</color>
+		</outline>
+	</shape>
+</style>

--- a/VisualizationBase/src/items/ViewItem.h
+++ b/VisualizationBase/src/items/ViewItem.h
@@ -106,6 +106,8 @@ class VISUALIZATIONBASE_API ViewItem : public Super<DeclarativeItem<ViewItem>> {
 		 */
 		void addArrow(Model::Node* from, Model::Node* to, QString layer,
 					  ViewItemNode* fromParent = nullptr, ViewItemNode* toParent = nullptr);
+
+		void setArrowStyle(QString layer, QString styleName);
 		/**
 		 * Returns the items for which an arrow should be drawn in the given arrow layer.
 		 */
@@ -153,6 +155,7 @@ class VISUALIZATIONBASE_API ViewItem : public Super<DeclarativeItem<ViewItem>> {
 			QString layer_;
 		};
 		QList<ArrowToAdd> arrowsToAdd_;
+		QHash<QString, QString> arrowStyles_;
 		QHash<QString, QList<QPair<Item*, Item*>>> arrows_;
 		QStringList disabledArrowLayers_;
 		QJsonObject arrowToJson(QPair<Item*, Item*> arrow, QString layer) const;


### PR DESCRIPTION
Add / Change some style files for highlights
Add possibility to define style for arrow layers in ViewItem
Add possibility to specify two versions for the CDiff command
Use RichText to support multi-line descriptions
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60582603%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60582653%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60583268%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60583448%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60584282%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60584433%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60584652%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60584803%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60585533%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60585643%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60586079%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60586603%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60586916%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60587322%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23issuecomment-213390766%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60739476%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60741158%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60741270%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60742555%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23issuecomment-213441704%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23issuecomment-213450740%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23issuecomment-213390766%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Updated%22%2C%20%22created_at%22%3A%20%222016-04-22T11%3A47%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Updated%22%2C%20%22created_at%22%3A%20%222016-04-22T14%3A06%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%2C%20Manuel.%22%2C%20%22created_at%22%3A%20%222016-04-22T14%3A34%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a9c51ff9ec1d49efefcd479401f7ad86c26c4e54%20VersionControlUI/src/commands/CDiff.cpp%20109%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60583268%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20this%20should%20be%20a%20one-liner.%20Please%2C%20implement%20this.%22%2C%20%22created_at%22%3A%20%222016-04-21T13%3A52%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20I%20understand%20correctly%2C%20this%20means%20that%20if%20I%20all%20I%20type%20is%20%5C%22diff%5C%22%20and%20then%20I%20hit%20enter%2C%20I%20get%20the%20head%20vs%20working%20directory.%22%2C%20%22created_at%22%3A%20%222016-04-21T13%3A53%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20but%20maybe%20it%20would%20be%20nicer%20to%20try%20to%20compare%20it%20to%20the%20current%20version%20in%20Envision.%20Basically%20to%20diff%20vs%20the%20currently%20loaded%20tree%20%28even%20if%20the%20changes%20are%20not%20saved%20to%20the%20working%20directory%29.%22%2C%20%22created_at%22%3A%20%222016-04-21T13%3A58%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22oh%2C%20It%27s%20a%20bad%20idea%20to%20diff%20to%20memory.%20Let%27s%20make%20our%20lives%20easier%20and%20just%20do%20this%20for%20things%20that%20are%20saved%20on%20disk.%22%2C%20%22created_at%22%3A%20%222016-04-21T14%3A10%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/commands/CDiff.cpp%3AL40-192%22%7D%2C%20%22Pull%20a9c51ff9ec1d49efefcd479401f7ad86c26c4e54%20VersionControlUI/src/commands/CDiff.cpp%2075%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60585643%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22don%27t%20bother%20for%20now%22%2C%20%22created_at%22%3A%20%222016-04-21T14%3A05%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/commands/CDiff.cpp%3AL40-192%22%7D%2C%20%22Pull%20a9c51ff9ec1d49efefcd479401f7ad86c26c4e54%20VersionControlUI/src/commands/CDiff.cpp%2076%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60584652%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22yes%2C%20please.%20That%20should%20be%20super%20easy.%22%2C%20%22created_at%22%3A%20%222016-04-21T14%3A00%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20believe%2C%20you%20should%20just%20%60WORKDIR%60%20instead%20of%20%60HEAD%60%20in%20one%20of%20the%20versions%20below.%20Check%20the%20%60Diff.cpp%60%20code%20to%20be%20sure.%22%2C%20%22created_at%22%3A%20%222016-04-21T14%3A00%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20just%20checked%2C%20in%20%60GitRepository.cpp%60%2C%20Use%20this%3A%20%60GitRepository%3A%3AWORKDIR%60%22%2C%20%22created_at%22%3A%20%222016-04-21T14%3A04%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20if%20I%20use%20this%20I%20have%20to%20change%20how%20the%20file%20content%20is%20loaded.%20At%20the%20moment%20I%20use%20getCommit%28%29%20which%20doesn%27t%20work%20with%20GitRepository%3A%3AWORKDIR%20I%20think.%20I%27ll%20have%20a%20look%20at%20it.%22%2C%20%22created_at%22%3A%20%222016-04-21T14%3A07%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Where%20do%20you%20use%20%60getCommit%60%3F%20In%20the%20%60DiffManager%60%3F%22%2C%20%22created_at%22%3A%20%222016-04-21T14%3A12%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20on%20line%20274%3A%20%60std%3A%3Aunique_ptr%3Cconst%20FilePersistence%3A%3ACommit%3E%20commit%7Brepository.getCommit%28version%29%7D%3B%60%22%2C%20%22created_at%22%3A%20%222016-04-21T14%3A14%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/commands/CDiff.cpp%3AL40-192%22%7D%2C%20%22Pull%20761d6e4ea0c6967b6304e2c26a57ff294e877f7e%20VersionControlUI/src/commands/CDiff.cpp%2061%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60741158%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22we%27re%20not%20really%20throwing%2C%20change%20the%20commit%20to%20say%20%27signal%20and%20error%60%22%2C%20%22created_at%22%3A%20%222016-04-22T13%3A49%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/commands/CDiff.cpp%3AL115-168%22%7D%2C%20%22Pull%20a9c51ff9ec1d49efefcd479401f7ad86c26c4e54%20VersionControlUI/src/commands/CDiff.cpp%20120%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60584433%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20think%20we%20should%20have%20nested%20loops%20here.%20You%20should%20always%20just%20looup%20the%20last%20available%20token%2C%20either%20the%20first%20one%20or%20the%20second%20one%2C%20and%20offer%20autocompletions%20with%20the%20initial%20text%20%2B%20the%20completion%20of%20the%20last%20token.%5Cr%5Cn%5Cr%5CnBtw%2C%20if%20I%20understand%20git%20correctly%2C%20you%20can%20specify%20a%20partial%20commit%20id%2C%20as%20long%20as%20it%20is%20unambiguous.%20Thus%20it%20would%20be%20good%20if%20your%20command%20work%20with%20partial%20ids%20as%20well%20%28I%20guess%20you%20just%20need%20to%20forward%20those%29.%20So%20for%20example%2C%20it%20would%20be%20nice%20if%20I%20could%20type%20%60diff%20abcd34%203323a%60%20and%20hit%20enter%2C%20without%20having%20to%20complete%20to%20the%20full-blown%20names.%5Cr%5Cn%5Cr%5CnA%20step%20further%20would%20be%2C%20for%20the%20auto-completion%20itself%20to%20only%20complete%20an%20id%20as%20much%20as%20needed%20to%20make%20it%20unambiguous%2C%20but%20not%20more%5Cr%5Cn%5Cr%5Cnso%20given%20the%20ids%20%60abc34567%60%20and%20%60abc99999%60%5Cr%5Cn%5Cr%5CnYou%20could%20offer%20completions%20that%20look%20like%20this%3A%20%60diff%20abc3%60%20and%20%60diff%20abc9%60%22%2C%20%22created_at%22%3A%20%222016-04-21T13%3A58%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/commands/CDiff.cpp%3AL40-192%22%7D%2C%20%22Pull%20761d6e4ea0c6967b6304e2c26a57ff294e877f7e%20VersionControlUI/src/commands/CDiff.cpp%2068%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60741270%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22no%20matching%20commit%20id%22%2C%20%22created_at%22%3A%20%222016-04-22T13%3A50%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/commands/CDiff.cpp%3AL115-168%22%7D%2C%20%22Pull%2012a2a403db117d3a4ad498b1e90e0900b398790b%20VersionControlUI/src/DiffManager.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60582603%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20be%20%60static%20const%60.%22%2C%20%22created_at%22%3A%20%222016-04-21T13%3A48%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Or%20if%20you%20use%20it%20in%20a%20number%20of%20places%2C%20then%20make%20it%20a%20const%20field%22%2C%20%22created_at%22%3A%20%222016-04-21T13%3A49%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL196-204%22%7D%2C%20%22Pull%2095554fc208b540b132bb1dc888702200937b1e4b%20VersionControlUI/src/DiffManager.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/370%23discussion_r60739476%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Err%2C%20but%20now%20you%20define%20this%20string%20twice%2C%20on%20this%20line%20and%20on%20the%20next%20one.%20Remove%20the%20next%20line.%22%2C%20%22created_at%22%3A%20%222016-04-22T13%3A37%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Woops%2C%20missed%20a%20line%20in%20git%20gui.%22%2C%20%22created_at%22%3A%20%222016-04-22T13%3A59%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL196-203%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 12a2a403db117d3a4ad498b1e90e0900b398790b VersionControlUI/src/DiffManager.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/370#discussion_r60582603'>File: VersionControlUI/src/DiffManager.cpp:L196-204</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This should be `static const`.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Or if you use it in a number of places, then make it a const field
- [ ] <a href='#crh-comment-Pull a9c51ff9ec1d49efefcd479401f7ad86c26c4e54 VersionControlUI/src/commands/CDiff.cpp 109'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/370#discussion_r60583268'>File: VersionControlUI/src/commands/CDiff.cpp:L40-192</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, this should be a one-liner. Please, implement this.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> If I understand correctly, this means that if I all I type is "diff" and then I hit enter, I get the head vs working directory.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Yes, but maybe it would be nicer to try to compare it to the current version in Envision. Basically to diff vs the currently loaded tree (even if the changes are not saved to the working directory).
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> oh, It's a bad idea to diff to memory. Let's make our lives easier and just do this for things that are saved on disk.
- [ ] <a href='#crh-comment-Pull a9c51ff9ec1d49efefcd479401f7ad86c26c4e54 VersionControlUI/src/commands/CDiff.cpp 120'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/370#discussion_r60584433'>File: VersionControlUI/src/commands/CDiff.cpp:L40-192</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I don't think we should have nested loops here. You should always just looup the last available token, either the first one or the second one, and offer autocompletions with the initial text + the completion of the last token.
  Btw, if I understand git correctly, you can specify a partial commit id, as long as it is unambiguous. Thus it would be good if your command work with partial ids as well (I guess you just need to forward those). So for example, it would be nice if I could type `diff abcd34 3323a` and hit enter, without having to complete to the full-blown names.
  A step further would be, for the auto-completion itself to only complete an id as much as needed to make it unambiguous, but not more
  so given the ids `abc34567` and `abc99999`
  You could offer completions that look like this: `diff abc3` and `diff abc9`
- [ ] <a href='#crh-comment-Pull a9c51ff9ec1d49efefcd479401f7ad86c26c4e54 VersionControlUI/src/commands/CDiff.cpp 76'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/370#discussion_r60584652'>File: VersionControlUI/src/commands/CDiff.cpp:L40-192</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> yes, please. That should be super easy.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I believe, you should just `WORKDIR` instead of `HEAD` in one of the versions below. Check the `Diff.cpp` code to be sure.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I just checked, in `GitRepository.cpp`, Use this: `GitRepository::WORKDIR`
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> I think if I use this I have to change how the file content is loaded. At the moment I use getCommit() which doesn't work with GitRepository::WORKDIR I think. I'll have a look at it.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Where do you use `getCommit`? In the `DiffManager`?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Yes, on line 274: `std::unique_ptr<const FilePersistence::Commit> commit{repository.getCommit(version)};`
- [ ] <a href='#crh-comment-Pull a9c51ff9ec1d49efefcd479401f7ad86c26c4e54 VersionControlUI/src/commands/CDiff.cpp 75'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/370#discussion_r60585643'>File: VersionControlUI/src/commands/CDiff.cpp:L40-192</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> don't bother for now
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/370#issuecomment-213390766'>General Comment</a></b>
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Updated
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Updated
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks, Manuel.
- [ ] <a href='#crh-comment-Pull 95554fc208b540b132bb1dc888702200937b1e4b VersionControlUI/src/DiffManager.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/370#discussion_r60739476'>File: VersionControlUI/src/DiffManager.cpp:L196-203</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Err, but now you define this string twice, on this line and on the next one. Remove the next line.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Woops, missed a line in git gui.
- [ ] <a href='#crh-comment-Pull 761d6e4ea0c6967b6304e2c26a57ff294e877f7e VersionControlUI/src/commands/CDiff.cpp 61'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/370#discussion_r60741158'>File: VersionControlUI/src/commands/CDiff.cpp:L115-168</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> we're not really throwing, change the commit to say 'signal and error`
- [ ] <a href='#crh-comment-Pull 761d6e4ea0c6967b6304e2c26a57ff294e877f7e VersionControlUI/src/commands/CDiff.cpp 68'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/370#discussion_r60741270'>File: VersionControlUI/src/commands/CDiff.cpp:L115-168</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> no matching commit id

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/370?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/370?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/370'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
