### PR TITLE
Gm diff manager

### DIFF
--- a/OOInteraction/src/commands/CSceneHandlerItemTest.cpp
+++ b/OOInteraction/src/commands/CSceneHandlerItemTest.cpp
@@ -58,8 +58,8 @@ Interaction::CommandResult* CSceneHandlerItemTest::execute(Visualization::Item*,
 		const QStringList&, const std::unique_ptr<Visualization::Cursor>&)
 {
 
-	VersionControlUI::DiffManager diffManager{"f02f73470efdd7153b83637ed17d12cb9ad67561",
-															"a4d1df8c996ec791ea84cd6d8d06d496c4d0be53", "DiffTest",
+	VersionControlUI::DiffManager diffManager{"a1f5",
+															"f02f", "DiffTest",
 															Model::SymbolMatcher{"Class"}};
 
 	diffManager.visualize();

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -218,6 +218,11 @@ bool DiffManager::findChangedNode(Model::TreeManager* treeManager, Model::NodeId
 			resultId = treeManager->nodeIdMap().id(changedNode);
 			return true;
 		}
+		else
+		{
+			resultId = treeManager->nodeIdMap().id(node);
+		}
+		return true;
 	}
 	return false;
 }

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -120,7 +120,14 @@ void DiffManager::visualize()
 	Visualization::VisualizationManager::instance().mainScene()->listenToTreeManager(oldVersionManager);
 
 	auto diffViewItem = Visualization::VisualizationManager::instance().mainScene()->
-			viewItems()->newViewItem("DiffView");
+			viewItems()->viewItem("DiffView");
+
+	if (diffViewItem)
+		Visualization::VisualizationManager::instance().mainScene()->
+					viewItems()->removeViewItem(diffViewItem);
+
+	diffViewItem = Visualization::VisualizationManager::instance().mainScene()->
+				viewItems()->newViewItem("DiffView");
 
 	diffViewItem->setMajorAxis(Visualization::GridLayouter::NoMajor);
 

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -97,6 +97,10 @@ class VERSIONCONTROLUI_API DiffManager
 		 */
 		static QSet<Visualization::Item*> findAllItemsWithAncestorsIn(QSet<Visualization::Item*> items);
 
+
+		static Visualization::Item* addHighlightAndReturnItem(Model::Node* node, Visualization::ViewItem* viewItem,
+																QString highlightOverlayName, QString highlightOverlayStyle);
+
 		QString getObjectPath(Model::Node* node);
 
 		QString oldVersion_;

--- a/VersionControlUI/src/items/VDiffComparisonPair.cpp
+++ b/VersionControlUI/src/items/VDiffComparisonPair.cpp
@@ -98,9 +98,8 @@ bool VDiffComparisonPair::isSensitiveToScale() const
 	return true;
 }
 
-void VDiffComparisonPair::determineChildren()
+void VDiffComparisonPair::scaleVisualizations()
 {
-	Super::determineChildren();
 	qreal factor = Visualization::VisualizationManager::instance().mainScene()->mainViewScalingFactor();
 	qreal scale;
 	if (factor >= 1.0)
@@ -109,16 +108,20 @@ void VDiffComparisonPair::determineChildren()
 		scale = 1.0/factor;
 	else
 		scale = 1.0;
-				//item->setScale((1/factor) * std::pow(0.95, 1/factor));
+
 	if (componentType_)
 		componentType_->setScale(scale);
+
 	if (oldVersionObjectPath_)
-	{
-		oldVersionObjectPath_->setTextFormat(Qt::RichText);
 		oldVersionObjectPath_->setScale(scale);
-	}
+
 	if (newVersionObjectPath_)
 		newVersionObjectPath_->setScale(scale);
 }
 
+void VDiffComparisonPair::determineChildren()
+{
+	Super::determineChildren();
+	scaleVisualizations();
+}
 }

--- a/VersionControlUI/src/items/VDiffComparisonPair.cpp
+++ b/VersionControlUI/src/items/VDiffComparisonPair.cpp
@@ -26,8 +26,11 @@
 
 #include "VDiffComparisonPair.h"
 
+#include "VisualizationBase/src/VisualizationManager.h"
 #include "VisualizationBase/src/declarative/DeclarativeItem.hpp"
+
 #include "ModelBase/src/nodes/Text.h"
+
 #include "VisualizationBase/src/items/VText.h"
 
 namespace VersionControlUI
