### PR TITLE
Gm diff manager

### DIFF
--- a/CodeReview/CMakeLists.txt
+++ b/CodeReview/CMakeLists.txt
@@ -8,8 +8,18 @@ add_library(CodeReview SHARED
 	src/CodeReviewException.h
 	src/codereview_api.h
 	src/CodeReviewPlugin.h
+	src/CodeReviewManager.h
+	src/commands/CCodeReviewComment.h
+	src/overlays/CodeReviewCommentOverlay.h
+	src/overlays/CodeReviewCommentOverlayStyle.h
+	src/handlers/HReviewableItem.h
 	src/CodeReviewException.cpp
 	src/CodeReviewPlugin.cpp
+	src/CodeReviewManager.cpp
+	src/commands/CCodeReviewComment.cpp
+	src/overlays/CodeReviewCommentOverlay.cpp
+	src/overlays/CodeReviewCommentOverlayStyle.cpp
+	src/handlers/HReviewableItem.cpp
 	test/SimpleTest.cpp
 )
-envision_plugin(CodeReview OOInteraction)
+envision_plugin(CodeReview OOInteraction VersionControlUI)

--- a/CodeReview/codereview.plugin
+++ b/CodeReview/codereview.plugin
@@ -4,5 +4,6 @@
 		<dependency pluginid="logger" version="0" />
 		<dependency pluginid="selftest" version="0" />
 		<dependency pluginid="oointeraction" version="1" />
+		<dependency pluginid="versioncontrolui" version="1" />
 	</dependencies>
 </plugin>

--- a/CodeReview/src/CodeReviewManager.cpp
+++ b/CodeReview/src/CodeReviewManager.cpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -23,34 +23,3 @@
  ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **
  **********************************************************************************************************************/
-
-#ifndef PRECOMPILED_CODEREVIEW_H_
-#define PRECOMPILED_CODEREVIEW_H_
-
-// TODO: Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
-// those headers will be included here
-#include "VersionControlUI/src/precompiled.h"
-#include "InteractionBase/src/precompiled.h"
-#include "OOVisualization/src/precompiled.h"
-#include "OOInteraction/src/precompiled.h"
-#include "VisualizationBase/src/precompiled.h"
-#include "OOModel/src/precompiled.h"
-#include "ModelBase/src/precompiled.h"
-#include "Logger/src/precompiled.h"
-#include "SelfTest/src/precompiled.h"
-#include "Core/src/precompiled.h"
-#include "Core/src/global.h"
-
-
-// Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
-// and will be included in their precompiled headers
-
-
-#if defined(CodeReview_EXPORTS)
-// Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
-// plug-ins which depend on this one will not include these headers.
-
-
-#endif
-
-#endif /* PRECOMPILED_CODEREVIEW_H_ */

--- a/CodeReview/src/CodeReviewManager.h
+++ b/CodeReview/src/CodeReviewManager.h
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -23,34 +23,3 @@
  ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **
  **********************************************************************************************************************/
-
-#ifndef PRECOMPILED_CODEREVIEW_H_
-#define PRECOMPILED_CODEREVIEW_H_
-
-// TODO: Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
-// those headers will be included here
-#include "VersionControlUI/src/precompiled.h"
-#include "InteractionBase/src/precompiled.h"
-#include "OOVisualization/src/precompiled.h"
-#include "OOInteraction/src/precompiled.h"
-#include "VisualizationBase/src/precompiled.h"
-#include "OOModel/src/precompiled.h"
-#include "ModelBase/src/precompiled.h"
-#include "Logger/src/precompiled.h"
-#include "SelfTest/src/precompiled.h"
-#include "Core/src/precompiled.h"
-#include "Core/src/global.h"
-
-
-// Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
-// and will be included in their precompiled headers
-
-
-#if defined(CodeReview_EXPORTS)
-// Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
-// plug-ins which depend on this one will not include these headers.
-
-
-#endif
-
-#endif /* PRECOMPILED_CODEREVIEW_H_ */

--- a/CodeReview/src/CodeReviewPlugin.cpp
+++ b/CodeReview/src/CodeReviewPlugin.cpp
@@ -24,9 +24,13 @@
  **
  **********************************************************************************************************************/
 
+#include "handlers/HReviewableItem.h"
+
 #include "CodeReviewPlugin.h"
 #include "SelfTest/src/TestManager.h"
 #include "Logger/src/Log.h"
