### PR TITLE
Improve visualization for DiffComparisonPair

### DIFF
--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -304,21 +304,6 @@ void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem
 	});
 }
 
-QString DiffManager::getObjectPath(Model::Node* node)
-{
-	if (!node) return "no node";
-	auto parent = node->parent();
-	QString objectPath = "";
-	while (parent)
-	{
-		if (parent->definesSymbol())
-			objectPath.prepend(parent->symbolName() + "/");
-		parent = parent->parent();
-	}
-
-	return objectPath;
-}
-
 Visualization::Item* DiffManager::addHighlightAndReturnItem(Model::Node* node, Visualization::ViewItem* viewItem,
                                                QString highlightOverlayName, QString highlightOverlayStyle)
 {
@@ -344,26 +329,7 @@ void DiffManager::visualizeChangedNodes(Model::TreeManager* oldVersionManager,
 		auto oldNode = const_cast<Model::Node*>(oldVersionManager->nodeIdMap().node(id));
 		auto newNode = const_cast<Model::Node*>(newVersionManager->nodeIdMap().node(id));
 
-		QString oldVersionObjectPath = getObjectPath(oldNode);
-		QString newVersionObjectPath = getObjectPath(newNode);
-
-		// TODO maybe add seperate field for typeName in visualization
-		QString componentType = (oldNode ? oldNode->typeName() : newNode->typeName());
-
-		// old version in left column
-		if (!oldNode)
-			oldNode = new Model::Text{"node in old version not found"};
-
-		// new version in right column
-		if (!newNode)
-			newNode = new Model::Text{"node in new version not found"};
-
-		auto diffNode = new DiffComparisonPair{};
-		diffNode->setOldVersionNode(oldNode);
-		diffNode->setNewVersionNode(newNode);
-		diffNode->setOldVersionObjectPath(new Model::Text{oldVersionObjectPath});
-		diffNode->setNewVersionObjectPath(new Model::Text{newVersionObjectPath});
-		diffNode->setComponentType(new Model::Text{componentType});
+		auto diffNode = new DiffComparisonPair{oldNode, newNode};
 
 		diffViewItem->insertNode(diffNode);
 	}

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -101,8 +101,6 @@ class VERSIONCONTROLUI_API DiffManager
 		static Visualization::Item* addHighlightAndReturnItem(Model::Node* node, Visualization::ViewItem* viewItem,
 																QString highlightOverlayName, QString highlightOverlayStyle);
 
-		QString getObjectPath(Model::Node* node);
-
 		QString oldVersion_;
 		QString newVersion_;
 		QString project_;

--- a/VersionControlUI/src/items/VDiffComparisonPair.cpp
+++ b/VersionControlUI/src/items/VDiffComparisonPair.cpp
@@ -33,6 +33,8 @@
 
 #include "VisualizationBase/src/items/VText.h"
 
+#include "../nodes/DiffComparisonPair.h"
+
 namespace VersionControlUI
 {
 
@@ -50,17 +52,18 @@ void VDiffComparisonPair::initializeForms()
 	auto newVersion = item(&I::newVersionNode_, [](I* v) {
 			return v->node()->newVersionNode();});
 
-	auto oldVersionObjectPath = item<Visualization::VText>(&I::oldVersionObjectPath_, [](I* v) {
-			return v->node()->oldVersionObjectPath();},
-			[](I* v) {return &v->style()->oldVersionObjectPath();});
-
-	auto newVersionObjectPath = item<Visualization::VText>(&I::newVersionObjectPath_, [](I* v) {
-			return v->node()->newVersionObjectPath();},
-			[](I* v) {return &v->style()->newVersionObjectPath();});
-
 	auto componentType = item<Visualization::VText>(&I::componentType_, [](I* v) {
 			return v->node()->componentType();},
 			[](I* v) {return &v->style()->componentType();});
+
+	auto noNodeFound = item<Visualization::Static>(&I::nodeNotFoundIcon_, &StyleType::nodeNotFoundIcon);
+
+
+	auto objectPath = item<Visualization::VText>(&I::singleObjectPath_, [](I* v) {
+			return v->node()->singleObjectPath();},
+			[](I* v) {return &v->style()->singleObjectPath();});
+
+	// form with both nodes and only one object path
 
 	auto infoGrid = (new Visualization::GridLayoutFormElement{})
 			->setHorizontalSpacing(50)
@@ -69,10 +72,23 @@ void VDiffComparisonPair::initializeForms()
 			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
 			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
 			->setColumnStretchFactor(0, 1)
-			->setColumnStretchFactor(1, 1)
-			->put(0, 0, oldVersionObjectPath)
-			->put(1, 0, newVersionObjectPath)
+			->put(0, 0, objectPath)
 			->put(0, 1, componentType);
+
+	auto diffGrid = (new Visualization::GridLayoutFormElement{})
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setColumnStretchFactor(1, 1)
+			->setRowStretchFactor(0, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
+			->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
+			->put(0, 0, oldVersion)
+			->put(1, 0, newVersion);
+
 	auto container = (new Visualization::GridLayoutFormElement{})
 				->setHorizontalSpacing(30)
 				->setVerticalSpacing(15)
@@ -81,15 +97,139 @@ void VDiffComparisonPair::initializeForms()
 				->setLeftMargin(10)
 				->setRightMargin(10)
 				->setColumnStretchFactor(0, 1)
-				->setColumnStretchFactor(1, 1)
 				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
 				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
-				->put(0, 0, infoGrid)
-				->setCellSpanning(2, 1)
-				->put(0, 1, oldVersion)
-				->put(1, 1, newVersion);
+				->setRowStretchFactor(0, 1)
+				->setRowStretchFactor(1, 1)
+				->put(0, 0, infoGrid->clone())
+				->put(0, 1, diffGrid->clone());
 
-	addForm(container);
+
+	addForm(container->clone());
+
+	// form with only new node available
+
+	diffGrid = (new Visualization::GridLayoutFormElement{})
+				->setHorizontalSpacing(50)
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->setColumnStretchFactor(0, 1)
+				->setColumnStretchFactor(1, 1)
+				->setRowStretchFactor(0, 1)
+				->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Center)
+				->put(0, 0, noNodeFound)
+				->put(1, 0, newVersion);
+
+	container = (new Visualization::GridLayoutFormElement{})
+				->setHorizontalSpacing(30)
+				->setVerticalSpacing(15)
+				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setColumnStretchFactor(0, 1)
+				->setRowStretchFactor(0, 1)
+				->setRowStretchFactor(1, 1)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->put(0, 0, infoGrid->clone())
+				->put(0, 1, diffGrid->clone());
+
+	addForm(container->clone());
+
+	// form with only old node available
+
+	diffGrid = (new Visualization::GridLayoutFormElement{})
+				->setHorizontalSpacing(50)
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->setColumnStretchFactor(0, 1)
+				->setColumnStretchFactor(1, 1)
+				->setRowStretchFactor(0, 1)
+				->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Center)
+				->put(0, 0, oldVersion)
+				->put(1, 0, noNodeFound);
+
+	container = (new Visualization::GridLayoutFormElement{})
+				->setHorizontalSpacing(30)
+				->setVerticalSpacing(15)
+				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setColumnStretchFactor(0, 1)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->put(0, 0, infoGrid->clone())
+				->put(0, 1, diffGrid->clone());
+
+	addForm(container->clone());
+
+	// form with two object paths and two nodes
+
+	auto oldVersionObjectPath = item<Visualization::VText>(&I::oldVersionObjectPath_, [](I* v) {
+			return v->node()->oldVersionObjectPath();},
+			[](I* v) {return &v->style()->oldVersionObjectPath();});
+
+	auto newVersionObjectPath = item<Visualization::VText>(&I::newVersionObjectPath_, [](I* v) {
+			return v->node()->newVersionObjectPath();},
+			[](I* v) {return &v->style()->newVersionObjectPath();});
+
+	infoGrid = (new Visualization::GridLayoutFormElement{})
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setColumnStretchFactor(1, 1)
+			->put(0, 0, oldVersionObjectPath)
+			->put(1, 0, newVersionObjectPath);
+
+	auto infoWithComponentTypeGrid = (new Visualization::GridLayoutFormElement{})
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setRowStretchFactor(0, 1)
+			->put(0, 0, infoGrid->clone())
+			->put(0, 1, componentType);
+
+	diffGrid = (new Visualization::GridLayoutFormElement{})
+				->setHorizontalSpacing(50)
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->setColumnStretchFactor(0, 1)
+				->setColumnStretchFactor(1, 1)
+				->setRowStretchFactor(0, 1)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
+				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
+				->put(0, 0, oldVersion)
+				->put(1, 0, newVersion);
+
+	container = (new Visualization::GridLayoutFormElement{})
+				->setHorizontalSpacing(30)
+				->setVerticalSpacing(15)
+				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setColumnStretchFactor(0, 1)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->put(0, 0, infoWithComponentTypeGrid->clone())
+				->put(0, 1, diffGrid->clone());
+
+	addForm(container->clone());
 
 }
 