@@ -55,18 +58,67 @@ void VDiffComparisonPair::initializeForms()
 			return v->node()->newVersionObjectPath();},
 			[](I* v) {return &v->style()->newVersionObjectPath();});
 
+	auto componentType = item<Visualization::VText>(&I::componentType_, [](I* v) {
+			return v->node()->componentType();},
+			[](I* v) {return &v->style()->componentType();});
+
+	auto infoGrid = (new Visualization::GridLayoutFormElement{})
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setColumnStretchFactor(1, 1)
+			->put(0, 0, oldVersionObjectPath)
+			->put(1, 0, newVersionObjectPath)
+			->put(0, 1, componentType);
 	auto container = (new Visualization::GridLayoutFormElement{})
 				->setHorizontalSpacing(30)
 				->setVerticalSpacing(15)
 				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
 				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->put(0, 0, oldVersionObjectPath)
-				->put(1, 0, newVersionObjectPath)
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setColumnStretchFactor(0, 1)
+				->setColumnStretchFactor(1, 1)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
+				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
+				->put(0, 0, infoGrid)
+				->setCellSpanning(2, 1)
 				->put(0, 1, oldVersion)
 				->put(1, 1, newVersion);
 
 	addForm(container);
 
+}
+
+bool VDiffComparisonPair::isSensitiveToScale() const
+{
+	return true;
+}
+
+void VDiffComparisonPair::determineChildren()
+{
+	Super::determineChildren();
+	qreal factor = Visualization::VisualizationManager::instance().mainScene()->mainViewScalingFactor();
+	qreal scale;
+	if (factor >= 1.0)
+		scale = 1.0;
+	else if (factor >= 0.03)
+		scale = 1.0/factor;
+	else
+		scale = 1.0;
+				//item->setScale((1/factor) * std::pow(0.95, 1/factor));
+	if (componentType_)
+		componentType_->setScale(scale);
+	if (oldVersionObjectPath_)
+	{
+		oldVersionObjectPath_->setTextFormat(Qt::RichText);
+		oldVersionObjectPath_->setScale(scale);
+	}
+	if (newVersionObjectPath_)
+		newVersionObjectPath_->setScale(scale);
 }
 
 }

--- a/VersionControlUI/src/items/VDiffComparisonPair.h
+++ b/VersionControlUI/src/items/VDiffComparisonPair.h
@@ -62,6 +62,7 @@ class VERSIONCONTROLUI_API VDiffComparisonPair : public Super<Visualization::Ite
 		Visualization::VText* newVersionObjectPath_{};
 
 		Visualization::VText* componentType_{};
+		void scaleVisualizations();
 };
 
 }

--- a/VersionControlUI/src/items/VDiffComparisonPair.h
+++ b/VersionControlUI/src/items/VDiffComparisonPair.h
@@ -51,12 +51,17 @@ class VERSIONCONTROLUI_API VDiffComparisonPair : public Super<Visualization::Ite
 	public:
 		VDiffComparisonPair(Visualization::Item* parent, NodeType* node, const StyleType* style = itemStyles().get());
 		static void initializeForms();
+		virtual bool isSensitiveToScale() const override;
+		virtual void determineChildren() override;
 
 	private:
 		Visualization::Item* oldVersionNode_{};
 		Visualization::Item* newVersionNode_{};
+
 		Visualization::VText* oldVersionObjectPath_{};
 		Visualization::VText* newVersionObjectPath_{};
+
+		Visualization::VText* componentType_{};
 };
 
 }

--- a/VersionControlUI/src/items/VDiffComparisonPairStyle.h
+++ b/VersionControlUI/src/items/VDiffComparisonPairStyle.h
@@ -41,5 +41,6 @@ class VERSIONCONTROLUI_API VDiffComparisonPairStyle : public Super<Visualization
 
 		Property<Visualization::TextStyle> oldVersionObjectPath{this, "oldVersionObjectPath"};
 		Property<Visualization::TextStyle> newVersionObjectPath{this, "newVersionObjectPath"};
+		Property<Visualization::TextStyle> componentType{this, "componentType"};
 };
 }

--- a/VersionControlUI/src/nodes/DiffComparisonPair.h
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.h
@@ -67,13 +67,14 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 
 
 		private:
-			Model::Node* oldVersionNode_;
-			Model::Node* newVersionNode_;
+			Model::Node* oldVersionNode_{};
+			Model::Node* newVersionNode_{};
 
-			Model::Text* newVersionObjectPath_;
-			Model::Text* oldVersionObjectPath_;
+			Model::Text* newVersionObjectPath_{};
+			Model::Text* oldVersionObjectPath_{};
 
-			Model::Text* componentType_;
+
+			Model::Text* componentType_{};
 
 
 };

--- a/VersionControlUI/src/nodes/DiffComparisonPair.h
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.h
@@ -52,6 +52,8 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 			void setNewVersionObjectPath(Model::Text* newVersionObjectPath);
 			void setOldVersionObjectPath(Model::Text* oldVersionObjectPath);
 
+			void setComponentType(Model::Text* componentType);
+
 
 			virtual QJsonValue toJson() const override;
 
@@ -61,27 +63,37 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 			Model::Text* newVersionObjectPath();
 			Model::Text* oldVersionObjectPath();
 
+			Model::Text* componentType();
+
 
 		private:
 			Model::Node* oldVersionNode_;
 			Model::Node* newVersionNode_;
+
 			Model::Text* newVersionObjectPath_;
 			Model::Text* oldVersionObjectPath_;
+
+			Model::Text* componentType_;
 
 
 };
 
 inline void DiffComparisonPair::setOldVersionNode(Model::Node* oldVersionNode) {oldVersionNode_ = oldVersionNode;}
 inline void DiffComparisonPair::setNewVersionNode(Model::Node* newVersionNode) {newVersionNode_ = newVersionNode;}
+
 inline void DiffComparisonPair::setNewVersionObjectPath(Model::Text* newVersionObjectPath)
 {newVersionObjectPath_ = newVersionObjectPath;}
 inline void DiffComparisonPair::setOldVersionObjectPath(Model::Text* oldVersionObjectPath)
 {oldVersionObjectPath_ = oldVersionObjectPath;}
 
+inline void DiffComparisonPair::setComponentType(Model::Text* componentType) {componentType_ = componentType; }
 
 inline Model::Node* DiffComparisonPair::newVersionNode() {return newVersionNode_;}
 inline Model::Node* DiffComparisonPair::oldVersionNode() {return oldVersionNode_;}
+
 inline Model::Text* DiffComparisonPair::newVersionObjectPath() {return newVersionObjectPath_;}
 inline Model::Text* DiffComparisonPair::oldVersionObjectPath() {return oldVersionObjectPath_;}
+
+inline Model::Text* DiffComparisonPair::componentType() {return componentType_;}
 
 }

--- a/VersionControlUI/styles/item/VDiffComparisonPair/default
+++ b/VersionControlUI/styles/item/VDiffComparisonPair/default
@@ -12,40 +12,52 @@
 			<color>#e6e6e6</color>
 		</outline>
 	</shape>
-<oldVersionObjectPath prototypes="item/Text/default">
-	<pen>
-		<style>1</style>
-		<color>#000000</color>
-	</pen>
-	<font>
-		<size>15</size>
-		<weight>75</weight>
-		<style>0</style>
-		<underline>false</underline>
-	</font>
-</oldVersionObjectPath>
-<newVersionObjectPath prototypes="item/Text/default">
-	<pen>
-		<style>1</style>
-		<color>#000000</color>
-	</pen>
-	<font>
-		<size>15</size>
-		<weight>30</weight>
-		<style>0</style>
-		<underline>false</underline>
-	</font>
-</newVersionObjectPath>
-<componentType prototypes="item/Text/default">
-	<pen>
-		<style>1</style>
-		<color>#000000</color>
-	</pen>
-	<font>
-		<size>15</size>
-		<weight>30</weight>
-		<style>0</style>
-		<underline>false</underline>
-	</font>
-</componentType>
+	<oldVersionObjectPath prototypes="item/Text/default">
+		<pen>
+			<style>1</style>
+			<color>#000000</color>
+		</pen>
+		<font>
+			<size>15</size>
+			<weight>75</weight>
+			<style>0</style>
+			<underline>false</underline>
+		</font>
+	</oldVersionObjectPath>
+	<newVersionObjectPath prototypes="item/Text/default">
+		<pen>
+			<style>1</style>
+			<color>#000000</color>
+		</pen>
+		<font>
+			<size>15</size>
+			<weight>30</weight>
+			<style>0</style>
+			<underline>false</underline>
+		</font>
+	</newVersionObjectPath>
+	<singleObjectPath prototypes="item/Text/default">
+		<pen>
+			<style>1</style>
+			<color>#000000</color>
+		</pen>
+		<font>
+			<size>15</size>
+			<weight>30</weight>
+			<style>0</style>
+			<underline>false</underline>
+		</font>
+	</singleObjectPath>
+	<componentType prototypes="item/Text/default">
+		<pen>
+			<style>1</style>
+			<color>#000000</color>
+		</pen>
+		<font>
+			<size>15</size>
+			<weight>30</weight>
+			<style>0</style>
+			<underline>false</underline>
+		</font>
+	</componentType>
 </style>