+
+#include "VersionControlUI/src/items/VDiffComparisonPair.h"
 
 namespace CodeReview {
 
@@ -38,6 +42,7 @@ Logger::Log& CodeReviewPlugin::log()
 
 bool CodeReviewPlugin::initialize(Core::EnvisionManager&)
 {
+	VersionControlUI::VDiffComparisonPair::setDefaultClassHandler(HReviewableItem::instance());
 	return true;
 }
 

--- a/CodeReview/src/commands/CCodeReviewComment.cpp
+++ b/CodeReview/src/commands/CCodeReviewComment.cpp
@@ -63,9 +63,7 @@ QList<Interaction::CommandSuggestion*> CCodeReviewComment::suggest(Visualization
 		const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>&)
 {
 	if (name().startsWith(textSoFar))
-	{
 		return {new Interaction::CommandSuggestion{name()}};
-	}
 	return {};
 }
 

--- a/CodeReview/src/commands/CCodeReviewComment.cpp
+++ b/CodeReview/src/commands/CCodeReviewComment.cpp
@@ -42,9 +42,11 @@ namespace CodeReview {
 CCodeReviewComment::CCodeReviewComment() : Command{"comment"} {}
 
 bool CCodeReviewComment::canInterpret(Visualization::Item*, Visualization::Item*,
-		const QStringList&, const std::unique_ptr<Visualization::Cursor>& )
+		const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& )
 {
-	return true;
+	if (commandTokens.size() > 0)
+		return name() == commandTokens.first();
+	return false;
 }
 
 Interaction::CommandResult* CCodeReviewComment::execute(Visualization::Item*, Visualization::Item*,

--- a/CodeReview/src/commands/CCodeReviewComment.cpp
+++ b/CodeReview/src/commands/CCodeReviewComment.cpp
@@ -1,0 +1,70 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2016 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+** * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+** disclaimer.
+** * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+** following disclaimer in the documentation and/or other materials provided with the distribution.
+** * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+** derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "CCodeReviewComment.h"
+
+#include "ModelBase/src/model/TreeManager.h"
+
+#include "VisualizationBase/src/items/Item.h"
+#include "VisualizationBase/src/items/ViewItem.h"
+#include "VisualizationBase/src/VisualizationManager.h"
+
+
+#include "../overlays/CodeReviewCommentOverlay.h"
+
+using namespace Visualization;
+
+namespace CodeReview {
+
+CCodeReviewComment::CCodeReviewComment() : Command{"comment"} {}
+
+bool CCodeReviewComment::canInterpret(Visualization::Item*, Visualization::Item*,
+		const QStringList&, const std::unique_ptr<Visualization::Cursor>& )
+{
+	return true;
+}
+
+Interaction::CommandResult* CCodeReviewComment::execute(Visualization::Item*, Visualization::Item*,
+				const QStringList&, const std::unique_ptr<Visualization::Cursor>& cursor)
+{
+	auto cursorOwner = cursor->owner();
+	auto overlay = new CodeReviewCommentOverlay{cursorOwner};
+	cursorOwner->addOverlay(overlay, "CodeReviewComment");
+
+	return new Interaction::CommandResult{};
+}
+
+QList<Interaction::CommandSuggestion*> CCodeReviewComment::suggest(Visualization::Item*, Visualization::Item*,
+		const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>&)
+{
+	if (name().startsWith(textSoFar))
+	{
+		return {new Interaction::CommandSuggestion{name()}};
+	}
+	return {};
+}
+
+}

--- a/CodeReview/src/commands/CCodeReviewComment.h
+++ b/CodeReview/src/commands/CCodeReviewComment.h
@@ -1,0 +1,49 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2016 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+** * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+** disclaimer.
+** * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+** following disclaimer in the documentation and/or other materials provided with the distribution.
+** * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+** derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../codereview_api.h"
+
+#include "InteractionBase/src/commands/CommandWithFlags.h"
+
+namespace CodeReview {
+
+class CODEREVIEW_API CCodeReviewComment : public Interaction::Command
+{
+	public:
+		CCodeReviewComment();
+		virtual bool canInterpret(Visualization::Item* source, Visualization::Item* target,
+				const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& cursor) override;
+		virtual Interaction::CommandResult* execute(Visualization::Item* source, Visualization::Item* target,
+				const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& cursor) override;
+
+		virtual QList<Interaction::CommandSuggestion*> suggest(Visualization::Item* source, Visualization::Item* target,
+				const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>& cursor) override;
+
+};
+
+}

--- a/CodeReview/src/handlers/HReviewableItem.cpp
+++ b/CodeReview/src/handlers/HReviewableItem.cpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -24,33 +24,22 @@
  **
  **********************************************************************************************************************/
 
-#ifndef PRECOMPILED_CODEREVIEW_H_
-#define PRECOMPILED_CODEREVIEW_H_
+#include "HReviewableItem.h"
 
-// TODO: Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
-// those headers will be included here
-#include "VersionControlUI/src/precompiled.h"
-#include "InteractionBase/src/precompiled.h"
-#include "OOVisualization/src/precompiled.h"
-#include "OOInteraction/src/precompiled.h"
-#include "VisualizationBase/src/precompiled.h"
-#include "OOModel/src/precompiled.h"
-#include "ModelBase/src/precompiled.h"
-#include "Logger/src/precompiled.h"
-#include "SelfTest/src/precompiled.h"
-#include "Core/src/precompiled.h"
-#include "Core/src/global.h"
+#include "../commands/CCodeReviewComment.h"
 
 
-// Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
-// and will be included in their precompiled headers
+namespace CodeReview {
 
+HReviewableItem::HReviewableItem()
+{
+	addCommand(new CCodeReviewComment{});
+}
 
-#if defined(CodeReview_EXPORTS)
-// Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
-// plug-ins which depend on this one will not include these headers.
+HReviewableItem* HReviewableItem::instance()
+{
+	static HReviewableItem h;
+	return &h;
+}
 
-
-#endif
-
-#endif /* PRECOMPILED_CODEREVIEW_H_ */
+}

--- a/CodeReview/src/handlers/HReviewableItem.h
+++ b/CodeReview/src/handlers/HReviewableItem.h
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -24,33 +24,20 @@
  **
  **********************************************************************************************************************/
 
-#ifndef PRECOMPILED_CODEREVIEW_H_
-#define PRECOMPILED_CODEREVIEW_H_
+#pragma once
 
-// TODO: Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
-// those headers will be included here
-#include "VersionControlUI/src/precompiled.h"
-#include "InteractionBase/src/precompiled.h"
-#include "OOVisualization/src/precompiled.h"
-#include "OOInteraction/src/precompiled.h"
-#include "VisualizationBase/src/precompiled.h"
-#include "OOModel/src/precompiled.h"
-#include "ModelBase/src/precompiled.h"
-#include "Logger/src/precompiled.h"
-#include "SelfTest/src/precompiled.h"
-#include "Core/src/precompiled.h"
-#include "Core/src/global.h"
+#include "../codereview_api.h"
 
+#include "InteractionBase/src/handlers/GenericHandler.h"
 
-// Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
-// and will be included in their precompiled headers
+namespace CodeReview {
 
+class CODEREVIEW_API HReviewableItem : public Interaction::GenericHandler {
+	protected:
+		HReviewableItem();
 
-#if defined(CodeReview_EXPORTS)
-// Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
-// plug-ins which depend on this one will not include these headers.
+	public:
+		static HReviewableItem* instance();
+};
 
-
-#endif
-
-#endif /* PRECOMPILED_CODEREVIEW_H_ */
+}

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -43,6 +43,10 @@ CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associat
 	Super{{associatedItem}, style}
 {
 	setAcceptedMouseButtons(Qt::AllButtons);
+	// TODO what happens now in initializeForms() because of the item() function which takes commentInput_ as item storage?
+	// Does it not initialize the item if it is already initialized?
+	commentInput_ = new Visualization::Text{this, ""};
+	commentInput_->setEditable(true);
 }
 
 void CodeReviewCommentOverlay::determineChildren()
@@ -53,8 +57,6 @@ void CodeReviewCommentOverlay::determineChildren()
 	qreal scale = 1.0/factor;
 	setScale(scale);
 
-	// TODO where should this be done (constructor to early?)
-	commentInput_->setEditable(true);
 }
 
 void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableHeight)

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -1,0 +1,72 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "CodeReviewCommentOverlay.h"
+
+#include "VisualizationBase/src/declarative/GridLayoutFormElement.h"
+
+#include "VisualizationBase/src/declarative/DeclarativeItem.hpp"
+
+#include "VisualizationBase/src/items/Item.h"
+
+#include "VisualizationBase/src/VisualizationManager.h"
+
+namespace CodeReview
+{
+
+DEFINE_ITEM_COMMON(CodeReviewCommentOverlay, "item")
+
+CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associatedItem, const StyleType* style) :
+	Super{{associatedItem}, style}
+{
+	setAcceptedMouseButtons(Qt::AllButtons);
+}
+
+void CodeReviewCommentOverlay::determineChildren()
+{
+	Super::determineChildren();
+
+	qreal factor = Visualization::VisualizationManager::instance().mainScene()->mainViewScalingFactor();
+	qreal scale = 1.0/factor;
+	setScale(scale);
+
+	// TODO where should this be done (constructor to early?)
+	commentInput_->setEditable(true);
+}
+
+void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableHeight)
+{
+	Super::updateGeometry(availableWidth, availableHeight);
+	setPos(associatedItem()->scenePos());
+}
+
+void CodeReviewCommentOverlay::initializeForms()
+{
+	addForm(item<Visualization::Text>(&I::commentInput_,  &StyleType::commentInput));
+
+}
+
+}

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -43,6 +43,8 @@ CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associat
 	Super{{associatedItem}, style}
 {
 	setAcceptedMouseButtons(Qt::AllButtons);
+	setFlag(QGraphicsItem::ItemIgnoresTransformations);
+
 	// TODO what happens now in initializeForms() because of the item() function which takes commentInput_ as item storage?
 	// Does it not initialize the item if it is already initialized?
 	commentInput_ = new Visualization::Text{this, ""};
@@ -52,11 +54,6 @@ CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associat
 void CodeReviewCommentOverlay::determineChildren()
 {
 	Super::determineChildren();
-
-	qreal factor = Visualization::VisualizationManager::instance().mainScene()->mainViewScalingFactor();
-	qreal scale = 1.0/factor;
-	setScale(scale);
-
 }
 
 void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableHeight)

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -45,15 +45,8 @@ CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associat
 	setAcceptedMouseButtons(Qt::AllButtons);
 	setFlag(QGraphicsItem::ItemIgnoresTransformations);
 