@@ -112,11 +252,17 @@ void VDiffComparisonPair::scaleVisualizations()
 	if (componentType_)
 		componentType_->setScale(scale);
 
+	if (singleObjectPath_)
+		singleObjectPath_->setScale(scale);
+
 	if (oldVersionObjectPath_)
 		oldVersionObjectPath_->setScale(scale);
 
 	if (newVersionObjectPath_)
 		newVersionObjectPath_->setScale(scale);
+
+	if (nodeNotFoundIcon_)
+		nodeNotFoundIcon_->setScale(scale);
 }
 
 void VDiffComparisonPair::determineChildren()
@@ -124,4 +270,24 @@ void VDiffComparisonPair::determineChildren()
 	Super::determineChildren();
 	scaleVisualizations();
 }
+
+int VDiffComparisonPair::determineForm()
+{
+	static const int FORM_WITH_SINGLE_OBJECT_PATH = 0;
+	static const int FORM_CONTAINING_ONLY_NEW_NODE = 1;
+	static const int FORM_CONTAINING_ONLY_OLD_NODE = 2;
+	static const int FORM_WITH_TWO_OBJECT_PATHS = 3;
+
+	DiffComparisonPair* associatedNode = node();
+	if (associatedNode->twoObjectPathsDefined())
+		return FORM_WITH_TWO_OBJECT_PATHS;
+	else
+		if (!associatedNode->oldVersionNode())
+			return FORM_CONTAINING_ONLY_NEW_NODE;
+		else if (!associatedNode->newVersionNode())
+			return FORM_CONTAINING_ONLY_OLD_NODE;
+		else
+			return FORM_WITH_SINGLE_OBJECT_PATH;
+}
+
 }

--- a/VersionControlUI/src/items/VDiffComparisonPair.cpp
+++ b/VersionControlUI/src/items/VDiffComparisonPair.cpp
@@ -52,10 +52,6 @@ void VDiffComparisonPair::initializeForms()
 	auto newVersion = item(&I::newVersionNode_, [](I* v) {
 			return v->node()->newVersionNode();});
 
-	auto componentType = item<Visualization::VText>(&I::componentType_, [](I* v) {
-			return v->node()->componentType();},
-			[](I* v) {return &v->style()->componentType();});
-
 	auto noNodeFound = item<Visualization::Static>(&I::nodeNotFoundIcon_, &StyleType::nodeNotFoundIcon);
 
 
@@ -72,8 +68,7 @@ void VDiffComparisonPair::initializeForms()
 			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
 			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
 			->setColumnStretchFactor(0, 1)
-			->put(0, 0, objectPath)
-			->put(0, 1, componentType);
+			->put(0, 0, objectPath);
 
 	auto diffGrid = (new Visualization::GridLayoutFormElement{})
 			->setHorizontalSpacing(50)
@@ -90,19 +85,19 @@ void VDiffComparisonPair::initializeForms()
 			->put(1, 0, newVersion);
 
 	auto container = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(30)
-				->setVerticalSpacing(15)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setColumnStretchFactor(0, 1)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
-				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
-				->setRowStretchFactor(0, 1)
-				->setRowStretchFactor(1, 1)
-				->put(0, 0, infoGrid->clone())
-				->put(0, 1, diffGrid->clone());
+			->setHorizontalSpacing(30)
+			->setVerticalSpacing(15)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setColumnStretchFactor(0, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
+			->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
+			->setRowStretchFactor(0, 1)
+			->setRowStretchFactor(1, 1)
+			->put(0, 0, infoGrid->clone())
+			->put(0, 1, diffGrid->clone());
 
 
 	addForm(container->clone());
@@ -110,64 +105,64 @@ void VDiffComparisonPair::initializeForms()
 	// form with only new node available
 
 	diffGrid = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(50)
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setColumnStretchFactor(0, 1)
-				->setColumnStretchFactor(1, 1)
-				->setRowStretchFactor(0, 1)
-				->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Center)
-				->put(0, 0, noNodeFound)
-				->put(1, 0, newVersion);
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setColumnStretchFactor(1, 1)
+			->setRowStretchFactor(0, 1)
+			->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Center)
+			->put(0, 0, noNodeFound)
+			->put(1, 0, newVersion);
 
 	container = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(30)
