### PR TITLE
Gm diff manager

### DIFF
--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -85,7 +85,9 @@ bool Commit::getFileContent(QString fileName, const char*& content, int& content
 		while (iter != files_.constEnd())
 		{
 			QFileInfo fileInfo{iter.key()};
-			if ((fileName.startsWith("{") && fileInfo.fileName().contains(fileName))|| fileInfo.fileName() == fileName)
+			if (!fileInfo.isDir() &&
+				 ((fileName.startsWith("{") && fileInfo.fileName().contains(fileName))
+				 || fileInfo.fileName() == fileName))
 				break;
 			iter++;
 		}

--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -82,8 +82,13 @@ bool Commit::getFileContent(QString fileName, const char*& content, int& content
 	else
 	{
 		iter = files_.constBegin();
-		while (!iter.key().contains(fileName) && iter != files_.constEnd())
+		while (iter != files_.constEnd())
+		{
+			QFileInfo fileInfo{iter.key()};
+			if ((fileName.startsWith("{") && fileInfo.fileName().contains(fileName))|| fileInfo.fileName() == fileName)
+				break;
 			iter++;
+		}
 	}
 
 	if (iter != files_.constEnd())

--- a/FilePersistence/src/version_control/GitPiecewiseLoader.h
+++ b/FilePersistence/src/version_control/GitPiecewiseLoader.h
@@ -48,7 +48,7 @@ class FILEPERSISTENCE_API GitPiecewiseLoader : public PiecewiseLoader
 		QList<NodeData> loadNodeChildrenData(Model::NodeIdType id);
 
 	private:
-		static NodeData parseGrepLine(const QString& line);
+		static NodeData parseGrepLine(const QString& line, bool isWorkDir);
 
 		static bool isPersistenceUnit(const QString& nodeLine);
 

--- a/OOInteraction/src/commands/CSceneHandlerItemTest.cpp
+++ b/OOInteraction/src/commands/CSceneHandlerItemTest.cpp
@@ -41,6 +41,8 @@
 #include "ModelBase/src/model/TreeManager.h"
 #include "ModelBase/src/nodes/Reference.h"
 
+#include "VersionControlUI/src/DiffManager.h"
+
 
 namespace OOInteraction {
 
@@ -55,99 +57,12 @@ bool CSceneHandlerItemTest::canInterpret(Visualization::Item*, Visualization::It
 Interaction::CommandResult* CSceneHandlerItemTest::execute(Visualization::Item*, Visualization::Item*,
 		const QStringList&, const std::unique_ptr<Visualization::Cursor>&)
 {
-	//Test code goes here
 
-	QString projectsDir = "projects/";
+	VersionControlUI::DiffManager diffManager{"f02f73470efdd7153b83637ed17d12cb9ad67561",
+															"a4d1df8c996ec791ea84cd6d8d06d496c4d0be53", "DiffTest",
+															Model::SymbolMatcher{"Class"}};
 
-	// versions to compare
-	QString newCommitId = "HEAD";
-	QString oldCommitId = "f1e118bc7e522e2c9404d29d1b21e58956018354";
-
-	// project names
-	QString newVersionProject = "MyTest"+newCommitId;
-	QString oldVersionProject = "MyTest"+oldCommitId;
-
-	FilePersistence::SimpleTextFileStore store;
-	store.setBaseFolder(projectsDir);
-
-	// load newer version
-	Model::TreeManager* newVersionManager = new Model::TreeManager{};
-	newVersionManager->load(&store, newVersionProject, false);
-
-	// load older version
-	Model::TreeManager* oldVersionManager = new Model::TreeManager{};
-	oldVersionManager->load(&store, oldVersionProject, false);
-
-	Model::Reference::resolvePending();
-
-	// get GitRepository
-	QString path{projectsDir + newVersionProject};
-	if (!FilePersistence::GitRepository::repositoryExists(path))
-	{
-		qDebug() << "no repository found at " + path;
-		return new Interaction::CommandResult{};
-	}
-
-	FilePersistence::GitRepository repository{path};
-
-	FilePersistence::Diff diff = repository.diff(oldCommitId, newCommitId);
-	auto changes = diff.changes();
-
-	QSet<Model::NodeIdType> changedNodesToVisualize;
-
-	auto typeMatcher = Model::SymbolMatcher::guessMatcher("Class");
-
-	for (auto change : changes.values())
-	{
-		if (change->isFake() || change->onlyStructureChange()) continue;
-
-		auto id = change->nodeId();
-
-		// search one instance of the changed node
-		if (auto node = const_cast<Model::Node*>(Model::AllTreeManagers::instance().nodeForId(id)))
-		{
-
-			Model::Node* changedNode = nullptr;
-
-			if (auto ancestorNode = node->firstAncestorOfType(typeMatcher))
-			{
-				changedNode = ancestorNode;
-				id = newVersionManager->nodeIdMap().id(changedNode);
-			}
-			else
-				changedNode = node;
-
-			// Ignore empty nodes
-			if (auto changedExpr = DCast<OOModel::ExpressionStatement>(changedNode))
-				if (DCast<OOModel::EmptyExpression>(changedExpr->expression()))
-					continue;
-
-			changedNodesToVisualize.insert(id);
-		}
-	}
-
-	Visualization::VisualizationManager::instance().mainScene()->listenToTreeManager(newVersionManager);
-	Visualization::VisualizationManager::instance().mainScene()->listenToTreeManager(oldVersionManager);
-
-	Visualization::VisualizationManager::instance().mainScene()->currentViewItem()
-			->setMajorAxis(Visualization::GridLayouter::NoMajor);
-
-	for (auto id : changedNodesToVisualize)
-	{
-		auto oldNode = const_cast<Model::Node*>(oldVersionManager->nodeIdMap().node(id));
-		auto newNode = const_cast<Model::Node*>(newVersionManager->nodeIdMap().node(id));
-
-
-		if (!oldNode)
-			oldNode = new Model::Text{"node in old version not found"};
-
-		Visualization::VisualizationManager::instance().mainScene()->addTopLevelNode(oldNode, 0);
-
-		if (!newNode)
-			newNode = new Model::Text{"node in new version not found"};
-
-		Visualization::VisualizationManager::instance().mainScene()->addTopLevelNode(newNode, 1);
-	}
+	diffManager.visualize();
 
 
 	return new Interaction::CommandResult{};

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -165,18 +165,18 @@ void DiffManager::removeDirectChildrenOfNodesInContainer(QList<ChangeWithNodes>*
 QSet<Model::Node*> DiffManager::findAllNodesWithDirectParentPresent(QHash<Model::Node*,
 																						  FilePersistence::ChangeType>& nodes)
 {
-	QSet<Model::Node*> nodesMarkedForRemoval;
+	QSet<Model::Node*> result;
 	for (auto node : nodes.keys())
 		// check that changeType also matches
 		if (nodes.contains(node->parent()) && nodes[node] == nodes[node->parent()])
-				nodesMarkedForRemoval.insert(node);
+				result.insert(node);
 
-	return nodesMarkedForRemoval;
+	return result;
 }
 
-QSet<Visualization::Item*> DiffManager::findAllItemsWithParentPresent(QSet<Visualization::Item*> items)
+QSet<Visualization::Item*> DiffManager::findAllItemsWithAncestorsIn(QSet<Visualization::Item*> items)
 {
-	QSet<Visualization::Item*> itemsMarkedForRemoval;
+	QSet<Visualization::Item*> result;
 	for (auto item : items)
 	{
 		auto parent = item->parent();
@@ -184,14 +184,14 @@ QSet<Visualization::Item*> DiffManager::findAllItemsWithParentPresent(QSet<Visua
 		{
 			if (items.contains(parent))
 			{
-				itemsMarkedForRemoval.insert(item);
+				result.insert(item);
 				break;
 			}
 			parent = parent->parent();
 		}
 	}
 
-	return itemsMarkedForRemoval;
+	return result;
 }
 
 // TODO find good way to return and use Node instead of Id
@@ -268,16 +268,9 @@ void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem
 		}
 	}
 
-	QSet<Visualization::Item*> removeItems = findAllItemsWithParentPresent(allItemsToScale);
+	QSet<Visualization::Item*> removeItems = findAllItemsWithAncestorsIn(allItemsToScale);
 
-	auto it = allItemsToScale.begin();
-	while (it != allItemsToScale.end())
-	{
-		if (removeItems.contains(*it))
-			it = allItemsToScale.erase(it);
-		else
-			it++;
-	}
+	allItemsToScale.subtract(removeItems);
 
 	Visualization::VisualizationManager::instance().mainScene()->
 			addOnZoomHandler([allItemsToScale](qreal factor)

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -95,7 +95,7 @@ class VERSIONCONTROLUI_API DiffManager
 		/**
 		 * Returns all items which have any of their parents present in \a items.
 		 */
-		static QSet<Visualization::Item*> findAllItemsWithParentPresent(QSet<Visualization::Item*> items);
+		static QSet<Visualization::Item*> findAllItemsWithAncestorsIn(QSet<Visualization::Item*> items);
 
 		QString oldVersion_;
 		QString newVersion_;

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -42,6 +42,7 @@ namespace FilePersistence
 namespace Visualization
 {
 	class ViewItem;
+	class Item;
 }
 
 namespace VersionControlUI {
@@ -90,6 +91,11 @@ class VERSIONCONTROLUI_API DiffManager
 		 * Creates a TreeManager from \a version using \a repository.
 		 */
 		Model::TreeManager* createTreeManagerFromVersion(FilePersistence::GitRepository& repository, QString version);
+
+		/**
+		 * Returns all items which have any of their parents present in \a items.
+		 */
+		static QSet<Visualization::Item*> findAllItemsWithParentPresent(QSet<Visualization::Item*> items);
 
 		QString oldVersion_;
 		QString newVersion_;

--- a/VersionControlUI/src/commands/CDiff.h
+++ b/VersionControlUI/src/commands/CDiff.h
@@ -51,11 +51,12 @@ class VERSIONCONTROLUI_API CDiff : public Interaction::Command
 		QList<QPair<QString, QString>> commitsWithDescriptionsStartingWith(QString partialCommitId,
 																								 Visualization::Item* target);
 
-		// TODO maybe move function to an appropriate util class?
 		/**
 		 * Returns for each entry in \a strings the corresponding unambigous prefix with minimum length \a minPrefixLength
 		 */
-		static QStringList unambiguousShortestPrefixesPerString(const QStringList& strings, const int minPrefixLength);
+		QStringList computeUnambiguousShortestPrefixesPerString(const QStringList& strings, const int minPrefixLength);
+
+		QHash<QString, QString> unambigousPrefixPerRevision_;
 };
 
 }

--- a/VisualizationBase/src/Scene.cpp
+++ b/VisualizationBase/src/Scene.cpp
@@ -477,6 +477,7 @@ void Scene::setMainViewScalingFactor(qreal factor)
 		previousMainViewScalingFactor_ = mainViewScalingFactor_;
 		mainViewScalingFactor_ = factor;
 		mainViewScalingFactorChanged_ = true;
+		for (auto onZoomHandler : onZoomHandlers_) onZoomHandler(factor);
 		scheduleUpdate();
 	}
 }

--- a/VisualizationBase/src/Scene.h
+++ b/VisualizationBase/src/Scene.h
@@ -59,6 +59,7 @@ class VISUALIZATIONBASE_API Scene : public QGraphicsScene
 	public:
 
 		using RefreshActionFunction = std::function<void (Scene* scene)>;
+		using OnZoomHandler = std::function<void (qreal factor)>;
 
 		Scene();
 		virtual ~Scene();
@@ -110,6 +111,7 @@ class VISUALIZATIONBASE_API Scene : public QGraphicsScene
 		const QList<Item*>& topLevelItems() const;
 
 		void addRefreshActionFunction(RefreshActionFunction func);
+		void addOnZoomHandler(OnZoomHandler onZoomHandler);
 
 		/**
 		 * Returns the focused item if it is an instance of Item* or the closest of its ancestors that is an Item*.
@@ -209,6 +211,7 @@ class VISUALIZATIONBASE_API Scene : public QGraphicsScene
 		const int MAX_MILLISECONDS_FOR_A_CLICK = 500;
 
 		QList<RefreshActionFunction> refreshActionFunctions_;
+		QList<OnZoomHandler> onZoomHandlers_;
 
 		QSet<Item*> itemsSensitiveToScale_;
 
@@ -231,6 +234,8 @@ inline SceneHandlerItem* Scene::sceneHandlerItem() {return sceneHandlerItem_; }
 inline Cursor* Scene::mainCursor() { return mainCursor_; }
 inline const QList<Item*>& Scene::topLevelItems() const {return topLevelItems_; }
 inline void Scene::addRefreshActionFunction(RefreshActionFunction func) {refreshActionFunctions_.append(func); }
+
+inline void Scene::addOnZoomHandler(OnZoomHandler onZoomHandler) {onZoomHandlers_.append(onZoomHandler);}
 
 inline bool Scene::isCurrentMousePressAClick() const { return isCurrentMousePressAClick_; }
 inline QPointF Scene::lastMouseHoverPosition() const { return lastMouseHoverPosition_; }


### PR DESCRIPTION
- Correct getFileContent to avoid matching of fileName with directory names
- Add handling for working directory
- Use test command to call DiffManager
- Add slower zooming for changed components
- Change behaviour of CDiff to use internally the complete sha1 hashes if available
  -> This is to avoid ambiguity conflicts with git intern objects other than commits
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61048637%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61048863%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61049714%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61054536%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61054617%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61054686%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61056860%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61057052%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23issuecomment-214689914%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23issuecomment-214709662%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23issuecomment-214710103%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23issuecomment-214689914%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Alright%2C%20I%27ve%20seen%20it%20all%2C%20just%20fix%20the%20few%20small%20issues%20and%20I%27ll%20merge%20it.%5Cr%5Cn%5Cr%5CnThanks.%22%2C%20%22created_at%22%3A%20%222016-04-26T10%3A00%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Updated%22%2C%20%22created_at%22%3A%20%222016-04-26T11%3A24%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%22%2C%20%22created_at%22%3A%20%222016-04-26T11%3A27%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20643ff8b0e8eab0c1da7775bb0f409bb310850988%20FilePersistence/src/version_control/GitPiecewiseLoader.cpp%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61048863%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looks%20fine%20to%20me.%20Does%20it%20work%20as%20expected%3F%22%2C%20%22created_at%22%3A%20%222016-04-26T08%3A47%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22As%20far%20as%20I%20can%20tell%3A%20yes.%22%2C%20%22created_at%22%3A%20%222016-04-26T09%3A27%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitPiecewiseLoader.cpp%3AL41-58%22%7D%2C%20%22Pull%208dbf7f6bcff02fd1da02b30621b392ac968f75b7%20VersionControlUI/src/DiffManager.h%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61049714%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22A%20slightly%20better%20name%20is%20%60findAllItemsWithParentIn%60%5Cr%5Cn%5Cr%5CnAre%20you%20talking%20about%20direct%20parents%20or%20Ancestors%3F%20If%20the%20second%20then%20please%20use%20the%20appropriate%20word.%22%2C%20%22created_at%22%3A%20%222016-04-26T08%3A54%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20you%20are%20right%2C%20ancestor%20would%20be%20correct.%5Cr%5Cn%5Cr%5CnI%27ll%20change%20it.%22%2C%20%22created_at%22%3A%20%222016-04-26T09%3A28%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.h%3AL92-103%22%7D%2C%20%22Pull%204d84618f37dad36513bb6da20cf23c9e5d6521a7%20FilePersistence/src/version_control/Commit.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61048637%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20check%20is%20still%20somewhat%20brittle%2C%20as%20it%20still%20relies%20on%20specifics%20of%20the%20name%2C%20which%20might%20change%20in%20the%20future.%5Cr%5Cn%5Cr%5CnWhy%20not%20use%20%60QFileInfo%3A%3AisDir%60%20for%20entries%20that%20contain%20%60fileName%60%3F%20This%20should%20be%20more%20stable.%22%2C%20%22created_at%22%3A%20%222016-04-26T08%3A45%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%2C%20I%20already%20avoid%20matching%20directories%20by%20using%20%60QFileInfo%3A%3AfileName%28%29%60%20which%20returns%20just%20the%20filename%20without%20the%20path.%5Cr%5Cn%5Cr%5CnThe%20check%20afterwards%20is%20to%20see%20if%20it%20is%20an%20UID%20which%20can%20be%20matched%20using%20contains%20or%20something%20else%2C%20where%20contains%20would%20not%20be%20good%20%28file%20%5C%22foobar%5C%22%20contains%20%5C%22foo%5C%22%29%20and%20thus%20I%20use%20exact%20matching%20for%20just%20the%20filename.%5Cr%5Cn%5Cr%5CnBut%20I%20agree%20it%20is%20brittle.%22%2C%20%22created_at%22%3A%20%222016-04-26T09%3A27%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL82-95%22%7D%2C%20%22Pull%208dbf7f6bcff02fd1da02b30621b392ac968f75b7%20VersionControlUI/src/DiffManager.cpp%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61057052%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Know%20your%20libraries%2C%20instead%20of%20these%20several%20lines%2C%20use%20simply%3A%5Cr%5Cnhttp%3A//doc.qt.io/qt-5/qset.html%23subtract%22%2C%20%22created_at%22%3A%20%222016-04-26T09%3A43%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL261-298%22%7D%2C%20%22Pull%208dbf7f6bcff02fd1da02b30621b392ac968f75b7%20VersionControlUI/src/DiffManager.cpp%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/371%23discussion_r61056860%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20name%20of%20this%20local%20field%20is%20out%20of%20place.%20Nothing%20in%20this%20method%20itself%20suggests%20what%20the%20resulting%20list%20will%20be%20used.%20You%27re%20just%20computing%20which%20are%20the%20items%20that%20have%20parents%2C%20and%20somebody%20on%20the%20outside%20uses%20this%20to%20remove%20some%20items%20from%20somewhere.%5Cr%5Cn%5Cr%5CnCall%20%20this%20%60result%60%22%2C%20%22created_at%22%3A%20%222016-04-26T09%3A42%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL174-200%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 4d84618f37dad36513bb6da20cf23c9e5d6521a7 FilePersistence/src/version_control/Commit.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/371#discussion_r61048637'>File: FilePersistence/src/version_control/Commit.cpp:L82-95</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This check is still somewhat brittle, as it still relies on specifics of the name, which might change in the future.
  Why not use `QFileInfo::isDir` for entries that contain `fileName`? This should be more stable.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Hm, I already avoid matching directories by using `QFileInfo::fileName()` which returns just the filename without the path.
  The check afterwards is to see if it is an UID which can be matched using contains or something else, where contains would not be good (file "foobar" contains "foo") and thus I use exact matching for just the filename.
  But I agree it is brittle.
- [ ] <a href='#crh-comment-Pull 643ff8b0e8eab0c1da7775bb0f409bb310850988 FilePersistence/src/version_control/GitPiecewiseLoader.cpp 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/371#discussion_r61048863'>File: FilePersistence/src/version_control/GitPiecewiseLoader.cpp:L41-58</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Looks fine to me. Does it work as expected?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> As far as I can tell: yes.
- [ ] <a href='#crh-comment-Pull 8dbf7f6bcff02fd1da02b30621b392ac968f75b7 VersionControlUI/src/DiffManager.h 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/371#discussion_r61049714'>File: VersionControlUI/src/DiffManager.h:L92-103</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> A slightly better name is `findAllItemsWithParentIn`
  Are you talking about direct parents or Ancestors? If the second then please use the appropriate word.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Ah you are right, ancestor would be correct.
  I'll change it.
- [ ] <a href='#crh-comment-Pull 8dbf7f6bcff02fd1da02b30621b392ac968f75b7 VersionControlUI/src/DiffManager.cpp 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/371#discussion_r61056860'>File: VersionControlUI/src/DiffManager.cpp:L174-200</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> The name of this local field is out of place. Nothing in this method itself suggests what the resulting list will be used. You're just computing which are the items that have parents, and somebody on the outside uses this to remove some items from somewhere.
  Call  this `result`
- [ ] <a href='#crh-comment-Pull 8dbf7f6bcff02fd1da02b30621b392ac968f75b7 VersionControlUI/src/DiffManager.cpp 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/371#discussion_r61057052'>File: VersionControlUI/src/DiffManager.cpp:L261-298</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Know your libraries, instead of these several lines, use simply:
  http://doc.qt.io/qt-5/qset.html#subtract
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/371#issuecomment-214689914'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Alright, I've seen it all, just fix the few small issues and I'll merge it.
  Thanks.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Updated
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/371?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/371?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/371'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