-	// TODO what happens now in initializeForms() because of the item() function which takes commentInput_ as item storage?
-	// Does it not initialize the item if it is already initialized?
 	commentInput_ = new Visualization::Text{this, ""};
 	commentInput_->setEditable(true);
-}
-
-void CodeReviewCommentOverlay::determineChildren()
-{
-	Super::determineChildren();
 }
 
 void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableHeight)

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.h
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.h
@@ -48,7 +48,6 @@ class CODEREVIEW_API CodeReviewCommentOverlay :
 		static void initializeForms();
 
 	protected:
-		virtual void determineChildren() override;
 		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.h
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.h
@@ -1,0 +1,59 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../codereview_api.h"
+
+#include "VisualizationBase/src/items/Text.h"
+#include "VisualizationBase/src/overlays/Overlay.h"
+#include "VisualizationBase/src/declarative/DeclarativeItem.h"
+
+#include "CodeReviewCommentOverlayStyle.h"
+
+namespace CodeReview
+{
+
+class CODEREVIEW_API CodeReviewCommentOverlay :
+		public Super<Visualization::Overlay<Visualization::DeclarativeItem<CodeReviewCommentOverlay>>>
+{
+	ITEM_COMMON(CodeReviewCommentOverlay)
+
+	public:
+		CodeReviewCommentOverlay(Item* associatedItem, const StyleType* style = itemStyles().get());
+
+		static void initializeForms();
+
+	protected:
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
+
+	private:
+		Visualization::Text* commentInput_{};
+
+};
+
+}