-				->setVerticalSpacing(15)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setColumnStretchFactor(0, 1)
-				->setRowStretchFactor(0, 1)
-				->setRowStretchFactor(1, 1)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->put(0, 0, infoGrid->clone())
-				->put(0, 1, diffGrid->clone());
+			->setHorizontalSpacing(30)
+			->setVerticalSpacing(15)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setColumnStretchFactor(0, 1)
+			->setRowStretchFactor(0, 1)
+			->setRowStretchFactor(1, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->put(0, 0, infoGrid->clone())
+			->put(0, 1, diffGrid->clone());
 
 	addForm(container->clone());
 
 	// form with only old node available
 
 	diffGrid = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(50)
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setColumnStretchFactor(0, 1)
-				->setColumnStretchFactor(1, 1)
-				->setRowStretchFactor(0, 1)
-				->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Center)
-				->put(0, 0, oldVersion)
-				->put(1, 0, noNodeFound);
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setColumnStretchFactor(1, 1)
+			->setRowStretchFactor(0, 1)
+			->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Center)
+			->put(0, 0, oldVersion)
+			->put(1, 0, noNodeFound);
 
 	container = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(30)
-				->setVerticalSpacing(15)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setColumnStretchFactor(0, 1)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->put(0, 0, infoGrid->clone())
-				->put(0, 1, diffGrid->clone());
+			->setHorizontalSpacing(30)
+			->setVerticalSpacing(15)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setColumnStretchFactor(0, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->put(0, 0, infoGrid->clone())
+			->put(0, 1, diffGrid->clone());
 
 	addForm(container->clone());
 
@@ -200,36 +195,35 @@ void VDiffComparisonPair::initializeForms()
 			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
 			->setColumnStretchFactor(0, 1)
 			->setRowStretchFactor(0, 1)
-			->put(0, 0, infoGrid->clone())
-			->put(0, 1, componentType);
+			->put(0, 0, infoGrid);
 
 	diffGrid = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(50)
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setColumnStretchFactor(0, 1)
-				->setColumnStretchFactor(1, 1)
-				->setRowStretchFactor(0, 1)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
-				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
-				->put(0, 0, oldVersion)
-				->put(1, 0, newVersion);
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setColumnStretchFactor(1, 1)
+			->setRowStretchFactor(0, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
+			->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
+			->put(0, 0, oldVersion)
+			->put(1, 0, newVersion);
 
 	container = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(30)
-				->setVerticalSpacing(15)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setColumnStretchFactor(0, 1)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->put(0, 0, infoWithComponentTypeGrid->clone())
-				->put(0, 1, diffGrid->clone());
+			->setHorizontalSpacing(30)
+			->setVerticalSpacing(15)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setColumnStretchFactor(0, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->put(0, 0, infoWithComponentTypeGrid)
+			->put(0, 1, diffGrid);
 
-	addForm(container->clone());
+	addForm(container);
 
 }
 
@@ -278,13 +272,12 @@ int VDiffComparisonPair::determineForm()
 	static const int FORM_CONTAINING_ONLY_OLD_NODE = 2;
 	static const int FORM_WITH_TWO_OBJECT_PATHS = 3;
 
-	DiffComparisonPair* associatedNode = node();
-	if (associatedNode->twoObjectPathsDefined())
+	if (node()->twoObjectPathsDefined())
 		return FORM_WITH_TWO_OBJECT_PATHS;
 	else
-		if (!associatedNode->oldVersionNode())
+		if (!node()->oldVersionNode())
 			return FORM_CONTAINING_ONLY_NEW_NODE;
-		else if (!associatedNode->newVersionNode())
+		else if (!node()->newVersionNode())
 			return FORM_CONTAINING_ONLY_OLD_NODE;
 		else
 			return FORM_WITH_SINGLE_OBJECT_PATH;

--- a/VersionControlUI/src/items/VDiffComparisonPair.h
+++ b/VersionControlUI/src/items/VDiffComparisonPair.h
@@ -35,6 +35,7 @@
 
 #include "VisualizationBase/src/items/Item.h"
 #include "VisualizationBase/src/items/VText.h"
+#include "VisualizationBase/src/items/Static.h"
 
 #include "../nodes/DiffComparisonPair.h"
 
@@ -53,6 +54,7 @@ class VERSIONCONTROLUI_API VDiffComparisonPair : public Super<Visualization::Ite
 		static void initializeForms();
 		virtual bool isSensitiveToScale() const override;
 		virtual void determineChildren() override;
+		int determineForm() override;
 
 	private:
 		Visualization::Item* oldVersionNode_{};
@@ -60,8 +62,12 @@ class VERSIONCONTROLUI_API VDiffComparisonPair : public Super<Visualization::Ite
 
 		Visualization::VText* oldVersionObjectPath_{};
 		Visualization::VText* newVersionObjectPath_{};
+		Visualization::VText* singleObjectPath_{};
+
+		Visualization::Static* nodeNotFoundIcon_{};
 
 		Visualization::VText* componentType_{};
+
 		void scaleVisualizations();
 };
 

--- a/VersionControlUI/src/items/VDiffComparisonPair.h
+++ b/VersionControlUI/src/items/VDiffComparisonPair.h
@@ -54,7 +54,7 @@ class VERSIONCONTROLUI_API VDiffComparisonPair : public Super<Visualization::Ite
 		static void initializeForms();
 		virtual bool isSensitiveToScale() const override;
 		virtual void determineChildren() override;
-		int determineForm() override;
+		virtual int determineForm() override;
 
 	private:
 		Visualization::Item* oldVersionNode_{};

--- a/VersionControlUI/src/items/VDiffComparisonPairStyle.h
+++ b/VersionControlUI/src/items/VDiffComparisonPairStyle.h
@@ -30,6 +30,7 @@
 
 #include "VisualizationBase/src/declarative/DeclarativeItemBaseStyle.h"
 #include "VisualizationBase/src/items/TextStyle.h"
+#include "VisualizationBase/src/items/Static.h"
 
 namespace VersionControlUI
 {
@@ -41,6 +42,8 @@ class VERSIONCONTROLUI_API VDiffComparisonPairStyle : public Super<Visualization
 
 		Property<Visualization::TextStyle> oldVersionObjectPath{this, "oldVersionObjectPath"};
 		Property<Visualization::TextStyle> newVersionObjectPath{this, "newVersionObjectPath"};
+		Property<Visualization::TextStyle> singleObjectPath{this, "singleObjectPath"};
 		Property<Visualization::TextStyle> componentType{this, "componentType"};
+		Property<Visualization::StaticStyle> nodeNotFoundIcon{this, "nodeNotFoundIcon"};
 };
 }

