### PR TITLE
Optimizes loadNodeData

### DIFF
--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -105,14 +105,14 @@ bool Commit::getFileContent(QString fileName, const char*& content, int& content
 
 QStringList Commit::nodeLinesFromId(Model::NodeIdType id, bool findChildrenByParentId) const
 {
-	auto idtext =  id.toString();
+	auto idText =  id.toString();
 	QStringList matches;
 	for (auto file : files())
 	{
 		int indexOfId = 0;
 		auto content = QString::fromUtf8(file->content());
 
-		indexOfId = content.indexOf(idtext, indexOfId);
+		indexOfId = content.indexOf(idText, indexOfId);
 		if (indexOfId != -1)
 		{
 			bool invalid = false;
@@ -131,7 +131,7 @@ QStringList Commit::nodeLinesFromId(Model::NodeIdType id, bool findChildrenByPar
 					}
 				start--;
 			}
-			if (invalid == true)	continue;
+			if (invalid)	continue;
 			start++;
 
 			// end is the character after the line containing id
@@ -146,7 +146,7 @@ QStringList Commit::nodeLinesFromId(Model::NodeIdType id, bool findChildrenByPar
 					}
 				end++;
 			}
-			if (invalid == true)	continue;
+			if (invalid)	continue;
 
 			QString match = file->relativePath_ + ":" + content.mid(start, end-start);
 			matches << match;

--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -103,19 +103,19 @@ bool Commit::getFileContent(QString fileName, const char*& content, int& content
 		return false;
 }
 
-QStringList Commit::nodeLinesFromId(Model::NodeIdType Id, bool findChildrenByParentId) const
+QStringList Commit::nodeLinesFromId(Model::NodeIdType id, bool findChildrenByParentId) const
 {
-	auto id =  Id.toString();
+	auto idtext =  id.toString();
 	QStringList matches;
 	for (auto file : files())
 	{
 		int indexOfId = 0;
 		auto content = QString::fromUtf8(file->content());
 
-		indexOfId = content.indexOf(id, indexOfId);
+		indexOfId = content.indexOf(idtext, indexOfId);
 		if (indexOfId != -1)
 		{
-			int invalid = 0;
+			bool invalid = false;
 			auto start = indexOfId;
 			auto end = indexOfId;
 
@@ -123,30 +123,30 @@ QStringList Commit::nodeLinesFromId(Model::NodeIdType Id, bool findChildrenByPar
 			while (start >= 0 && content[start] != '\n')
 			{
 				// String is of the form {.*} {id}
-				if (findChildrenByParentId == 0)
+				if (!findChildrenByParentId)
 					if (content[start] == '}')
 					{
-						invalid = 1;
+						invalid = true;
 						break;
 					}
 				start--;
 			}
-			if (invalid == 1)	continue;
+			if (invalid == true)	continue;
 			start++;
 
 			// end is the character after the line containing id
 			while (end <= content.size() && content[end] != '\n')
 			{
 				// String is of the form {id} {*.}
-				if (findChildrenByParentId == 1)
+				if (findChildrenByParentId)
 					if (content[end] == '{')
 					{
-						invalid = 1;
+						invalid = true;
 						break;
 					}
 				end++;
 			}
-			if (invalid == 1)	continue;
+			if (invalid == true)	continue;
 
 			QString match = file->relativePath_ + ":" + content.mid(start, end-start);
 			matches << match;

--- a/FilePersistence/src/version_control/Commit.h
+++ b/FilePersistence/src/version_control/Commit.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "../filepersistence_api.h"
+#include "ModelBase/src/persistence/PersistentStore.h"
 
 namespace FilePersistence {
 
@@ -79,6 +80,8 @@ class FILEPERSISTENCE_API Commit
 		void addFile(QString relativePath, qint64 size, std::unique_ptr<char[], CommitFileContentDeleter> content);
 
 		bool getFileContent(QString fileName, const char*& content, int& contentSize, bool exactFileNameMatching) const;
+		QStringList nodeLinesFromId(Model::NodeIdType id, bool findChildrenByParentId = 0) const;
+
 
 	private:
 		CommitMetaData information_;

--- a/FilePersistence/src/version_control/GitPiecewiseLoader.cpp
+++ b/FilePersistence/src/version_control/GitPiecewiseLoader.cpp
@@ -62,7 +62,7 @@ NodeData GitPiecewiseLoader::loadNodeData(Model::NodeIdType id)
 	{
 		if (!commit_)
 			commit_.reset(repo_->getCommit(revision_));
-		auto s = commit_->nodeLinesFromId(id, 0);
+		auto s = commit_->nodeLinesFromId(id, false);
 
 		Q_ASSERT(s.size() == 1 || s.size() == 2);
 		for (auto line : s)
@@ -96,7 +96,7 @@ QList<NodeData> GitPiecewiseLoader::loadNodeChildrenData(Model::NodeIdType id)
 		if (!commit_)
 			commit_.reset(repo_->getCommit(revision_));
 
-		auto s = commit_->nodeLinesFromId(id, 1);
+		auto s = commit_->nodeLinesFromId(id, true);
 		Q_ASSERT(s.size() == 1);
 
 		for (auto line : s)

--- a/FilePersistence/src/version_control/GitPiecewiseLoader.cpp
+++ b/FilePersistence/src/version_control/GitPiecewiseLoader.cpp
@@ -46,7 +46,6 @@ NodeData GitPiecewiseLoader::loadNodeData(Model::NodeIdType id)
 	if (isWorkDir)
 	{
 		auto regEx = ".*" + id.toString() + " {.*}.*";
-		qDebug() << regEx;
 		SystemCommandResult result = runSystemCommand("grep", {"-G", "-r", regEx}, workDir_);
 		Q_ASSERT(result.exitCode() == 0);
 		Q_ASSERT(!result.standardout().isEmpty());

--- a/FilePersistence/src/version_control/GitPiecewiseLoader.h
+++ b/FilePersistence/src/version_control/GitPiecewiseLoader.h
@@ -36,6 +36,7 @@ namespace FilePersistence {
 
 class GitRepository;
 class GenericTree;
+class Commit;
 
 class FILEPERSISTENCE_API GitPiecewiseLoader : public PiecewiseLoader
 {
@@ -48,13 +49,15 @@ class FILEPERSISTENCE_API GitPiecewiseLoader : public PiecewiseLoader
 		QList<NodeData> loadNodeChildrenData(Model::NodeIdType id);
 
 	private:
-		static NodeData parseGrepLine(const QString& line, bool isWorkDir);
+		static NodeData parseGrepLine(const QString& line);
 
 		static bool isPersistenceUnit(const QString& nodeLine);
 
 		const GitRepository* repo_;
 		QString revision_;
 		QString workDir_;
+
+		std::unique_ptr<const Commit> commit_;
 };
 
 }


### PR DESCRIPTION
Removes runSystemCommand and implements it manually using QStrings
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62350214%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62350339%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62350516%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62350822%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62351007%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62351399%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62351571%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62351784%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62351914%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62352020%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23issuecomment-217488511%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62539633%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62539857%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62540150%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62540835%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62540904%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62540999%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23issuecomment-217937066%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62677943%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62677993%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62678136%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23issuecomment-218175064%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23issuecomment-217488511%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22OK%2C%20I%27m%20done%20with%20the%20review%2C%20please%20have%20a%20look%20and%20push%20another%20commit%20that%20fixes%20the%20issues%20I%20mentioned.%22%2C%20%22created_at%22%3A%20%222016-05-06T16%3A18%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Alright.%20I%27m%20done%20with%20this%20round%20of%20reviews%2C%20I%20hope%20I%20will%20merge%20the%20next%20version.%20Please%20commit%20only%20fixes%20to%20the%20issues%20I%20pointed%20out%2C%20without%20any%20other%20changes%20or%20additions.%20If%20you%20don%27t%20know%20a%20good%20way%20to%20work%20in%20parallel%20on%20new%20features%20and%20existing%20PRs%2C%20please%20talk%20to%20Manuel%20and%20he%27ll%20advise%20you%20on%20some%20git%20magic%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-05-09T17%3A49%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20a%20lot%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-05-10T14%3A29%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f53dec631fc7d82e891772cc9df66bf41670efc5%20FilePersistence/src/version_control/Commit.cpp%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62539857%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22you%20can%20call%20this%2C%20%60idText%60%22%2C%20%22created_at%22%3A%20%222016-05-09T17%3A39%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-163%22%7D%2C%20%22Pull%20f53dec631fc7d82e891772cc9df66bf41670efc5%20FilePersistence/src/version_control/Commit.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62539633%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22please%20follow%20the%20Envision%20camelCaseRules.%20Variable%20names%20start%20with%20a%20lowercase%20letter%2C%20not%20upper%20case%20%60id%60.%22%2C%20%22created_at%22%3A%20%222016-05-09T17%3A38%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-163%22%7D%2C%20%22Pull%20c121e96b95b17bb805dbf1eea7756937ffb031dc%20FilePersistence/src/version_control/Commit.cpp%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62351399%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Same%20comments%20like%20the%20function%20above%3A%20use%20%60NodeIdType%60%20and%20avoid%20regex%20in%20the%20name%22%2C%20%22created_at%22%3A%20%222016-05-06T16%3A08%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20method%20is%20very%20very%20similar%20to%20the%20one%20above.%20Merge%20them%20into%20one%20method%20by%20adding%20an%20extra%20parameter%20%60bool%20findChildrenByParentId%60%22%2C%20%22created_at%22%3A%20%222016-05-06T16%3A10%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-191%22%7D%2C%20%22Pull%20c121e96b95b17bb805dbf1eea7756937ffb031dc%20FilePersistence/src/version_control/GitPiecewiseLoader.cpp%2069%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62351784%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22actually%2C%20if%20you%20look%20at%20the%20two%20branches%20of%20this%20if%20statement%2C%20you%20will%20see%20that%20now%20both%20branches%20are%20identical%20after%20our%20changes.%20Please%20simplify%20this%20whole%20method%20by%20removing%20the%20%60if%60%22%2C%20%22created_at%22%3A%20%222016-05-06T16%3A12%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitPiecewiseLoader.cpp%3AL114-122%22%7D%2C%20%22Pull%20bc084b49ba846d29fa0cb1a082ade09c8cec0661%20FilePersistence/src/version_control/Commit.cpp%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62678136%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22proper%20camel%20case%20would%20be%20%60idText%60%20%28capital%20T%29%22%2C%20%22created_at%22%3A%20%222016-05-10T14%3A12%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-153%22%7D%2C%20%22Pull%20008f3542ab222fdcaf5ff3f73cbd7fa5f7ed0577%20FilePersistence/src/version_control/Commit.h%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62540835%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22do%20not%20%2Aever%2A%20use%20%600%60%20and%20%601%60%20when%20working%20with%20booleans.%20Always%20use%20%60true%60%20and%20%60false%60.%20I%20know%20that%20internally%20%600%60%20and%20%601%60%20are%20the%20same%20thing%2C%20but%20this%20is%20bad%20coding%20practice%20and%20is%20harder%20to%20read.%22%2C%20%22created_at%22%3A%20%222016-05-09T17%3A44%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.h%3AL80-88%22%7D%2C%20%22Pull%20f53dec631fc7d82e891772cc9df66bf41670efc5%20FilePersistence/src/version_control/Commit.cpp%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62540150%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20should%20be%20a%20%60bool%60%20not%20an%20int.%20You%20only%20ever%20use%200%20and%201.%20So%20use%2C%20%60true%60%2C%20and%20%60false%60%20instead.%22%2C%20%22created_at%22%3A%20%222016-05-09T17%3A40%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-163%22%7D%2C%20%22Pull%20c121e96b95b17bb805dbf1eea7756937ffb031dc%20FilePersistence/src/version_control/Commit.cpp%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62351007%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22please%20don%27t%20assign%20and%20compare%20in%20a%20single%20if%20condition.%20write%20the%20assignment%20on%20the%20previous%20line.%22%2C%20%22created_at%22%3A%20%222016-05-06T16%3A05%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-191%22%7D%2C%20%22Pull%20bc084b49ba846d29fa0cb1a082ade09c8cec0661%20FilePersistence/src/version_control/Commit.cpp%2057%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62677993%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60if%20%28invalid%29%60%22%2C%20%22created_at%22%3A%20%222016-05-10T14%3A11%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-153%22%7D%2C%20%22Pull%20008f3542ab222fdcaf5ff3f73cbd7fa5f7ed0577%20FilePersistence/src/version_control/GitPiecewiseLoader.cpp%20119%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62540999%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20%27true%27%20instead%20of%201.%22%2C%20%22created_at%22%3A%20%222016-05-09T17%3A45%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitPiecewiseLoader.cpp%3AL41-120%22%7D%2C%20%22Pull%20c121e96b95b17bb805dbf1eea7756937ffb031dc%20FilePersistence/src/version_control/GitPiecewiseLoader.cpp%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62352020%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22remove%22%2C%20%22created_at%22%3A%20%222016-05-06T16%3A13%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitPiecewiseLoader.cpp%3AL41-77%22%7D%2C%20%22Pull%20c121e96b95b17bb805dbf1eea7756937ffb031dc%20FilePersistence/src/version_control/GitPiecewiseLoader.cpp%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62351914%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20do%20not%20commit%20%60qDebug%60%20lines.%20Using%20%60git%20gui%60%20you%20can%20select%20individual%20lines%20of%20a%20modified%20file%20to%20commit%2C%20so%20you%20don%27t%20need%20to%20do%20all%20or%20nothing.%22%2C%20%22created_at%22%3A%20%222016-05-06T16%3A13%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitPiecewiseLoader.cpp%3AL41-77%22%7D%2C%20%22Pull%20c121e96b95b17bb805dbf1eea7756937ffb031dc%20FilePersistence/src/version_control/Commit.cpp%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62350516%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Don%27t%20call%20things%20using%20generic%20names%20like%20%60index%60%20or%20%60flag%60.%20What%20is%20this%20index%3F%20What%20does%20the%20flag%20actually%20indicate%3F%20Please%20use%20descriptive%20names.%22%2C%20%22created_at%22%3A%20%222016-05-06T16%3A02%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-191%22%7D%2C%20%22Pull%20c121e96b95b17bb805dbf1eea7756937ffb031dc%20FilePersistence/src/precompiled.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62350214%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20remove%20this%2C%20we%27re%20no%20longer%20using%20regular%20expressions.%22%2C%20%22created_at%22%3A%20%222016-05-06T16%3A00%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/precompiled.h%3AL44-52%22%7D%2C%20%22Pull%20c121e96b95b17bb805dbf1eea7756937ffb031dc%20FilePersistence/src/version_control/Commit.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62350339%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Don%27t%20call%20this%20method%20%60regex...%60%20it%27s%20not%20using%20regular%20expressions.%20Call%20it%20%60nodeLinesFromId%60.%22%2C%20%22created_at%22%3A%20%222016-05-06T16%3A01%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Also%20this%20function%20should%20accept%20directly%20an%20%60NodeIdType%60%20and%20convert%20it%20to%20%60QString%60%20locally.%22%2C%20%22created_at%22%3A%20%222016-05-06T16%3A04%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-191%22%7D%2C%20%22Pull%20bc084b49ba846d29fa0cb1a082ade09c8cec0661%20FilePersistence/src/version_control/Commit.cpp%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62677943%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20write%20concisely%2C%20this%20is%20equivalent%20to%20%60if%20%28invalid%29%60%22%2C%20%22created_at%22%3A%20%222016-05-10T14%3A11%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-153%22%7D%2C%20%22Pull%20008f3542ab222fdcaf5ff3f73cbd7fa5f7ed0577%20FilePersistence/src/version_control/GitPiecewiseLoader.cpp%2051%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/376%23discussion_r62540904%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22do%20not%20use%200%20here%2C%20use%20%60false%60%22%2C%20%22created_at%22%3A%20%222016-05-09T17%3A45%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitPiecewiseLoader.cpp%3AL41-120%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull c121e96b95b17bb805dbf1eea7756937ffb031dc FilePersistence/src/precompiled.h 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62350214'>File: FilePersistence/src/precompiled.h:L44-52</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please remove this, we're no longer using regular expressions.
- [x] <a href='#crh-comment-Pull c121e96b95b17bb805dbf1eea7756937ffb031dc FilePersistence/src/version_control/Commit.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62350339'>File: FilePersistence/src/version_control/Commit.cpp:L103-191</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Don't call this method `regex...` it's not using regular expressions. Call it `nodeLinesFromId`.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Also this function should accept directly an `NodeIdType` and convert it to `QString` locally.
- [x] <a href='#crh-comment-Pull c121e96b95b17bb805dbf1eea7756937ffb031dc FilePersistence/src/version_control/Commit.cpp 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62350516'>File: FilePersistence/src/version_control/Commit.cpp:L103-191</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Don't call things using generic names like `index` or `flag`. What is this index? What does the flag actually indicate? Please use descriptive names.
- [x] <a href='#crh-comment-Pull c121e96b95b17bb805dbf1eea7756937ffb031dc FilePersistence/src/version_control/Commit.cpp 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62351007'>File: FilePersistence/src/version_control/Commit.cpp:L103-191</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> please don't assign and compare in a single if condition. write the assignment on the previous line.
- [x] <a href='#crh-comment-Pull c121e96b95b17bb805dbf1eea7756937ffb031dc FilePersistence/src/version_control/Commit.cpp 46'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62351399'>File: FilePersistence/src/version_control/Commit.cpp:L103-191</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Same comments like the function above: use `NodeIdType` and avoid regex in the name
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This method is very very similar to the one above. Merge them into one method by adding an extra parameter `bool findChildrenByParentId`
- [x] <a href='#crh-comment-Pull c121e96b95b17bb805dbf1eea7756937ffb031dc FilePersistence/src/version_control/GitPiecewiseLoader.cpp 69'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62351784'>File: FilePersistence/src/version_control/GitPiecewiseLoader.cpp:L114-122</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> actually, if you look at the two branches of this if statement, you will see that now both branches are identical after our changes. Please simplify this whole method by removing the `if`
- [x] <a href='#crh-comment-Pull c121e96b95b17bb805dbf1eea7756937ffb031dc FilePersistence/src/version_control/GitPiecewiseLoader.cpp 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62351914'>File: FilePersistence/src/version_control/GitPiecewiseLoader.cpp:L41-77</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please do not commit `qDebug` lines. Using `git gui` you can select individual lines of a modified file to commit, so you don't need to do all or nothing.
- [x] <a href='#crh-comment-Pull c121e96b95b17bb805dbf1eea7756937ffb031dc FilePersistence/src/version_control/GitPiecewiseLoader.cpp 52'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62352020'>File: FilePersistence/src/version_control/GitPiecewiseLoader.cpp:L41-77</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> remove
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#issuecomment-217488511'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> OK, I'm done with the review, please have a look and push another commit that fixes the issues I mentioned.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Alright. I'm done with this round of reviews, I hope I will merge the next version. Please commit only fixes to the issues I pointed out, without any other changes or additions. If you don't know a good way to work in parallel on new features and existing PRs, please talk to Manuel and he'll advise you on some git magic :)
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks a lot :)
- [x] <a href='#crh-comment-Pull f53dec631fc7d82e891772cc9df66bf41670efc5 FilePersistence/src/version_control/Commit.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62539633'>File: FilePersistence/src/version_control/Commit.cpp:L103-163</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> please follow the Envision camelCaseRules. Variable names start with a lowercase letter, not upper case `id`.
- [x] <a href='#crh-comment-Pull f53dec631fc7d82e891772cc9df66bf41670efc5 FilePersistence/src/version_control/Commit.cpp 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62539857'>File: FilePersistence/src/version_control/Commit.cpp:L103-163</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> you can call this, `idText`
- [x] <a href='#crh-comment-Pull f53dec631fc7d82e891772cc9df66bf41670efc5 FilePersistence/src/version_control/Commit.cpp 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62540150'>File: FilePersistence/src/version_control/Commit.cpp:L103-163</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> this should be a `bool` not an int. You only ever use 0 and 1. So use, `true`, and `false` instead.
- [x] <a href='#crh-comment-Pull 008f3542ab222fdcaf5ff3f73cbd7fa5f7ed0577 FilePersistence/src/version_control/Commit.h 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62540835'>File: FilePersistence/src/version_control/Commit.h:L80-88</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> do not _ever_ use `0` and `1` when working with booleans. Always use `true` and `false`. I know that internally `0` and `1` are the same thing, but this is bad coding practice and is harder to read.
- [x] <a href='#crh-comment-Pull 008f3542ab222fdcaf5ff3f73cbd7fa5f7ed0577 FilePersistence/src/version_control/GitPiecewiseLoader.cpp 51'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62540904'>File: FilePersistence/src/version_control/GitPiecewiseLoader.cpp:L41-120</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> do not use 0 here, use `false`
- [x] <a href='#crh-comment-Pull 008f3542ab222fdcaf5ff3f73cbd7fa5f7ed0577 FilePersistence/src/version_control/GitPiecewiseLoader.cpp 119'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62540999'>File: FilePersistence/src/version_control/GitPiecewiseLoader.cpp:L41-120</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Use 'true' instead of 1.
- [x] <a href='#crh-comment-Pull bc084b49ba846d29fa0cb1a082ade09c8cec0661 FilePersistence/src/version_control/Commit.cpp 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62677943'>File: FilePersistence/src/version_control/Commit.cpp:L103-153</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please write concisely, this is equivalent to `if (invalid)`
- [x] <a href='#crh-comment-Pull bc084b49ba846d29fa0cb1a082ade09c8cec0661 FilePersistence/src/version_control/Commit.cpp 57'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62677993'>File: FilePersistence/src/version_control/Commit.cpp:L103-153</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `if (invalid)`
- [x] <a href='#crh-comment-Pull bc084b49ba846d29fa0cb1a082ade09c8cec0661 FilePersistence/src/version_control/Commit.cpp 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/376#discussion_r62678136'>File: FilePersistence/src/version_control/Commit.cpp:L103-153</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> proper camel case would be `idText` (capital T)

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/376?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/376?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/376'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