--- a/CodeReview/src/overlays/CodeReviewCommentOverlayStyle.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlayStyle.cpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -24,33 +24,11 @@
  **
  **********************************************************************************************************************/
 
-#ifndef PRECOMPILED_CODEREVIEW_H_
-#define PRECOMPILED_CODEREVIEW_H_
+#include "CodeReviewCommentOverlayStyle.h"
 
-// TODO: Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
-// those headers will be included here
-#include "VersionControlUI/src/precompiled.h"
-#include "InteractionBase/src/precompiled.h"
-#include "OOVisualization/src/precompiled.h"
-#include "OOInteraction/src/precompiled.h"
-#include "VisualizationBase/src/precompiled.h"
-#include "OOModel/src/precompiled.h"
-#include "ModelBase/src/precompiled.h"
-#include "Logger/src/precompiled.h"
-#include "SelfTest/src/precompiled.h"
-#include "Core/src/precompiled.h"
-#include "Core/src/global.h"
+namespace CodeReview
+{
 
+CodeReviewCommentOverlayStyle::~CodeReviewCommentOverlayStyle(){}
 
-// Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
-// and will be included in their precompiled headers
-
-
-#if defined(CodeReview_EXPORTS)
-// Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
-// plug-ins which depend on this one will not include these headers.
-
-
-#endif
-
-#endif /* PRECOMPILED_CODEREVIEW_H_ */
+}