--- a/VersionControlUI/src/nodes/DiffComparisonPair.cpp
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.cpp
@@ -37,31 +37,33 @@ DiffComparisonPair::DiffComparisonPair(Model::Node* oldVersionNode, Model::Node*
 	oldVersionNode_ = oldVersionNode;
 	newVersionNode_ = newVersionNode;
 
-	setUpObjectPath();
+	computeObjectPath();
 
-	setUpComponentType();
+	computeComponentName();
 
 }
 
-void DiffComparisonPair::setUpObjectPath()
+void DiffComparisonPair::computeObjectPath()
 {
-	QString oldVersionObjectPath = computeObjectPath(oldVersionNode_);
-	QString newVersionObjectPath = computeObjectPath(newVersionNode_);
+	auto oldVersionObjectPath = computeObjectPath(oldVersionNode_);
+	auto newVersionObjectPath = computeObjectPath(newVersionNode_);
+	auto componentName = computeComponentName();
+
 	if (oldVersionObjectPath == newVersionObjectPath)
 	{
-		singleObjectPath_ = new Model::Text{oldVersionObjectPath};
+		singleObjectPath_ = new Model::Text{oldVersionObjectPath+componentName};
 		twoObjectPathsDefined_ = false;
 	}
 	else if (oldVersionObjectPath == "" || newVersionObjectPath == "")
 	{
 		auto objectPath = oldVersionObjectPath == "" ? newVersionObjectPath : oldVersionObjectPath;
-		singleObjectPath_ = new Model::Text{objectPath};
+		singleObjectPath_ = new Model::Text{objectPath+componentName};
 		twoObjectPathsDefined_ = false;
 	}
 	else
 	{
-		oldVersionObjectPath_ = new Model::Text{oldVersionObjectPath};
-		newVersionObjectPath_ = new Model::Text{newVersionObjectPath};
+		oldVersionObjectPath_ = new Model::Text{oldVersionObjectPath+componentName};
+		newVersionObjectPath_ = new Model::Text{newVersionObjectPath+componentName};
 		twoObjectPathsDefined_ = true;
 	}
 }
@@ -81,10 +83,10 @@ QString DiffComparisonPair::computeObjectPath(Model::Node* node)
 	return objectPath;
 }
 
-void DiffComparisonPair::setUpComponentType()
+QString DiffComparisonPair::computeComponentName()
 {
 	Model::Node* nodeToComputeComponentType = nullptr;
-	QString componentType = "unknown";
+	QString componentName = "";
 
 	if (oldVersionNode_)
 		nodeToComputeComponentType = oldVersionNode_;
@@ -98,22 +100,16 @@ void DiffComparisonPair::setUpComponentType()
 
 	if (searchCompositeNode)
 	{
-		Model::CompositeNode* compositeNode = DCast<Model::CompositeNode>(searchCompositeNode);
-		if (compositeNode == nodeToComputeComponentType)
-		{
-			componentType = compositeNode->typeName();
-		} else
+		auto compositeNode = DCast<Model::CompositeNode>(searchCompositeNode);
+		if (compositeNode != nodeToComputeComponentType)
 		{
 			auto index = compositeNode->indexOf(nodeToComputeComponentType);
-			componentType = compositeNode->meta().attribute(index).name();
+			componentName = compositeNode->meta().attribute(index).name();
 		}
-
 	}
-	// TODO maybe first char of componentType toUpper?
-	componentType_ = new Model::Text{componentType};
+	return componentName;
 }
 