--- a/VersionControlUI/styles/item/VDiffComparisonPair/default
+++ b/VersionControlUI/styles/item/VDiffComparisonPair/default
@@ -2,23 +2,50 @@
 <style prototypes="item/DeclarativeItemBase/default">
 	<shape prototypes="shape/Box/default">
 		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#e6e6e6</color>
+		</backgroundBrush>
 		<outline>
 			<width>10.0</width>
 			<style>1</style>
-			<color>#ff000000</color>
+			<color>#e6e6e6</color>
 		</outline>
 	</shape>
 <oldVersionObjectPath prototypes="item/Text/default">
 	<pen>
 		<style>1</style>
-		<color>#0000ff</color>
+		<color>#000000</color>
 	</pen>
 	<font>
 		<size>15</size>
 		<weight>75</weight>
 		<style>0</style>
-		<underline>true</underline>
+		<underline>false</underline>
 	</font>
 </oldVersionObjectPath>
-<newVersionObjectPath prototypes="item/Text/default" />
+<newVersionObjectPath prototypes="item/Text/default">
+	<pen>
+		<style>1</style>
+		<color>#000000</color>
+	</pen>
+	<font>
+		<size>15</size>
+		<weight>30</weight>
+		<style>0</style>
+		<underline>false</underline>
+	</font>
+</newVersionObjectPath>
+<componentType prototypes="item/Text/default">
+	<pen>
+		<style>1</style>
+		<color>#000000</color>
+	</pen>
+	<font>
+		<size>15</size>
+		<weight>30</weight>
+		<style>0</style>
+		<underline>false</underline>
+	</font>
+</componentType>
 </style>

--- a/VisualizationBase/src/ViewItemManager.cpp
+++ b/VisualizationBase/src/ViewItemManager.cpp
@@ -135,6 +135,24 @@ void ViewItemManager::removeAllViewItems()
 	currentViewItem_ = nullptr;
 }
 