--- a/CodeReview/src/overlays/CodeReviewCommentOverlayStyle.h
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlayStyle.h
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -24,33 +24,23 @@
  **
  **********************************************************************************************************************/
 
-#ifndef PRECOMPILED_CODEREVIEW_H_
-#define PRECOMPILED_CODEREVIEW_H_
+#pragma once
 
-// TODO: Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
-// those headers will be included here
-#include "VersionControlUI/src/precompiled.h"
-#include "InteractionBase/src/precompiled.h"
-#include "OOVisualization/src/precompiled.h"
-#include "OOInteraction/src/precompiled.h"
-#include "VisualizationBase/src/precompiled.h"
-#include "OOModel/src/precompiled.h"
-#include "ModelBase/src/precompiled.h"
-#include "Logger/src/precompiled.h"
-#include "SelfTest/src/precompiled.h"
-#include "Core/src/precompiled.h"
-#include "Core/src/global.h"
+#include "../codereview_api.h"
+
+#include "VisualizationBase/src/declarative/DeclarativeItemBaseStyle.h"
+#include "VisualizationBase/src/items/TextStyle.h"
 
 
-// Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
-// and will be included in their precompiled headers
+namespace CodeReview
+{
 
+class CODEREVIEW_API CodeReviewCommentOverlayStyle : public Super<Visualization::DeclarativeItemBaseStyle>
+{
+	public:
+		virtual ~CodeReviewCommentOverlayStyle() override;
 
-#if defined(CodeReview_EXPORTS)
-// Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
-// plug-ins which depend on this one will not include these headers.
+		Property<Visualization::TextStyle> commentInput{this, "commentInput"};
 
-
-#endif
-
-#endif /* PRECOMPILED_CODEREVIEW_H_ */
+};
+}