-// TODO force top constructor, is this right way? or remove macro which introduces the constructor?
 DiffComparisonPair::DiffComparisonPair(Model::Node *)
 	:Super{}
 {

--- a/VersionControlUI/src/nodes/DiffComparisonPair.cpp
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.cpp
@@ -25,14 +25,99 @@
  **********************************************************************************************************************/
 #include "DiffComparisonPair.h"
 
+#include "ModelBase/src/nodes/composite/CompositeNode.h"
+
 namespace VersionControlUI
 {
 
 DEFINE_NODE_TYPE_REGISTRATION_METHODS(DiffComparisonPair)
 
+DiffComparisonPair::DiffComparisonPair(Model::Node* oldVersionNode, Model::Node* newVersionNode) : Super{}
+{
+	oldVersionNode_ = oldVersionNode;
+	newVersionNode_ = newVersionNode;
+
+	setUpObjectPath();
+
+	setUpComponentType();
+
+}
+
+void DiffComparisonPair::setUpObjectPath()
+{
+	QString oldVersionObjectPath = computeObjectPath(oldVersionNode_);
+	QString newVersionObjectPath = computeObjectPath(newVersionNode_);
+	if (oldVersionObjectPath == newVersionObjectPath)
+	{
+		singleObjectPath_ = new Model::Text{oldVersionObjectPath};
+		twoObjectPathsDefined_ = false;
+	}
+	else if (oldVersionObjectPath == "" || newVersionObjectPath == "")
+	{
+		auto objectPath = oldVersionObjectPath == "" ? newVersionObjectPath : oldVersionObjectPath;
+		singleObjectPath_ = new Model::Text{objectPath};
+		twoObjectPathsDefined_ = false;
+	}
+	else
+	{
+		oldVersionObjectPath_ = new Model::Text{oldVersionObjectPath};
+		newVersionObjectPath_ = new Model::Text{newVersionObjectPath};
+		twoObjectPathsDefined_ = true;
+	}
+}
+
+QString DiffComparisonPair::computeObjectPath(Model::Node* node)
+{
+	if (!node) return "";
+	auto parent = node->parent();
+	QString objectPath = "";
+	while (parent)
+	{
+		if (parent->definesSymbol())
+			objectPath.prepend(parent->symbolName() + "/");
+		parent = parent->parent();
+	}
+
+	return objectPath;
+}
+
+void DiffComparisonPair::setUpComponentType()
+{
+	Model::Node* nodeToComputeComponentType = nullptr;
+	QString componentType = "unknown";
+
+	if (oldVersionNode_)
+		nodeToComputeComponentType = oldVersionNode_;
+	else
+		nodeToComputeComponentType = newVersionNode_;
+
+	auto searchCompositeNode = nodeToComputeComponentType;
+
+	while (searchCompositeNode && !DCast<Model::CompositeNode>(searchCompositeNode))
+		searchCompositeNode = searchCompositeNode->parent();
+
+	if (searchCompositeNode)
+	{
+		Model::CompositeNode* compositeNode = DCast<Model::CompositeNode>(searchCompositeNode);
+		if (compositeNode == nodeToComputeComponentType)
+		{
+			componentType = compositeNode->typeName();
+		} else
+		{
+			auto index = compositeNode->indexOf(nodeToComputeComponentType);
+			componentType = compositeNode->meta().attribute(index).name();
+		}
+
+	}
+	// TODO maybe first char of componentType toUpper?
+	componentType_ = new Model::Text{componentType};
+}
+
+// TODO force top constructor, is this right way? or remove macro which introduces the constructor?
 DiffComparisonPair::DiffComparisonPair(Model::Node *)
 	:Super{}
 {
+	Q_ASSERT(false);
 }
 
 DiffComparisonPair::DiffComparisonPair(Model::Node *, Model::PersistentStore &, bool)
@@ -47,5 +132,6 @@ QJsonValue DiffComparisonPair::toJson() const
 {
 	return QJsonValue{};
 }
+
 
 }

--- a/VersionControlUI/src/nodes/DiffComparisonPair.h
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.h
@@ -58,13 +58,11 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 
 			Model::Text* singleObjectPath();
 
-			Model::Text* componentType();
-
 			bool twoObjectPathsDefined();
 
 
 		private:
-			bool twoObjectPathsDefined_;
+			bool twoObjectPathsDefined_{};
 
 			Model::Node* oldVersionNode_{};
 			Model::Node* newVersionNode_{};
@@ -74,12 +72,9 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 
 			Model::Text* singleObjectPath_{};
 
-			Model::Text* componentType_{};
-
 			QString computeObjectPath(Model::Node* node);
-
-			void setUpComponentType();
-			void setUpObjectPath();
+			QString computeComponentName();
+			void computeObjectPath();
 };
 
 inline Model::Node* DiffComparisonPair::newVersionNode() {return newVersionNode_;}
@@ -89,8 +84,6 @@ inline Model::Text* DiffComparisonPair::newVersionObjectPath() {return newVersio
 inline Model::Text* DiffComparisonPair::oldVersionObjectPath() {return oldVersionObjectPath_;}
 
 inline Model::Text* DiffComparisonPair::singleObjectPath() {return singleObjectPath_;}
-
-inline Model::Text* DiffComparisonPair::componentType() {return componentType_;}
 
 inline bool DiffComparisonPair::twoObjectPathsDefined() {return twoObjectPathsDefined_;}
 

--- a/VersionControlUI/src/nodes/DiffComparisonPair.h
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.h
@@ -46,14 +46,7 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 		NODE_DECLARE_STANDARD_METHODS(DiffComparisonPair)
 
 		public:
-			void setOldVersionNode(Model::Node* oldVersionNode);
-			void setNewVersionNode(Model::Node* newVersionNode);
-
-			void setNewVersionObjectPath(Model::Text* newVersionObjectPath);
-			void setOldVersionObjectPath(Model::Text* oldVersionObjectPath);
-
-			void setComponentType(Model::Text* componentType);
-
+			DiffComparisonPair(Model::Node* oldVersionNode, Model::Node* newVersionNode);
 
 			virtual QJsonValue toJson() const override;
 
@@ -63,31 +56,31 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 			Model::Text* newVersionObjectPath();
 			Model::Text* oldVersionObjectPath();
 
+			Model::Text* singleObjectPath();
+
 			Model::Text* componentType();
+
+			bool twoObjectPathsDefined();
 
 
 		private:
+			bool twoObjectPathsDefined_;
+
 			Model::Node* oldVersionNode_{};
 			Model::Node* newVersionNode_{};
 
 			Model::Text* newVersionObjectPath_{};
 			Model::Text* oldVersionObjectPath_{};
 
+			Model::Text* singleObjectPath_{};
 
 			Model::Text* componentType_{};
 
+			QString computeObjectPath(Model::Node* node);
 
+			void setUpComponentType();
+			void setUpObjectPath();
 };
-
-inline void DiffComparisonPair::setOldVersionNode(Model::Node* oldVersionNode) {oldVersionNode_ = oldVersionNode;}
-inline void DiffComparisonPair::setNewVersionNode(Model::Node* newVersionNode) {newVersionNode_ = newVersionNode;}
-
-inline void DiffComparisonPair::setNewVersionObjectPath(Model::Text* newVersionObjectPath)
-{newVersionObjectPath_ = newVersionObjectPath;}
-inline void DiffComparisonPair::setOldVersionObjectPath(Model::Text* oldVersionObjectPath)
-{oldVersionObjectPath_ = oldVersionObjectPath;}
-
-inline void DiffComparisonPair::setComponentType(Model::Text* componentType) {componentType_ = componentType; }
 
 inline Model::Node* DiffComparisonPair::newVersionNode() {return newVersionNode_;}
 inline Model::Node* DiffComparisonPair::oldVersionNode() {return oldVersionNode_;}
@@ -95,6 +88,10 @@ inline Model::Node* DiffComparisonPair::oldVersionNode() {return oldVersionNode_
 inline Model::Text* DiffComparisonPair::newVersionObjectPath() {return newVersionObjectPath_;}
 inline Model::Text* DiffComparisonPair::oldVersionObjectPath() {return oldVersionObjectPath_;}
 
+inline Model::Text* DiffComparisonPair::singleObjectPath() {return singleObjectPath_;}
+
 inline Model::Text* DiffComparisonPair::componentType() {return componentType_;}
+
+inline bool DiffComparisonPair::twoObjectPathsDefined() {return twoObjectPathsDefined_;}
 
 }