+
+void ViewItemManager::removeViewItem(ViewItem* view)
+{
+	for (auto& vector : viewItems_)
+	{
+		auto iter = vector.begin();
+		while (iter != vector.end())
+		{
+			if (*iter == view)
+			{
+				vector.erase(iter);
+				return;
+			}
+			iter++;
+		}
+	}
+}
+
 void ViewItemManager::saveView(ViewItem* view, Model::TreeManager* manager) const
 {
 	auto json = view->toJson().toJson();

--- a/VisualizationBase/src/ViewItemManager.cpp
+++ b/VisualizationBase/src/ViewItemManager.cpp
@@ -145,6 +145,7 @@ void ViewItemManager::removeViewItem(ViewItem* view)
 		{
 			if (*iter == view)
 			{
+				scene_->removeTopLevelItem(*iter);
 				vector.erase(iter);
 				return;
 			}

--- a/VisualizationBase/src/ViewItemManager.h
+++ b/VisualizationBase/src/ViewItemManager.h
@@ -82,6 +82,10 @@ class VISUALIZATIONBASE_API ViewItemManager
 		 * Removes all existing ViewItems from the manager.
 		 */
 		void removeAllViewItems();
+		/**
+		 * Removes \a view from the manager.
+		 */
+		void removeViewItem(ViewItem* view);
 
 		/**
 		 * Saves the given view persistently on disk, using the given manager.

--- a/VisualizationBase/src/overlays/ArrowOverlay.cpp
+++ b/VisualizationBase/src/overlays/ArrowOverlay.cpp
@@ -50,15 +50,16 @@ void ArrowOverlay::updateGeometry(int, int)
 	//Find the space the line will occupy in the scene
 	auto first = firstAssociatedItem();
 	auto second = secondAssociatedItem();
+
 	auto leftTopCorner = QPointF{
-				std::min(first->scenePos().x() + first->widthInLocal(),
-							second->scenePos().x() + second->widthInLocal()),
-				std::min(first->scenePos().y() + first->heightInLocal() / 2,
-							second->scenePos().y() + second->heightInLocal() / 2)}.toPoint();
+				std::min(first->scenePos().x() + first->widthInScene(),
+							second->scenePos().x() + second->widthInScene()),
+				std::min(first->scenePos().y() + first->heightInScene() / 2,
+							second->scenePos().y() + second->heightInScene() / 2)}.toPoint();
 	auto rightBottomCorner = QPointF{
 				std::max(first->scenePos().x(), second->scenePos().x()),
-				std::max(first->scenePos().y() + first->heightInLocal() / 2,
-							second->scenePos().y() + second->heightInLocal() / 2)}.toPoint();
+				std::max(first->scenePos().y() + first->heightInScene() / 2,
+							second->scenePos().y() + second->heightInScene() / 2)}.toPoint();
 
 	setPos(leftTopCorner.x(), leftTopCorner.y());
 	setSize(rightBottomCorner.x() - leftTopCorner.x(),
@@ -72,10 +73,10 @@ void ArrowOverlay::updateGeometry(int, int)
 		first = temp;
 		invertArrow_ = true;
 	}
-	lineFrom_ = QPointF{first->scenePos().x() + first->widthInLocal() - leftTopCorner.x(),
-						first->scenePos().y() + first->heightInLocal() / 2 - leftTopCorner.y()}.toPoint();
+	lineFrom_ = QPointF{first->scenePos().x() + first->widthInScene() - leftTopCorner.x(),
+						first->scenePos().y() + first->heightInScene() / 2 - leftTopCorner.y()}.toPoint();
 	lineTo_ = QPointF{second->scenePos().x() - leftTopCorner.x(),
-					 second->scenePos().y() + second->heightInLocal() / 2 - leftTopCorner.y()}.toPoint();
+					 second->scenePos().y() + second->heightInScene() / 2 - leftTopCorner.y()}.toPoint();
 }
 
 }

--- a/VisualizationBase/src/overlays/Overlay.h
+++ b/VisualizationBase/src/overlays/Overlay.h
@@ -70,7 +70,7 @@ inline Overlay<Super>::Overlay(QList<Item*> associatedItems, const typename Supe
 	Q_ASSERT(!associatedItems_.isEmpty());
 
 	Super::setFlags(0);
-	Super::setAcceptedMouseButtons(0);
+	Super::setAcceptedMouseButtons(Qt::NoButton);
 	Super::setZValue(Super::LAYER_OVERLAY_Z);
 	Super::setItemCategory(Scene::SelectionItemCategory);
 }

--- a/VisualizationBase/src/views/MainView.cpp
+++ b/VisualizationBase/src/views/MainView.cpp
@@ -128,8 +128,7 @@ void MainView::wheelEvent(QWheelEvent *event)
 			auto itemsAtEvent = items(event->pos());
 			auto iter = itemsAtEvent.begin();
 			// avoid zooming in on Overlays
-			// TODO cast *iter to Item to use DCast or is this fine?
-			while (iter != itemsAtEvent.end() && dynamic_cast<Overlay<Item>*>(*iter)) iter++;
+			while (iter != itemsAtEvent.end() && (*iter)->acceptedMouseButtons() == 0) iter++;
 			if (iter != itemsAtEvent.end())
 			{
 				itemUnderCursor = *iter;

--- a/VisualizationBase/src/views/MainView.cpp
+++ b/VisualizationBase/src/views/MainView.cpp
@@ -30,9 +30,6 @@
 #include "../items/Item.h"
 #include "../VisualizationBasePlugin.h"
 #include "../VisualizationManager.h"
-#include "../overlays/Overlay.h"
-#include "../overlays/HighlightOverlay.h"
-#include "../overlays/ArrowOverlay.h"
 
 #include "Logger/src/Timer.h"
 #include "Logger/src/Log.h"
@@ -128,7 +125,7 @@ void MainView::wheelEvent(QWheelEvent *event)
 			auto itemsAtEvent = items(event->pos());
 			auto iter = itemsAtEvent.begin();
 			// avoid zooming in on Overlays
-			while (iter != itemsAtEvent.end() && (*iter)->acceptedMouseButtons() == 0) iter++;
+			while (iter != itemsAtEvent.end() && (*iter)->acceptedMouseButtons() == Qt::NoButton) iter++;
 			if (iter != itemsAtEvent.end())
 			{
 				itemUnderCursor = *iter;

--- a/VisualizationBase/src/views/MainView.h
+++ b/VisualizationBase/src/views/MainView.h
@@ -67,6 +67,7 @@ class VISUALIZATIONBASE_API MainView: public View
 		MiniMap* miniMap;
 
 		static const int SCALING_FACTOR = 2;
+		static const bool ITEM_STRUCTURE_AWARE_ZOOM_ANCHORING = true;
 		int scaleLevel;
 
 		bool showTimers_{false};


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61909449%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61909772%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61910806%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61911242%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61911416%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61911528%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61911825%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61912103%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61912193%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61913959%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23issuecomment-216591522%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61955400%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61955612%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61955630%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r62002354%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23issuecomment-216777858%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23issuecomment-216778861%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23issuecomment-216591522%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20done%20with%20the%20review.%20Overall%2C%20only%20smaller%20comments.%20I%20like%20where%20things%20are%20going.%22%2C%20%22created_at%22%3A%20%222016-05-03T16%3A45%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20the%20feedback.%20Updated.%22%2C%20%22created_at%22%3A%20%222016-05-04T08%3A13%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-05-04T08%3A16%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20730fd7902056647d537c5cc6bdeaec39b747686f%20VersionControlUI/src/items/VDiffComparisonPair.cpp%2074%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61912103%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22somehow%20I%20think%20this%20should%20be%20symmetric.%20Why%20are%20there%20two%20statements%20here%20in%20the%20old%20version%20case%2C%20but%20only%20a%20single%20statement%20in%20the%20new%20version%20case%3F%22%2C%20%22created_at%22%3A%20%222016-05-03T16%3A30%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/items/VDiffComparisonPair.cpp%3AL58-125%22%7D%2C%20%22Pull%2086f80f66235af62fa9298583c3bb1dc292f17967%20VisualizationBase/src/ViewItemManager.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61910806%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20method%20has%20to%20be%20more%20symmetric%20to%20the%20%60addViewItem%60%20one.%20Make%20sure%20to%20call%20%60scene_-%3EremoveTopLevelItem%60.%22%2C%20%22created_at%22%3A%20%222016-05-03T16%3A21%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VisualizationBase/src/ViewItemManager.cpp%3AL135-159%22%7D%2C%20%22Pull%20b398292097dcbd73fbdef5d4b4254b17e4770162%20VisualizationBase/src/views/MainView.cpp%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61955612%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20includes%20of%20overlays%20seem%20no%20longer%20needed%3F%22%2C%20%22created_at%22%3A%20%222016-05-03T21%3A02%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VisualizationBase/src/views/MainView.cpp%3AL29-39%22%7D%2C%20%22Pull%20b398292097dcbd73fbdef5d4b4254b17e4770162%20VisualizationBase/src/views/MainView.cpp%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61912193%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22yeah%20I%20should%20have%20looked%20here%20earlier%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-05-03T16%3A31%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VisualizationBase/src/views/MainView.cpp%3AL128-135%22%7D%2C%20%22Pull%20730fd7902056647d537c5cc6bdeaec39b747686f%20VersionControlUI/src/items/VDiffComparisonPair.cpp%2061%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61911242%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22To%20make%20what%27s%20going%20on%20here%20a%20little%20more%20isolated%2C%20please%20put%20all%20the%20code%20after%20the%20super%20call%20in%20a%20separate%20private%20method.%22%2C%20%22created_at%22%3A%20%222016-05-03T16%3A24%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/items/VDiffComparisonPair.cpp%3AL58-125%22%7D%2C%20%22Pull%20b398292097dcbd73fbdef5d4b4254b17e4770162%20VisualizationBase/src/views/MainView.cpp%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61955400%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20recommend%20to%20use%20Qt%3A%3ANoButton%20instead%20of%200%22%2C%20%22created_at%22%3A%20%222016-05-03T21%3A01%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ahh%2C%20good%20point.%20%20%3A%29%20Thanks.%22%2C%20%22created_at%22%3A%20%222016-05-03T21%3A03%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VisualizationBase/src/views/MainView.cpp%3AL115-143%22%7D%2C%20%22Pull%20730fd7902056647d537c5cc6bdeaec39b747686f%20VersionControlUI/src/nodes/DiffComparisonPair.h%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61911825%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20sure%20I%20understand.%20Isn%27t%20this%20simply%20%60oldVersionNode_-%3EtypeName%60%20%3F%20Why%20do%20we%20need%20a%20setter%20and%20a%20getter%20for%20this%3F%22%2C%20%22created_at%22%3A%20%222016-05-03T16%3A29%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20will%20change%20in%20the%20next%20iteration.%20It%20will%20then%20be%20smarter%20%28using%20if%20applicable%20CompositeNodes%20meta%20information%29.%22%2C%20%22created_at%22%3A%20%222016-05-04T08%3A13%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/nodes/DiffComparisonPair.h%3AL63-100%22%7D%2C%20%22Pull%200946f25cb7f839d591445d80ac067049840f51a6%20VersionControlUI/src/DiffManager.cpp%2057%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61913959%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22When%20you%20switch%20to%20using%20%60Static%60%2C%20you%20can%20put%20this%20text%20in%20a%20style.%22%2C%20%22created_at%22%3A%20%222016-05-03T16%3A42%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL306-313%22%7D%2C%20%22Pull%20e6f9cdc426936279fdac7c3ca42195d68e5b41a8%20VisualizationBase/src/views/MainView.cpp%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61909772%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Two%20completely%20unrelated%20comments%20here%3A%5Cr%5Cn%5Cr%5Cn1.%20Please%20use%20the%20transparency%20of%20the%20item%2C%20instead%20of%20whether%20it%27s%20an%20overlay%20or%20not.%5Cr%5Cn%5Cr%5Cn2.%20This%20check%2C%20isn%27t%20actually%20going%20to%20work%20for%20all%20overlays.%20This%20will%20only%20work%20for%20overlay%20items%2C%20where%20%60Overlay%60%20directly%20inherits%20from%20%60Item%60.%20But%20if%20the%20overlay%20inherits%20from%2C%20say%2C%20%60DeclarativeItem%60%2C%20the%20cast%20will%20fail.%22%2C%20%22created_at%22%3A%20%222016-05-03T16%3A15%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VisualizationBase/src/views/MainView.cpp%3AL115-144%22%7D%2C%20%22Pull%20e6f9cdc426936279fdac7c3ca42195d68e5b41a8%20VisualizationBase/src/views/MainView.cpp%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61909449%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20general%2C%20for%20things%20that%20inherit%20from%20%60Item%60%20or%20%60Node%60%2C%20always%20use%20%60DCast%60.%20It%27s%20faster.%22%2C%20%22created_at%22%3A%20%222016-05-03T16%3A13%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VisualizationBase/src/views/MainView.cpp%3AL115-144%22%7D%2C%20%22Pull%20730fd7902056647d537c5cc6bdeaec39b747686f%20VersionControlUI/styles/item/VDiffComparisonPair/default%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61911528%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22please%20indent%20this%20xml%20file%20properly%22%2C%20%22created_at%22%3A%20%222016-05-03T16%3A27%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/styles/item/VDiffComparisonPair/default%3AL2-52%22%7D%2C%20%22Pull%20730fd7902056647d537c5cc6bdeaec39b747686f%20VersionControlUI/src/nodes/DiffComparisonPair.h%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/373%23discussion_r61911416%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20should%20have%20mentioned%20this%20earlier%3A%20please%20always%20default%20initialize%20%60%7B%7D%60%20pointers.%20Do%20this%20for%20all%20members.%20It%20helps%20avoid%20stupid%20mistakes%20sometimes.%22%2C%20%22created_at%22%3A%20%222016-05-03T16%3A26%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/nodes/DiffComparisonPair.h%3AL63-100%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull e6f9cdc426936279fdac7c3ca42195d68e5b41a8 VisualizationBase/src/views/MainView.cpp 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#discussion_r61909449'>File: VisualizationBase/src/views/MainView.cpp:L115-144</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> In general, for things that inherit from `Item` or `Node`, always use `DCast`. It's faster.
- [ ] <a href='#crh-comment-Pull e6f9cdc426936279fdac7c3ca42195d68e5b41a8 VisualizationBase/src/views/MainView.cpp 29'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#discussion_r61909772'>File: VisualizationBase/src/views/MainView.cpp:L115-144</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Two completely unrelated comments here:
- Please use the transparency of the item, instead of whether it's an overlay or not.
- This check, isn't actually going to work for all overlays. This will only work for overlay items, where `Overlay` directly inherits from `Item`. But if the overlay inherits from, say, `DeclarativeItem`, the cast will fail.
- [ ] <a href='#crh-comment-Pull 86f80f66235af62fa9298583c3bb1dc292f17967 VisualizationBase/src/ViewItemManager.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#discussion_r61910806'>File: VisualizationBase/src/ViewItemManager.cpp:L135-159</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This method has to be more symmetric to the `addViewItem` one. Make sure to call `scene_->removeTopLevelItem`.
- [ ] <a href='#crh-comment-Pull 730fd7902056647d537c5cc6bdeaec39b747686f VersionControlUI/src/items/VDiffComparisonPair.cpp 61'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#discussion_r61911242'>File: VersionControlUI/src/items/VDiffComparisonPair.cpp:L58-125</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> To make what's going on here a little more isolated, please put all the code after the super call in a separate private method.
- [ ] <a href='#crh-comment-Pull 730fd7902056647d537c5cc6bdeaec39b747686f VersionControlUI/src/nodes/DiffComparisonPair.h 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#discussion_r61911416'>File: VersionControlUI/src/nodes/DiffComparisonPair.h:L63-100</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I should have mentioned this earlier: please always default initialize `{}` pointers. Do this for all members. It helps avoid stupid mistakes sometimes.
- [ ] <a href='#crh-comment-Pull 730fd7902056647d537c5cc6bdeaec39b747686f VersionControlUI/styles/item/VDiffComparisonPair/default 30'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#discussion_r61911528'>File: VersionControlUI/styles/item/VDiffComparisonPair/default:L2-52</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> please indent this xml file properly
- [ ] <a href='#crh-comment-Pull 730fd7902056647d537c5cc6bdeaec39b747686f VersionControlUI/src/nodes/DiffComparisonPair.h 44'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#discussion_r61911825'>File: VersionControlUI/src/nodes/DiffComparisonPair.h:L63-100</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I'm not sure I understand. Isn't this simply `oldVersionNode_->typeName` ? Why do we need a setter and a getter for this?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> This will change in the next iteration. It will then be smarter (using if applicable CompositeNodes meta information).
- [ ] <a href='#crh-comment-Pull 730fd7902056647d537c5cc6bdeaec39b747686f VersionControlUI/src/items/VDiffComparisonPair.cpp 74'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#discussion_r61912103'>File: VersionControlUI/src/items/VDiffComparisonPair.cpp:L58-125</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> somehow I think this should be symmetric. Why are there two statements here in the old version case, but only a single statement in the new version case?
- [ ] <a href='#crh-comment-Pull b398292097dcbd73fbdef5d4b4254b17e4770162 VisualizationBase/src/views/MainView.cpp 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#discussion_r61912193'>File: VisualizationBase/src/views/MainView.cpp:L128-135</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> yeah I should have looked here earlier :)
- [ ] <a href='#crh-comment-Pull 0946f25cb7f839d591445d80ac067049840f51a6 VersionControlUI/src/DiffManager.cpp 57'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#discussion_r61913959'>File: VersionControlUI/src/DiffManager.cpp:L306-313</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> When you switch to using `Static`, you can put this text in a style.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#issuecomment-216591522'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I'm done with the review. Overall, only smaller comments. I like where things are going.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Thanks for the feedback. Updated.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks :)
- [ ] <a href='#crh-comment-Pull b398292097dcbd73fbdef5d4b4254b17e4770162 VisualizationBase/src/views/MainView.cpp 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#discussion_r61955400'>File: VisualizationBase/src/views/MainView.cpp:L115-143</a></b>
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> I would recommend to use Qt::NoButton instead of 0
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Ahh, good point.  :) Thanks.
- [ ] <a href='#crh-comment-Pull b398292097dcbd73fbdef5d4b4254b17e4770162 VisualizationBase/src/views/MainView.cpp 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/373#discussion_r61955612'>File: VisualizationBase/src/views/MainView.cpp:L29-39</a></b>
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> The includes of overlays seem no longer needed?

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/373?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/373?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/373'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