--- a/CodeReview/styles/item/CodeReviewCommentOverlay/default
+++ b/CodeReview/styles/item/CodeReviewCommentOverlay/default
@@ -1,0 +1,12 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+	<shape prototypes="shape/Box/default">
+		Box
+		<cornerRadius>2</cornerRadius>
+		<backgroundBrush>
+			<style>1</style>
+			<color>#ffffff</color>
+		</backgroundBrush>
+	</shape>
+	<commentInput prototypes="item/Text/default" />
+</style>

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -71,7 +71,7 @@ DiffManager::DiffManager(QString oldVersion, QString newVersion, QString project
 
 DiffSetup DiffManager::initializeDiffPrerequisites()
 {
-	DiffSetup diffSetup{};
+
 
 	QString projectsDir = "projects/" + project_;
 
@@ -79,6 +79,7 @@ DiffSetup DiffManager::initializeDiffPrerequisites()
 	if (!FilePersistence::GitRepository::repositoryExists(projectsDir))
 		throw VersionControlUIException{"Diff setup not possible. No repository found at " + projectsDir};
 
+	DiffSetup diffSetup{};
 	diffSetup.repository_ = new FilePersistence::GitRepository{projectsDir};;
 
 	// load newer version

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -342,6 +342,12 @@ Visualization::Item* DiffManager::addHighlightAndReturnItem(Model::Node* node, V
 					Visualization::HighlightOverlay::itemStyles().get(highlightOverlayStyle)};
 			resultItem->addOverlay(overlay, highlightOverlayName);
 		}
+		else if (auto parent = DCast<Model::CompositeNode>(node->parent()))
+		{
+			auto index = parent->indexOf(node);
+			if (!parent->meta().attribute(index).name().startsWith("_"))
+				return addHighlightAndReturnItem(node->parent(), viewItem, highlightOverlayName, highlightOverlayStyle);
+		}
 	}
 	return resultItem;
 }

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -71,8 +71,6 @@ DiffManager::DiffManager(QString oldVersion, QString newVersion, QString project
 
 DiffSetup DiffManager::initializeDiffPrerequisites()
 {
-
-
 	QString projectsDir = "projects/" + project_;
 
 	// get GitRepository
@@ -91,7 +89,6 @@ DiffSetup DiffManager::initializeDiffPrerequisites()
 	Model::Reference::resolvePending();
 
 	return diffSetup;
-
 }
 
 void DiffManager::computeChangeNodesAndNodesToVisualize(FilePersistence::IdToChangeDescriptionHash changes,

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -32,6 +32,7 @@
 #include "ModelBase/src/util/SymbolMatcher.h"
 
 #include "FilePersistence/src/version_control/ChangeDescription.h"
+#include "FilePersistence/src/version_control/Diff.h"
 
 
 namespace FilePersistence
@@ -48,6 +49,8 @@ namespace Visualization
 namespace VersionControlUI {
 
 struct ChangeWithNodes;
+struct DiffSetup;
+class DiffComparisonPair;
 
 class VERSIONCONTROLUI_API DiffManager
 {
@@ -56,6 +59,16 @@ class VERSIONCONTROLUI_API DiffManager
 		void visualize();
 
 	private:
+
+		DiffSetup initializeDiffPrerequisites();
+
+		/**
+		 * Inserts for entries of \a changes a ChangeWithNodes in \a changesWithNodes. Computes id of nodes which
+		 * should be visualized and inserts them in \a changedNodesToVisualize.
+		 */
+		void computeChangeNodesAndNodesToVisualize(FilePersistence::IdToChangeDescriptionHash changes,
+								QList<ChangeWithNodes>& changesWithNodes, QSet<Model::NodeIdType>& changedNodesToVisualize,
+																 DiffSetup& diffSetup);
 
 		/**
 		 * Deletes all nodes in \a container if their direct parent is also in \a container and has the same change type.
@@ -80,17 +93,15 @@ class VERSIONCONTROLUI_API DiffManager
 		static void createOverlaysForChanges(Visualization::ViewItem* diffViewItem, QList<ChangeWithNodes> changesWithNodes);
 
 		/**
-		 * Inserts the nodes with id from \a changedNodesToVisualize into the \a diffViewItem.
-		 * If a node isn't available in \a oldVersionManager or \a newVersionManager, it will add instead a text which
-		 * informs about this fact.
+		 * Returns a list of DiffComparisonPair created from the ids from \a diffComparisonPairNodeIds.
 		 */
-		void visualizeChangedNodes(Model::TreeManager* oldVersionManager, QSet<Model::NodeIdType> changedNodesToVisualize,
-											Model::TreeManager* newVersionManager, Visualization::ViewItem* diffViewItem);
+		QList<DiffComparisonPair*> createDiffComparisonPairs(DiffSetup& diffSetup,
+																			 QSet<Model::NodeIdType> diffComparisonPairNodeIds);
 
 		/**
 		 * Creates a TreeManager from \a version using \a repository.
 		 */
-		Model::TreeManager* createTreeManagerFromVersion(FilePersistence::GitRepository& repository, QString version);
+		Model::TreeManager* createTreeManagerFromVersion(FilePersistence::GitRepository* repository, QString version);
 
 		/**
 		 * Returns all items which have any of their parents present in \a items.
@@ -105,7 +116,6 @@ class VERSIONCONTROLUI_API DiffManager
 		QString newVersion_;
 		QString project_;
 		Model::SymbolMatcher contextUnitMatcher_;
-
 
 };
 


### PR DESCRIPTION
- Add (very) basic functionality to comment on selected nodes in DiffView  
- Refactoring of DiffManager to split visualization from other computations
- Search for parent visualization if nothing found (Ignores attributes with name starting with "_")
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62679307%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62679475%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62680805%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62680999%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62681470%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23issuecomment-218176816%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23issuecomment-218392419%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62854523%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62854704%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62854833%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62861115%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62861445%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62861871%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23issuecomment-218490109%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23issuecomment-218495464%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23issuecomment-218176816%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Alright%2C%20that%27s%20all.%20I%20am%20just%20wondering%2C%20why%20did%20you%20need%20to%20do%20the%20second%20commit%3F%22%2C%20%22created_at%22%3A%20%222016-05-10T14%3A35%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%20The%20second%20commit%20is%20not%20needed%20yet.%20I%20wanted%20to%20make%20it%20easier%20to%20get%20information%20about%20the%20Diff%20from%20%60DiffManager%60%20if%20needed%2C%20having%20the%20Code%20Review%20plugin%20in%20mind.%20Updated%22%2C%20%22created_at%22%3A%20%222016-05-11T08%3A16%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Updated%22%2C%20%22created_at%22%3A%20%222016-05-11T15%3A12%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-05-11T15%3A29%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c0f6aeb785b686d0f83a3f154183e6a205f9d32a%20CodeReview/src/overlays/CodeReviewCommentOverlay.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62854523%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20%60initializeForms%60%20just%20describes%20what%20an%20%5C%22update%5C%22%20to%20the%20item%20would%20look%20like%2C%20but%20since%20you%27re%20not%20really%20doing%20anything%20special%20to%20it%2C%20%60commentInput_%60%20will%20be%20basically%20left%20alone%20%3A%29%5Cr%5Cn%5Cr%5CnPlease%20remove%20this%20TODO.%22%2C%20%22created_at%22%3A%20%222016-05-11T14%3A09%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20I%20see%20thanks.%22%2C%20%22created_at%22%3A%20%222016-05-11T14%3A43%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/overlays/CodeReviewCommentOverlay.cpp%3AL43-53%22%7D%2C%20%22Pull%2029b386743241b4fec253e37a566f8898f3edd60a%20CodeReview/src/commands/CCodeReviewComment.cpp%2064%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62679475%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22no%20need%20for%20%60%7B%7D%60%22%2C%20%22created_at%22%3A%20%222016-05-10T14%3A18%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CCodeReviewComment.cpp%3AL1-71%22%7D%2C%20%22Pull%2029b386743241b4fec253e37a566f8898f3edd60a%20CodeReview/src/overlays/CodeReviewCommentOverlay.cpp%2057%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62680999%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20could%20do%20it%20in%20the%20constructor%2C%20but%20in%20that%20case%20you%20would%20have%20to%20already%20create%20the%20Text%20item%20already%20there%2C%20which%20is%20fine%20and%20preferable%2C%20since%20that%20item%20won%27t%20change%20and%20you%20don%27t%20need%20to%20make%20it%20editable%20on%20every%20update%20cycle.%22%2C%20%22created_at%22%3A%20%222016-05-10T14%3A26%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/overlays/CodeReviewCommentOverlay.cpp%3AL1-73%22%7D%2C%20%22Pull%20cf200de4619d91a9ef8448f61e1814c33c0e42ca%20VersionControlUI/src/DiffManager.cpp%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62681470%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Always%20do%20things%20as%20late%20as%20possible.%20So%20just%20before%20you%20use%20%60diffSetup%60%20for%20the%20first%20time.%22%2C%20%22created_at%22%3A%20%222016-05-10T14%3A28%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL53-147%22%7D%2C%20%22Pull%2029b386743241b4fec253e37a566f8898f3edd60a%20CodeReview/src/overlays/CodeReviewCommentOverlay.cpp%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62680805%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20instead%20of%20doing%20this%2C%20try%20setting%20the%20%60ItemIgnoresTransformations%60%20flag%20and%20see%20if%20that%20works%20for%20you.%22%2C%20%22created_at%22%3A%20%222016-05-10T14%3A25%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/overlays/CodeReviewCommentOverlay.cpp%3AL1-73%22%7D%2C%20%22Pull%2029b386743241b4fec253e37a566f8898f3edd60a%20CodeReview/src/commands/CCodeReviewComment.cpp%2047%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62679307%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20shouldn%27t%20be%20always%20true.%20You%20should%20first%20at%20least%20check%20if%20the%20name%20of%20the%20command%20matches.%22%2C%20%22created_at%22%3A%20%222016-05-10T14%3A17%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CCodeReviewComment.cpp%3AL1-71%22%7D%2C%20%22Pull%20c0f6aeb785b686d0f83a3f154183e6a205f9d32a%20CodeReview/src/overlays/CodeReviewCommentOverlay.cpp%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62854704%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Don%27t%20use%20%5C%22%5C%22%20for%20the%20style%2C%20provide%20the%20proper%20style%20directly.%22%2C%20%22created_at%22%3A%20%222016-05-11T14%3A10%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20the%20argument%20for%20the%20text%2C%20not%20style.%20Will%20the%20style%20be%20set%20correctly%20from%20initializeForms%3F%20Or%20would%20I%20need%20to%20do%20this%20here%3F%22%2C%20%22created_at%22%3A%20%222016-05-11T14%3A45%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20never%20mind%20then%2C%20the%20style%20will%20be%20set%20correctly.%22%2C%20%22created_at%22%3A%20%222016-05-11T14%3A47%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/overlays/CodeReviewCommentOverlay.cpp%3AL43-53%22%7D%2C%20%22Pull%20df8701b04d9119cf18d40818be40d0c3db3a67fc%20CodeReview/src/overlays/CodeReviewCommentOverlay.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/377%23discussion_r62854833%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20this%20works%20as%20you%20expected%20and%20you%20no%20longer%20need%20specialized%20behavior%20in%20%60determineChildren%60%20please%20remove%20that%20method.%22%2C%20%22created_at%22%3A%20%222016-05-11T14%3A11%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/overlays/CodeReviewCommentOverlay.cpp%3AL43-51%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 29b386743241b4fec253e37a566f8898f3edd60a CodeReview/src/commands/CCodeReviewComment.cpp 47'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/377#discussion_r62679307'>File: CodeReview/src/commands/CCodeReviewComment.cpp:L1-71</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This shouldn't be always true. You should first at least check if the name of the command matches.
- [ ] <a href='#crh-comment-Pull 29b386743241b4fec253e37a566f8898f3edd60a CodeReview/src/commands/CCodeReviewComment.cpp 64'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/377#discussion_r62679475'>File: CodeReview/src/commands/CCodeReviewComment.cpp:L1-71</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> no need for `{}`
- [ ] <a href='#crh-comment-Pull 29b386743241b4fec253e37a566f8898f3edd60a CodeReview/src/overlays/CodeReviewCommentOverlay.cpp 52'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/377#discussion_r62680805'>File: CodeReview/src/overlays/CodeReviewCommentOverlay.cpp:L1-73</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, instead of doing this, try setting the `ItemIgnoresTransformations` flag and see if that works for you.
- [ ] <a href='#crh-comment-Pull 29b386743241b4fec253e37a566f8898f3edd60a CodeReview/src/overlays/CodeReviewCommentOverlay.cpp 57'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/377#discussion_r62680999'>File: CodeReview/src/overlays/CodeReviewCommentOverlay.cpp:L1-73</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You could do it in the constructor, but in that case you would have to already create the Text item already there, which is fine and preferable, since that item won't change and you don't need to make it editable on every update cycle.
- [ ] <a href='#crh-comment-Pull cf200de4619d91a9ef8448f61e1814c33c0e42ca VersionControlUI/src/DiffManager.cpp 26'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/377#discussion_r62681470'>File: VersionControlUI/src/DiffManager.cpp:L53-147</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Always do things as late as possible. So just before you use `diffSetup` for the first time.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/377#issuecomment-218176816'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Alright, that's all. I am just wondering, why did you need to do the second commit?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Thanks. The second commit is not needed yet. I wanted to make it easier to get information about the Diff from `DiffManager` if needed, having the Code Review plugin in mind. Updated
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Updated
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks :)
- [ ] <a href='#crh-comment-Pull c0f6aeb785b686d0f83a3f154183e6a205f9d32a CodeReview/src/overlays/CodeReviewCommentOverlay.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/377#discussion_r62854523'>File: CodeReview/src/overlays/CodeReviewCommentOverlay.cpp:L43-53</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> The `initializeForms` just describes what an "update" to the item would look like, but since you're not really doing anything special to it, `commentInput_` will be basically left alone :)
  Please remove this TODO.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> OK, I see thanks.
- [ ] <a href='#crh-comment-Pull c0f6aeb785b686d0f83a3f154183e6a205f9d32a CodeReview/src/overlays/CodeReviewCommentOverlay.cpp 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/377#discussion_r62854704'>File: CodeReview/src/overlays/CodeReviewCommentOverlay.cpp:L43-53</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Don't use "" for the style, provide the proper style directly.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> This is the argument for the text, not style. Will the style be set correctly from initializeForms? Or would I need to do this here?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Ah never mind then, the style will be set correctly.
- [ ] <a href='#crh-comment-Pull df8701b04d9119cf18d40818be40d0c3db3a67fc CodeReview/src/overlays/CodeReviewCommentOverlay.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/377#discussion_r62854833'>File: CodeReview/src/overlays/CodeReviewCommentOverlay.cpp:L43-51</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> If this works as you expected and you no longer need specialized behavior in `determineChildren` please remove that method.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/377?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/377?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/377'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