--- a/VersionControlUI/styles/item/VDiffComparisonPair/default
+++ b/VersionControlUI/styles/item/VDiffComparisonPair/default
@@ -12,52 +12,11 @@
 			<color>#e6e6e6</color>
 		</outline>
 	</shape>
-	<oldVersionObjectPath prototypes="item/Text/default">
-		<pen>
-			<style>1</style>
-			<color>#000000</color>
-		</pen>
-		<font>
-			<size>15</size>
-			<weight>75</weight>
-			<style>0</style>
-			<underline>false</underline>
-		</font>
-	</oldVersionObjectPath>
-	<newVersionObjectPath prototypes="item/Text/default">
-		<pen>
-			<style>1</style>
-			<color>#000000</color>
-		</pen>
-		<font>
-			<size>15</size>
-			<weight>30</weight>
-			<style>0</style>
-			<underline>false</underline>
-		</font>
-	</newVersionObjectPath>
-	<singleObjectPath prototypes="item/Text/default">
-		<pen>
-			<style>1</style>
-			<color>#000000</color>
-		</pen>
-		<font>
-			<size>15</size>
-			<weight>30</weight>
-			<style>0</style>
-			<underline>false</underline>
-		</font>
-	</singleObjectPath>
-	<componentType prototypes="item/Text/default">
-		<pen>
-			<style>1</style>
-			<color>#000000</color>
-		</pen>
-		<font>
-			<size>15</size>
-			<weight>30</weight>
-			<style>0</style>
-			<underline>false</underline>
-		</font>
-	</componentType>
+	<oldVersionObjectPath prototypes="text" />
+	<newVersionObjectPath prototypes="text" />
+	<singleObjectPath prototypes="text" />
+	<componentType prototypes="text" />
+	<nodeNotFoundIcon prototypes="item/Symbol/keyword">
+		<symbol>no node</symbol>
+	</nodeNotFoundIcon>
 </style>

--- a/VersionControlUI/styles/item/VDiffComparisonPair/text
+++ b/VersionControlUI/styles/item/VDiffComparisonPair/text
@@ -1,0 +1,12 @@
+<style prototypes="item/Text/default">
+	<pen>
+		<style>1</style>
+		<color>#000000</color>
+	</pen>
+	<font>
+		<size>15</size>
+		<weight>75</weight>
+		<style>0</style>
+		<underline>false</underline>
+	</font>
+</style>


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62030849%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031124%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031231%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031288%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031359%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031621%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031717%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031919%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031984%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62032085%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62032161%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62032284%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62032593%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62032971%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62033312%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62033540%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62033770%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62034121%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62034663%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62034936%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23issuecomment-216874826%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23issuecomment-216881720%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23issuecomment-216874826%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Updated.%22%2C%20%22created_at%22%3A%20%222016-05-04T14%3A02%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%22%2C%20%22created_at%22%3A%20%222016-05-04T14%3A26%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20032a11a5af87dd538d58f7d3877ad808717ca086%20VersionControlUI/src/nodes/DiffComparisonPair.cpp%2080%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031621%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Oh%20I%20didn%27t%20expect%20to%20see%20this%20here.%20Is%20it%20really%20useful%20to%20show%20this%3F%20Ideally%20the%20object%20we%20show%20for%20the%20diff%20is%20some%20bigger%20object%2C%20where%20the%20type%20is%20clear%20from%20the%20visualization.%5Cr%5Cn%5Cr%5CnDo%20you%20have%20a%20use%20case%20in%20mind%20where%2C%20it%27s%20useful%20to%20show%20the%20type%20name%3F%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A44%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20guess%20in%20this%20case%20the%20type%20is%20clear%20from%20the%20visualization.%20At%20the%20moment%20the%20componentName/Type%20is%20always%20shown.%20So%20you%20see%20the%20type%20whether%20it%20is%20a%20Class%20or%20the%20name%20of%20a%20module%20which%20has%20changed.%20I%20did%20it%20mainly%20for%20consistency%20reasons%2C%20but%20I%20think%20only%20showing%20it%20in%20the%20special%20cases%20would%20also%20be%20fine.%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A47%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20it%20might%20be%20a%20bit%20confusing%20to%20sometimes%20show%20a%20type%20name%20and%20sometimes%20show%20a%20name%2C%20so%20I%20think%20for%20consistency%20it%27s%20better%20to%20just%20show%20the%20name.%5Cr%5Cn%5Cr%5CnIf%20you%20want%20to%20make%20your%20visualization%20easier%2C%20you%20could%20consider%20adding%20this%20as%20the%20last%20component%20of%20the%20path%20%28which%20it%20sort%20of%20is%2C%20anyway%29.%20Then%20you%27ll%20always%20have%20something%20%28a%20path%29%20and%20it%20will%20sometimes%20just%20be%20longer%20%28include%20a%20name%29.%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A57%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20I%27ll%20do%20it%20that%20way.%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A58%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/nodes/DiffComparisonPair.cpp%3AL25-124%22%7D%2C%20%22Pull%20032a11a5af87dd538d58f7d3877ad808717ca086%20VersionControlUI/src/nodes/DiffComparisonPair.cpp%2092%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031124%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ideally%20we%20don%27t%20have%20to%20write%20this%20dummy%20method%2C%20but%20if%20removing%20the%20macro%20means%20that%20we%20would%20have%20to%20write%20a%20lot%20of%20other%20things%20by%20hand%2C%20I%27d%20rather%20keep%20the%20macro%20and%20this%20method.%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A39%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/nodes/DiffComparisonPair.cpp%3AL25-124%22%7D%2C%20%22Pull%20032a11a5af87dd538d58f7d3877ad808717ca086%20VersionControlUI/src/nodes/DiffComparisonPair.cpp%2060%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031231%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20this%20method%20end%20in%20%60Name%60%20as%20opposed%20to%20%60Type%60%3F%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A40%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/nodes/DiffComparisonPair.cpp%3AL25-124%22%7D%2C%20%22Pull%20032a11a5af87dd538d58f7d3877ad808717ca086%20VersionControlUI/src/items/VDiffComparisonPair.h%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62032161%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22it%20is%20not%20strictly%20needed%2C%20but%20please%20put%20%60virtual%60%20infront%20here%2C%20to%20match%20the%20style%20of%20the%20rest%20of%20envision.%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A48%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/items/VDiffComparisonPair.h%3AL54-74%22%7D%2C%20%22Pull%20032a11a5af87dd538d58f7d3877ad808717ca086%20VersionControlUI/src/nodes/DiffComparisonPair.cpp%2088%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031717%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22naah%2C%20I%27d%20leave%20it%20as%20it%20is.%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A45%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/nodes/DiffComparisonPair.cpp%3AL25-124%22%7D%2C%20%22Pull%20032a11a5af87dd538d58f7d3877ad808717ca086%20VersionControlUI/src/items/VDiffComparisonPair.cpp%2051%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62032593%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%20lines%20are%20indented%20with%20one%20additional%20tab%20compared%20to%20the%20analogous%20lines%20in%20the%20form%20elements%20above.%20Please%20use%20consistent%20indentation.%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A52%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/items/VDiffComparisonPair.cpp%3AL52-179%22%7D%2C%20%22Pull%20032a11a5af87dd538d58f7d3877ad808717ca086%20VersionControlUI/src/nodes/DiffComparisonPair.cpp%2072%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031288%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20I%20don%27t%20think%20we%20should%20iterate%20here.%20Just%20look%20at%20the%20direct%20parent.%20What%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A41%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20was%20not%20sure%20if%20the%20direct%20parent%20is%20enough%2C%20is%20it%20possible%20that%20the%20direct%20parent%20is%20not%20a%20composite%20node%3F%20If%20not%20then%20I%20guess%20only%20looking%20at%20the%20direct%20parent%20would%20be%20enough.%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A47%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20theoretically%20possible%20that%20the%20direct%20parent%20is%20not%20a%20composite%20node.%20In%20the%20current%20design%2C%20pretty%20much%20the%20only%20other%20option%20is%20if%20the%20parent%20is%20a%20list.%20But%20in%20that%20case%2C%20do%20you%20think%20it%27s%20reasonable%20to%20go%20the%20list%27s%20parent%20and%20check%20if%20that%27s%20composite%3F%20Would%20it%20help%20if%20we%20showed%20the%20name%20of%20the%20link%20that%20the%20list%20has%20with%20it%27s%20parent%3F%20I%20think%20in%20such%20cases%2C%20we%20should%20just%20be%20visualizing%20more%20than%20just%20the%20node%20and%20so%20the%20search%20should%20already%20start%20from%20an%20ancestor.%22%2C%20%22created_at%22%3A%20%222016-05-04T13%3A00%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22On%20the%20other%20hand%2C%20maybe%20it%20doesn%27t%20hurt.%20E.g.%20if%20we%20keep%20the%20current%20design%2C%20changing%20a%20statement%20in%20a%20method%20will%20display%20the%20path%3A%5Cr%5Cn%5Cr%5CnProject/Package/ClassName/methods%5Cr%5Cnas%20opposed%20to%20just%5Cr%5CnProjct/Package/ClassName%5Cr%5Cn%5Cr%5CnI%20don%27t%20know%2C%20maybe%20we%20can%20keep%20it%20and%20see.%20Do%20you%20have%20more%20thoughts%20on%20this%3F%22%2C%20%22created_at%22%3A%20%222016-05-04T13%3A02%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sure%2C%20I%20think%20it%20could%20be%20OK%20to%20see%20a%20little%20bit%20more.%20Should%20I%20keep%20it%20the%20way%20it%20is%20and%20have%20a%20look%20at%20it%20when%20we%20have%20more%20examples%20to%20see%20how%20it%20looks%20/%20how%20useful%20it%20is%3F%22%2C%20%22created_at%22%3A%20%222016-05-04T13%3A06%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sure%2C%20let%27s%20do%20that.%20Thanks.%22%2C%20%22created_at%22%3A%20%222016-05-04T13%3A08%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/nodes/DiffComparisonPair.cpp%3AL25-124%22%7D%2C%20%22Pull%20032a11a5af87dd538d58f7d3877ad808717ca086%20VersionControlUI/src/items/VDiffComparisonPair.cpp%20237%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62032284%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22you%20don%27t%20need%20this.%20just%20use%20%60node%28%29%60%20in%20all%20places%20below.%20This%20is%20an%20inline%20function%20so%20it%20will%20be%20plenty%20fast.%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A49%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/items/VDiffComparisonPair.cpp%3AL252-294%22%7D%2C%20%22Pull%20032a11a5af87dd538d58f7d3877ad808717ca086%20VersionControlUI/src/nodes/DiffComparisonPair.cpp%2077%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031359%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22use%20%60auto%60%20as%20much%20as%20possible.%20For%20example%2C%20for%20the%20type%20of%20the%20variable.here.%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A42%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/nodes/DiffComparisonPair.cpp%3AL25-124%22%7D%2C%20%22Pull%20032a11a5af87dd538d58f7d3877ad808717ca086%20VersionControlUI/src/items/VDiffComparisonPair.cpp%20203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62032971%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22So%20here%2C%20you%20have%20a%20memory%20leak.%20You%20have%20the%20container%20variable%2C%20which%20you%20always%20cloned%2C%20and%20now%20it%27s%20an%20unused%20pointer%20left%20at%20the%20end%20of%20the%20method%20and%20will%20not%20be%20deleted.%20Simply%20don%27t%20clone%20it%20once.%20E.g.%20here.%20Then%20the%20declarative%20item%20infrastructure%20will%20take%20ownership%20of%20it.%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A54%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/items/VDiffComparisonPair.cpp%3AL190-236%22%7D%2C%20%22Pull%20032a11a5af87dd538d58f7d3877ad808717ca086%20VersionControlUI/src/nodes/DiffComparisonPair.h%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62031919%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Default%20initialize%20all%20primitive%20types%20%28int%2C%20bool%2C%20float%2C%20all%20%2A%29%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A46%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/nodes/DiffComparisonPair.h%3AL56-98%22%7D%2C%20%22Pull%20032a11a5af87dd538d58f7d3877ad808717ca086%20VersionControlUI/src/nodes/DiffComparisonPair.h%2042%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/374%23discussion_r62030849%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20name%20could%20be%20confused%20with%20the%20name%20of%20a%20setter.%20change%20%60setUp%60%20to%20%60compute%60%2C%20and%20the%20same%20for%20the%20method%20below.%22%2C%20%22created_at%22%3A%20%222016-05-04T12%3A37%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/nodes/DiffComparisonPair.h%3AL56-98%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 032a11a5af87dd538d58f7d3877ad808717ca086 VersionControlUI/src/nodes/DiffComparisonPair.h 42'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#discussion_r62030849'>File: VersionControlUI/src/nodes/DiffComparisonPair.h:L56-98</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> this name could be confused with the name of a setter. change `setUp` to `compute`, and the same for the method below.
- [ ] <a href='#crh-comment-Pull 032a11a5af87dd538d58f7d3877ad808717ca086 VersionControlUI/src/nodes/DiffComparisonPair.cpp 92'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#discussion_r62031124'>File: VersionControlUI/src/nodes/DiffComparisonPair.cpp:L25-124</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Ideally we don't have to write this dummy method, but if removing the macro means that we would have to write a lot of other things by hand, I'd rather keep the macro and this method.
- [ ] <a href='#crh-comment-Pull 032a11a5af87dd538d58f7d3877ad808717ca086 VersionControlUI/src/nodes/DiffComparisonPair.cpp 60'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#discussion_r62031231'>File: VersionControlUI/src/nodes/DiffComparisonPair.cpp:L25-124</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Shouldn't this method end in `Name` as opposed to `Type`?
- [ ] <a href='#crh-comment-Pull 032a11a5af87dd538d58f7d3877ad808717ca086 VersionControlUI/src/nodes/DiffComparisonPair.cpp 72'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#discussion_r62031288'>File: VersionControlUI/src/nodes/DiffComparisonPair.cpp:L25-124</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, I don't think we should iterate here. Just look at the direct parent. What do you think?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> I was not sure if the direct parent is enough, is it possible that the direct parent is not a composite node? If not then I guess only looking at the direct parent would be enough.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> It is theoretically possible that the direct parent is not a composite node. In the current design, pretty much the only other option is if the parent is a list. But in that case, do you think it's reasonable to go the list's parent and check if that's composite? Would it help if we showed the name of the link that the list has with it's parent? I think in such cases, we should just be visualizing more than just the node and so the search should already start from an ancestor.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> On the other hand, maybe it doesn't hurt. E.g. if we keep the current design, changing a statement in a method will display the path:
  Project/Package/ClassName/methods
  as opposed to just
  Projct/Package/ClassName
  I don't know, maybe we can keep it and see. Do you have more thoughts on this?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> I'm not sure, I think it could be OK to see a little bit more. Should I keep it the way it is and have a look at it when we have more examples to see how it looks / how useful it is?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Sure, let's do that. Thanks.
- [ ] <a href='#crh-comment-Pull 032a11a5af87dd538d58f7d3877ad808717ca086 VersionControlUI/src/nodes/DiffComparisonPair.cpp 77'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#discussion_r62031359'>File: VersionControlUI/src/nodes/DiffComparisonPair.cpp:L25-124</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> use `auto` as much as possible. For example, for the type of the variable.here.
- [ ] <a href='#crh-comment-Pull 032a11a5af87dd538d58f7d3877ad808717ca086 VersionControlUI/src/nodes/DiffComparisonPair.cpp 80'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#discussion_r62031621'>File: VersionControlUI/src/nodes/DiffComparisonPair.cpp:L25-124</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Oh I didn't expect to see this here. Is it really useful to show this? Ideally the object we show for the diff is some bigger object, where the type is clear from the visualization.
  Do you have a use case in mind where, it's useful to show the type name?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> I guess in this case the type is clear from the visualization. At the moment the componentName/Type is always shown. So you see the type whether it is a Class or the name of a module which has changed. I did it mainly for consistency reasons, but I think only showing it in the special cases would also be fine.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Well, it might be a bit confusing to sometimes show a type name and sometimes show a name, so I think for consistency it's better to just show the name.
  If you want to make your visualization easier, you could consider adding this as the last component of the path (which it sort of is, anyway). Then you'll always have something (a path) and it will sometimes just be longer (include a name).
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> OK, I'll do it that way.
- [ ] <a href='#crh-comment-Pull 032a11a5af87dd538d58f7d3877ad808717ca086 VersionControlUI/src/nodes/DiffComparisonPair.cpp 88'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#discussion_r62031717'>File: VersionControlUI/src/nodes/DiffComparisonPair.cpp:L25-124</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> naah, I'd leave it as it is.
- [ ] <a href='#crh-comment-Pull 032a11a5af87dd538d58f7d3877ad808717ca086 VersionControlUI/src/nodes/DiffComparisonPair.h 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#discussion_r62031919'>File: VersionControlUI/src/nodes/DiffComparisonPair.h:L56-98</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Default initialize all primitive types (int, bool, float, all *)
- [ ] <a href='#crh-comment-Pull 032a11a5af87dd538d58f7d3877ad808717ca086 VersionControlUI/src/items/VDiffComparisonPair.h 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#discussion_r62032161'>File: VersionControlUI/src/items/VDiffComparisonPair.h:L54-74</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> it is not strictly needed, but please put `virtual` infront here, to match the style of the rest of envision.
- [ ] <a href='#crh-comment-Pull 032a11a5af87dd538d58f7d3877ad808717ca086 VersionControlUI/src/items/VDiffComparisonPair.cpp 237'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#discussion_r62032284'>File: VersionControlUI/src/items/VDiffComparisonPair.cpp:L252-294</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> you don't need this. just use `node()` in all places below. This is an inline function so it will be plenty fast.
- [ ] <a href='#crh-comment-Pull 032a11a5af87dd538d58f7d3877ad808717ca086 VersionControlUI/src/items/VDiffComparisonPair.cpp 51'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#discussion_r62032593'>File: VersionControlUI/src/items/VDiffComparisonPair.cpp:L52-179</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> These lines are indented with one additional tab compared to the analogous lines in the form elements above. Please use consistent indentation.
- [ ] <a href='#crh-comment-Pull 032a11a5af87dd538d58f7d3877ad808717ca086 VersionControlUI/src/items/VDiffComparisonPair.cpp 203'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#discussion_r62032971'>File: VersionControlUI/src/items/VDiffComparisonPair.cpp:L190-236</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> So here, you have a memory leak. You have the container variable, which you always cloned, and now it's an unused pointer left at the end of the method and will not be deleted. Simply don't clone it once. E.g. here. Then the declarative item infrastructure will take ownership of it.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/374#issuecomment-216874826'>General Comment</a></b>
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Updated.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/374?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/374?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/374'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
