### PR TITLE
Generalized code for loadNodedata

### DIFF
--- a/CodeReview/CMakeLists.txt
+++ b/CodeReview/CMakeLists.txt
@@ -8,8 +8,18 @@ add_library(CodeReview SHARED
 	src/CodeReviewException.h
 	src/codereview_api.h
 	src/CodeReviewPlugin.h
+	src/CodeReviewManager.h
+	src/commands/CCodeReviewComment.h
+	src/overlays/CodeReviewCommentOverlay.h
+	src/overlays/CodeReviewCommentOverlayStyle.h
+	src/handlers/HReviewableItem.h
 	src/CodeReviewException.cpp
 	src/CodeReviewPlugin.cpp
+	src/CodeReviewManager.cpp
+	src/commands/CCodeReviewComment.cpp
+	src/overlays/CodeReviewCommentOverlay.cpp
+	src/overlays/CodeReviewCommentOverlayStyle.cpp
+	src/handlers/HReviewableItem.cpp
 	test/SimpleTest.cpp
 )
-envision_plugin(CodeReview OOInteraction)
+envision_plugin(CodeReview OOInteraction VersionControlUI)

--- a/CodeReview/codereview.plugin
+++ b/CodeReview/codereview.plugin
@@ -4,5 +4,6 @@
 		<dependency pluginid="logger" version="0" />
 		<dependency pluginid="selftest" version="0" />
 		<dependency pluginid="oointeraction" version="1" />
+		<dependency pluginid="versioncontrolui" version="1" />
 	</dependencies>
 </plugin>

--- a/CodeReview/src/CodeReviewManager.cpp
+++ b/CodeReview/src/CodeReviewManager.cpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -23,34 +23,3 @@
  ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **
  **********************************************************************************************************************/
-
-#ifndef PRECOMPILED_CODEREVIEW_H_
-#define PRECOMPILED_CODEREVIEW_H_
-
-// TODO: Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
-// those headers will be included here
-#include "VersionControlUI/src/precompiled.h"
-#include "InteractionBase/src/precompiled.h"
-#include "OOVisualization/src/precompiled.h"
-#include "OOInteraction/src/precompiled.h"
-#include "VisualizationBase/src/precompiled.h"
-#include "OOModel/src/precompiled.h"
-#include "ModelBase/src/precompiled.h"
-#include "Logger/src/precompiled.h"
-#include "SelfTest/src/precompiled.h"
-#include "Core/src/precompiled.h"
-#include "Core/src/global.h"
-
-
-// Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
-// and will be included in their precompiled headers
-
-
-#if defined(CodeReview_EXPORTS)
-// Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
-// plug-ins which depend on this one will not include these headers.
-
-
-#endif
-
-#endif /* PRECOMPILED_CODEREVIEW_H_ */

--- a/CodeReview/src/CodeReviewManager.h
+++ b/CodeReview/src/CodeReviewManager.h
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -23,34 +23,3 @@
  ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **
  **********************************************************************************************************************/
-
-#ifndef PRECOMPILED_CODEREVIEW_H_
-#define PRECOMPILED_CODEREVIEW_H_
-
-// TODO: Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
-// those headers will be included here
-#include "VersionControlUI/src/precompiled.h"
-#include "InteractionBase/src/precompiled.h"
-#include "OOVisualization/src/precompiled.h"
-#include "OOInteraction/src/precompiled.h"
-#include "VisualizationBase/src/precompiled.h"
-#include "OOModel/src/precompiled.h"
-#include "ModelBase/src/precompiled.h"
-#include "Logger/src/precompiled.h"
-#include "SelfTest/src/precompiled.h"
-#include "Core/src/precompiled.h"
-#include "Core/src/global.h"
-
-
-// Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
-// and will be included in their precompiled headers
-
-
-#if defined(CodeReview_EXPORTS)
-// Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
-// plug-ins which depend on this one will not include these headers.
-
-
-#endif
-
-#endif /* PRECOMPILED_CODEREVIEW_H_ */

--- a/CodeReview/src/CodeReviewPlugin.cpp
+++ b/CodeReview/src/CodeReviewPlugin.cpp
@@ -24,9 +24,13 @@
  **
  **********************************************************************************************************************/
 
+#include "handlers/HReviewableItem.h"
+
 #include "CodeReviewPlugin.h"
 #include "SelfTest/src/TestManager.h"
 #include "Logger/src/Log.h"
+
+#include "VersionControlUI/src/items/VDiffComparisonPair.h"
 
 namespace CodeReview {
 
@@ -38,6 +42,7 @@ Logger::Log& CodeReviewPlugin::log()
 
 bool CodeReviewPlugin::initialize(Core::EnvisionManager&)
 {
+	VersionControlUI::VDiffComparisonPair::setDefaultClassHandler(HReviewableItem::instance());
 	return true;
 }
 

--- a/CodeReview/src/commands/CCodeReviewComment.cpp
+++ b/CodeReview/src/commands/CCodeReviewComment.cpp
@@ -63,9 +63,7 @@ QList<Interaction::CommandSuggestion*> CCodeReviewComment::suggest(Visualization
 		const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>&)
 {
 	if (name().startsWith(textSoFar))
-	{
 		return {new Interaction::CommandSuggestion{name()}};
-	}
 	return {};
 }
 

--- a/CodeReview/src/commands/CCodeReviewComment.cpp
+++ b/CodeReview/src/commands/CCodeReviewComment.cpp
@@ -42,9 +42,11 @@ namespace CodeReview {
 CCodeReviewComment::CCodeReviewComment() : Command{"comment"} {}
 
 bool CCodeReviewComment::canInterpret(Visualization::Item*, Visualization::Item*,
-		const QStringList&, const std::unique_ptr<Visualization::Cursor>& )
+		const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& )
 {
-	return true;
+	if (commandTokens.size() > 0)
+		return name() == commandTokens.first();
+	return false;
 }
 
 Interaction::CommandResult* CCodeReviewComment::execute(Visualization::Item*, Visualization::Item*,

--- a/CodeReview/src/commands/CCodeReviewComment.cpp
+++ b/CodeReview/src/commands/CCodeReviewComment.cpp
@@ -1,0 +1,70 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2016 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+** * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+** disclaimer.
+** * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+** following disclaimer in the documentation and/or other materials provided with the distribution.
+** * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+** derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "CCodeReviewComment.h"
+
+#include "ModelBase/src/model/TreeManager.h"
+
+#include "VisualizationBase/src/items/Item.h"
+#include "VisualizationBase/src/items/ViewItem.h"
+#include "VisualizationBase/src/VisualizationManager.h"
+
+
+#include "../overlays/CodeReviewCommentOverlay.h"
+
+using namespace Visualization;
+
+namespace CodeReview {
+
+CCodeReviewComment::CCodeReviewComment() : Command{"comment"} {}
+
+bool CCodeReviewComment::canInterpret(Visualization::Item*, Visualization::Item*,
+		const QStringList&, const std::unique_ptr<Visualization::Cursor>& )
+{
+	return true;
+}
+
+Interaction::CommandResult* CCodeReviewComment::execute(Visualization::Item*, Visualization::Item*,
+				const QStringList&, const std::unique_ptr<Visualization::Cursor>& cursor)
+{
+	auto cursorOwner = cursor->owner();
+	auto overlay = new CodeReviewCommentOverlay{cursorOwner};
+	cursorOwner->addOverlay(overlay, "CodeReviewComment");
+
+	return new Interaction::CommandResult{};
+}
+
+QList<Interaction::CommandSuggestion*> CCodeReviewComment::suggest(Visualization::Item*, Visualization::Item*,
+		const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>&)
+{
+	if (name().startsWith(textSoFar))
+	{
+		return {new Interaction::CommandSuggestion{name()}};
+	}
+	return {};
+}
+
+}

--- a/CodeReview/src/commands/CCodeReviewComment.h
+++ b/CodeReview/src/commands/CCodeReviewComment.h
@@ -1,0 +1,49 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2016 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+** * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+** disclaimer.
+** * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+** following disclaimer in the documentation and/or other materials provided with the distribution.
+** * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+** derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../codereview_api.h"
+
+#include "InteractionBase/src/commands/CommandWithFlags.h"
+
+namespace CodeReview {
+
+class CODEREVIEW_API CCodeReviewComment : public Interaction::Command
+{
+	public:
+		CCodeReviewComment();
+		virtual bool canInterpret(Visualization::Item* source, Visualization::Item* target,
+				const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& cursor) override;
+		virtual Interaction::CommandResult* execute(Visualization::Item* source, Visualization::Item* target,
+				const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& cursor) override;
+
+		virtual QList<Interaction::CommandSuggestion*> suggest(Visualization::Item* source, Visualization::Item* target,
+				const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>& cursor) override;
+
+};
+
+}

--- a/CodeReview/src/handlers/HReviewableItem.cpp
+++ b/CodeReview/src/handlers/HReviewableItem.cpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -24,33 +24,22 @@
  **
  **********************************************************************************************************************/
 
-#ifndef PRECOMPILED_CODEREVIEW_H_
-#define PRECOMPILED_CODEREVIEW_H_
+#include "HReviewableItem.h"
 
-// TODO: Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
-// those headers will be included here
-#include "VersionControlUI/src/precompiled.h"
-#include "InteractionBase/src/precompiled.h"
-#include "OOVisualization/src/precompiled.h"
-#include "OOInteraction/src/precompiled.h"
-#include "VisualizationBase/src/precompiled.h"
-#include "OOModel/src/precompiled.h"
-#include "ModelBase/src/precompiled.h"
-#include "Logger/src/precompiled.h"
-#include "SelfTest/src/precompiled.h"
-#include "Core/src/precompiled.h"
-#include "Core/src/global.h"
+#include "../commands/CCodeReviewComment.h"
 
 
-// Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
-// and will be included in their precompiled headers
+namespace CodeReview {
 
+HReviewableItem::HReviewableItem()
+{
+	addCommand(new CCodeReviewComment{});
+}
 
-#if defined(CodeReview_EXPORTS)
-// Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
-// plug-ins which depend on this one will not include these headers.
+HReviewableItem* HReviewableItem::instance()
+{
+	static HReviewableItem h;
+	return &h;
+}
 
-
-#endif
-
-#endif /* PRECOMPILED_CODEREVIEW_H_ */
+}

--- a/CodeReview/src/handlers/HReviewableItem.h
+++ b/CodeReview/src/handlers/HReviewableItem.h
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -24,33 +24,20 @@
  **
  **********************************************************************************************************************/
 
-#ifndef PRECOMPILED_CODEREVIEW_H_
-#define PRECOMPILED_CODEREVIEW_H_
+#pragma once
 
-// TODO: Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
-// those headers will be included here
-#include "VersionControlUI/src/precompiled.h"
-#include "InteractionBase/src/precompiled.h"
-#include "OOVisualization/src/precompiled.h"
-#include "OOInteraction/src/precompiled.h"
-#include "VisualizationBase/src/precompiled.h"
-#include "OOModel/src/precompiled.h"
-#include "ModelBase/src/precompiled.h"
-#include "Logger/src/precompiled.h"
-#include "SelfTest/src/precompiled.h"
-#include "Core/src/precompiled.h"
-#include "Core/src/global.h"
+#include "../codereview_api.h"
 
+#include "InteractionBase/src/handlers/GenericHandler.h"
 
-// Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
-// and will be included in their precompiled headers
+namespace CodeReview {
 
+class CODEREVIEW_API HReviewableItem : public Interaction::GenericHandler {
+	protected:
+		HReviewableItem();
 
-#if defined(CodeReview_EXPORTS)
-// Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
-// plug-ins which depend on this one will not include these headers.
+	public:
+		static HReviewableItem* instance();
+};
 
-
-#endif
-
-#endif /* PRECOMPILED_CODEREVIEW_H_ */
+}

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -43,6 +43,10 @@ CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associat
 	Super{{associatedItem}, style}
 {
 	setAcceptedMouseButtons(Qt::AllButtons);
+	// TODO what happens now in initializeForms() because of the item() function which takes commentInput_ as item storage?
+	// Does it not initialize the item if it is already initialized?
+	commentInput_ = new Visualization::Text{this, ""};
+	commentInput_->setEditable(true);
 }
 
 void CodeReviewCommentOverlay::determineChildren()
@@ -53,8 +57,6 @@ void CodeReviewCommentOverlay::determineChildren()
 	qreal scale = 1.0/factor;
 	setScale(scale);
 
-	// TODO where should this be done (constructor to early?)
-	commentInput_->setEditable(true);
 }
 
 void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableHeight)

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -1,0 +1,72 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "CodeReviewCommentOverlay.h"
+
+#include "VisualizationBase/src/declarative/GridLayoutFormElement.h"
+
+#include "VisualizationBase/src/declarative/DeclarativeItem.hpp"
+
+#include "VisualizationBase/src/items/Item.h"
+
+#include "VisualizationBase/src/VisualizationManager.h"
+
+namespace CodeReview
+{
+
+DEFINE_ITEM_COMMON(CodeReviewCommentOverlay, "item")
+
+CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associatedItem, const StyleType* style) :
+	Super{{associatedItem}, style}
+{
+	setAcceptedMouseButtons(Qt::AllButtons);
+}
+
+void CodeReviewCommentOverlay::determineChildren()
+{
+	Super::determineChildren();
+
+	qreal factor = Visualization::VisualizationManager::instance().mainScene()->mainViewScalingFactor();
+	qreal scale = 1.0/factor;
+	setScale(scale);
+
+	// TODO where should this be done (constructor to early?)
+	commentInput_->setEditable(true);
+}
+
+void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableHeight)
+{
+	Super::updateGeometry(availableWidth, availableHeight);
+	setPos(associatedItem()->scenePos());
+}
+
+void CodeReviewCommentOverlay::initializeForms()
+{
+	addForm(item<Visualization::Text>(&I::commentInput_,  &StyleType::commentInput));
+
+}
+
+}

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -43,6 +43,8 @@ CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associat
 	Super{{associatedItem}, style}
 {
 	setAcceptedMouseButtons(Qt::AllButtons);
+	setFlag(QGraphicsItem::ItemIgnoresTransformations);
+
 	// TODO what happens now in initializeForms() because of the item() function which takes commentInput_ as item storage?
 	// Does it not initialize the item if it is already initialized?
 	commentInput_ = new Visualization::Text{this, ""};
@@ -52,11 +54,6 @@ CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associat
 void CodeReviewCommentOverlay::determineChildren()
 {
 	Super::determineChildren();
-
-	qreal factor = Visualization::VisualizationManager::instance().mainScene()->mainViewScalingFactor();
-	qreal scale = 1.0/factor;
-	setScale(scale);
-
 }
 
 void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableHeight)

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -45,15 +45,8 @@ CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associat
 	setAcceptedMouseButtons(Qt::AllButtons);
 	setFlag(QGraphicsItem::ItemIgnoresTransformations);
 
-	// TODO what happens now in initializeForms() because of the item() function which takes commentInput_ as item storage?
-	// Does it not initialize the item if it is already initialized?
 	commentInput_ = new Visualization::Text{this, ""};
 	commentInput_->setEditable(true);
-}
-
-void CodeReviewCommentOverlay::determineChildren()
-{
-	Super::determineChildren();
 }
 
 void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableHeight)

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.h
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.h
@@ -48,7 +48,6 @@ class CODEREVIEW_API CodeReviewCommentOverlay :
 		static void initializeForms();
 
 	protected:
-		virtual void determineChildren() override;
 		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.h
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.h
@@ -1,0 +1,59 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2015 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../codereview_api.h"
+
+#include "VisualizationBase/src/items/Text.h"
+#include "VisualizationBase/src/overlays/Overlay.h"
+#include "VisualizationBase/src/declarative/DeclarativeItem.h"
+
+#include "CodeReviewCommentOverlayStyle.h"
+
+namespace CodeReview
+{
+
+class CODEREVIEW_API CodeReviewCommentOverlay :
+		public Super<Visualization::Overlay<Visualization::DeclarativeItem<CodeReviewCommentOverlay>>>
+{
+	ITEM_COMMON(CodeReviewCommentOverlay)
+
+	public:
+		CodeReviewCommentOverlay(Item* associatedItem, const StyleType* style = itemStyles().get());
+
+		static void initializeForms();
+
+	protected:
+		virtual void determineChildren() override;
+		virtual void updateGeometry(int availableWidth, int availableHeight) override;
+
+	private:
+		Visualization::Text* commentInput_{};
+
+};
+
+}

--- a/CodeReview/src/overlays/CodeReviewCommentOverlayStyle.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlayStyle.cpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -24,33 +24,11 @@
  **
  **********************************************************************************************************************/
 
-#ifndef PRECOMPILED_CODEREVIEW_H_
-#define PRECOMPILED_CODEREVIEW_H_
+#include "CodeReviewCommentOverlayStyle.h"
 
-// TODO: Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
-// those headers will be included here
-#include "VersionControlUI/src/precompiled.h"
-#include "InteractionBase/src/precompiled.h"
-#include "OOVisualization/src/precompiled.h"
-#include "OOInteraction/src/precompiled.h"
-#include "VisualizationBase/src/precompiled.h"
-#include "OOModel/src/precompiled.h"
-#include "ModelBase/src/precompiled.h"
-#include "Logger/src/precompiled.h"
-#include "SelfTest/src/precompiled.h"
-#include "Core/src/precompiled.h"
-#include "Core/src/global.h"
+namespace CodeReview
+{
 
+CodeReviewCommentOverlayStyle::~CodeReviewCommentOverlayStyle(){}
 
-// Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
-// and will be included in their precompiled headers
-
-
-#if defined(CodeReview_EXPORTS)
-// Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
-// plug-ins which depend on this one will not include these headers.
-
-
-#endif
-
-#endif /* PRECOMPILED_CODEREVIEW_H_ */
+}

--- a/CodeReview/src/overlays/CodeReviewCommentOverlayStyle.h
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlayStyle.h
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -24,33 +24,23 @@
  **
  **********************************************************************************************************************/
 
-#ifndef PRECOMPILED_CODEREVIEW_H_
-#define PRECOMPILED_CODEREVIEW_H_
+#pragma once
 
-// TODO: Include here the precompiled headers of other plug-ins that this plug-in uses. Only the "public" part of
-// those headers will be included here
-#include "VersionControlUI/src/precompiled.h"
-#include "InteractionBase/src/precompiled.h"
-#include "OOVisualization/src/precompiled.h"
-#include "OOInteraction/src/precompiled.h"
-#include "VisualizationBase/src/precompiled.h"
-#include "OOModel/src/precompiled.h"
-#include "ModelBase/src/precompiled.h"
-#include "Logger/src/precompiled.h"
-#include "SelfTest/src/precompiled.h"
-#include "Core/src/precompiled.h"
-#include "Core/src/global.h"
+#include "../codereview_api.h"
+
+#include "VisualizationBase/src/declarative/DeclarativeItemBaseStyle.h"
+#include "VisualizationBase/src/items/TextStyle.h"
 
 
-// Put here includes which appear in header files. This will also be visible to other plug-in which depend on this one
-// and will be included in their precompiled headers
+namespace CodeReview
+{
 
+class CODEREVIEW_API CodeReviewCommentOverlayStyle : public Super<Visualization::DeclarativeItemBaseStyle>
+{
+	public:
+		virtual ~CodeReviewCommentOverlayStyle() override;
 
-#if defined(CodeReview_EXPORTS)
-// Put here includes which only appear in compilation units and do not appear in headers. Precompiled headers of
-// plug-ins which depend on this one will not include these headers.
+		Property<Visualization::TextStyle> commentInput{this, "commentInput"};
 
-
-#endif
-
-#endif /* PRECOMPILED_CODEREVIEW_H_ */
+};
+}

--- a/CodeReview/styles/item/CodeReviewCommentOverlay/default
+++ b/CodeReview/styles/item/CodeReviewCommentOverlay/default
@@ -1,0 +1,12 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+	<shape prototypes="shape/Box/default">
+		Box
+		<cornerRadius>2</cornerRadius>
+		<backgroundBrush>
+			<style>1</style>
+			<color>#ffffff</color>
+		</backgroundBrush>
+	</shape>
+	<commentInput prototypes="item/Text/default" />
+</style>

--- a/FilePersistence/src/precompiled.h
+++ b/FilePersistence/src/precompiled.h
@@ -54,7 +54,11 @@
 
 #include <iostream>
 #include <git2.h>
+#include <QtCore/QDirIterator>
+#include <QtCore/QFileInfo>
+#include <QtCore/QFile>
 
+#include <a.out.h>
 #endif
 
 #endif /* PRECOMPILED_FILEPERSISTENCE_H_ */

--- a/FilePersistence/src/precompiled.h
+++ b/FilePersistence/src/precompiled.h
@@ -57,7 +57,6 @@
 #include <QtCore/QDirIterator>
 #include <QtCore/QFileInfo>
 #include <QtCore/QFile>
-
 #include <a.out.h>
 #endif
 

--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -153,5 +153,3 @@ QStringList Commit::nodeLinesFromId(Model::NodeIdType id, bool findChildrenByPar
 }
 
 }
-
-

--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -153,3 +153,5 @@ QStringList Commit::nodeLinesFromId(Model::NodeIdType id, bool findChildrenByPar
 }
 
 }
+
+

--- a/FilePersistence/src/version_control/Commit.h
+++ b/FilePersistence/src/version_control/Commit.h
@@ -82,6 +82,7 @@ class FILEPERSISTENCE_API Commit
 		bool getFileContent(QString fileName, const char*& content, int& contentSize, bool exactFileNameMatching) const;
 		bool isValidMatch(QString content, int indexOfId, int& start, int& end, bool findChildrenByParentId) const;
 		QStringList nodeLinesFromId(Model::NodeIdType id, bool findChildrenByParentId = false) const;
+											 bool findChildrenByParentId = 0) const;
 
 
 	private:

--- a/FilePersistence/src/version_control/Commit.h
+++ b/FilePersistence/src/version_control/Commit.h
@@ -81,7 +81,7 @@ class FILEPERSISTENCE_API Commit
 
 		bool getFileContent(QString fileName, const char*& content, int& contentSize, bool exactFileNameMatching) const;
 		bool isValidMatch(QString content, int indexOfId, int& start, int& end, bool findChildrenByParentId) const;
-		QStringList nodeLinesFromId(Model::NodeIdType id, bool findChildrenByParentId = 0) const;
+		QStringList nodeLinesFromId(Model::NodeIdType id, bool findChildrenByParentId = false) const;
 
 
 	private:

--- a/FilePersistence/src/version_control/Commit.h
+++ b/FilePersistence/src/version_control/Commit.h
@@ -82,7 +82,6 @@ class FILEPERSISTENCE_API Commit
 		bool getFileContent(QString fileName, const char*& content, int& contentSize, bool exactFileNameMatching) const;
 		bool isValidMatch(QString content, int indexOfId, int& start, int& end, bool findChildrenByParentId) const;
 		QStringList nodeLinesFromId(Model::NodeIdType id, bool findChildrenByParentId = false) const;
-											 bool findChildrenByParentId = 0) const;
 
 
 	private:

--- a/FilePersistence/src/version_control/Commit.h
+++ b/FilePersistence/src/version_control/Commit.h
@@ -80,6 +80,7 @@ class FILEPERSISTENCE_API Commit
 		void addFile(QString relativePath, qint64 size, std::unique_ptr<char[], CommitFileContentDeleter> content);
 
 		bool getFileContent(QString fileName, const char*& content, int& contentSize, bool exactFileNameMatching) const;
+		bool isValidMatch(QString content, int indexOfId, int& start, int& end, bool findChildrenByParentId) const;
 		QStringList nodeLinesFromId(Model::NodeIdType id, bool findChildrenByParentId = 0) const;
 
 

--- a/FilePersistence/src/version_control/GitPiecewiseLoader.cpp
+++ b/FilePersistence/src/version_control/GitPiecewiseLoader.cpp
@@ -40,72 +40,32 @@ GitPiecewiseLoader::~GitPiecewiseLoader() {}
 
 NodeData GitPiecewiseLoader::loadNodeData(Model::NodeIdType id)
 {
+	if (!commit_)
+		commit_.reset(repo_->getCommit(revision_));
+	auto s = commit_->nodeLinesFromId(id, false);
 
-	bool isWorkDir = (revision_ == GitRepository::WORKDIR);
-
-	if (isWorkDir)
-	{
-		auto regEx = ".*" + id.toString() + " {.*}.*";
-		SystemCommandResult result = runSystemCommand("grep", {"-G", "-r", regEx}, workDir_);
-		Q_ASSERT(result.exitCode() == 0);
-		Q_ASSERT(!result.standardout().isEmpty());
-
-		Q_ASSERT(result.standardout().size() == 1 ||
-					result.standardout().size() == 2);
-
-		for (auto line : result.standardout())
-			if (!isPersistenceUnit(line))
-				return parseGrepLine(line);
-		Q_ASSERT(false);
-	}
-	else
-	{
-		if (!commit_)
-			commit_.reset(repo_->getCommit(revision_));
-		auto s = commit_->nodeLinesFromId(id, false);
-
-		Q_ASSERT(s.size() == 1 || s.size() == 2);
-		for (auto line : s)
-			if (!isPersistenceUnit(line))
-				return parseGrepLine(line);
-		Q_ASSERT(false);
-	}
+	Q_ASSERT(s.size() == 1 || s.size() == 2);
+	for (auto line : s)
+		if (!isPersistenceUnit(line))
+			return parseGrepLine(line);
+	Q_ASSERT(false);
 }
 
 QList<NodeData> GitPiecewiseLoader::loadNodeChildrenData(Model::NodeIdType id)
 {
 	QList<NodeData> children;
-	bool isWorkDir = (revision_ == GitRepository::WORKDIR);
+	if (!commit_)
+		commit_.reset(repo_->getCommit(revision_));
 
-	if (isWorkDir)
-	{
-		auto regEx = "{.*} " + id.toString();
-		SystemCommandResult result = runSystemCommand("grep", {"-G", "-r", regEx}, workDir_);
-		Q_ASSERT(result.exitCode() == 0 || result.exitCode() == 1);
-		Q_ASSERT(result.standarderr().isEmpty());
+	auto s = commit_->nodeLinesFromId(id, true);
+	Q_ASSERT(s.size() == 1);
 
-		for (auto line : result.standardout())
-			if (!isPersistenceUnit(line))
-			{
-				auto nodeData = parseGrepLine(line);
-				children.append(nodeData);
-			}
-	}
-	else
-	{
-		if (!commit_)
-			commit_.reset(repo_->getCommit(revision_));
-
-		auto s = commit_->nodeLinesFromId(id, true);
-		Q_ASSERT(s.size() == 1);
-
-		for (auto line : s)
-			if (!isPersistenceUnit(line))
-			{
-				auto nodeData = parseGrepLine(line);
-				children.append(nodeData);
-			}
-	}
+	for (auto line : s)
+		if (!isPersistenceUnit(line))
+		{
+			auto nodeData = parseGrepLine(line);
+			children.append(nodeData);
+		}
 	return children;
 }
 

--- a/FilePersistence/src/version_control/GitPiecewiseLoader.cpp
+++ b/FilePersistence/src/version_control/GitPiecewiseLoader.cpp
@@ -30,6 +30,7 @@
 #include "../simple/GenericNode.h"
 
 #include "Core/src/global.h"
+
 namespace FilePersistence {
 
 GitPiecewiseLoader::GitPiecewiseLoader(std::shared_ptr<GenericTree>& tree,
@@ -37,6 +38,7 @@ GitPiecewiseLoader::GitPiecewiseLoader(std::shared_ptr<GenericTree>& tree,
 	PiecewiseLoader{tree}, repo_{repo}, revision_{revision}, workDir_{repo->workdirPath()} {}
 
 GitPiecewiseLoader::~GitPiecewiseLoader() {}
+
 
 NodeData GitPiecewiseLoader::loadNodeData(Model::NodeIdType id)
 {

--- a/FilePersistence/src/version_control/GitRepository.cpp
+++ b/FilePersistence/src/version_control/GitRepository.cpp
@@ -320,28 +320,50 @@ const Commit* GitRepository::getCommit(QString revision) const
 {
 	Q_ASSERT(revision != WORKDIR);
 	Q_ASSERT(revision != INDEX);
+	if (revision == WORKDIR)
+	{
+		auto m = new Commit();
+		QDirIterator DirIter(workdirPath(), QDirIterator::Subdirectories);
+		while (DirIter.hasNext())
+		{
+			DirIter.next();
+			if (DirIter.fileInfo().isFile())
+			{
+				QFile file(DirIter.filePath());	// projects/Testproject
+				if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) continue;
+				QByteArray text = file.readAll();
+				char *content = new char[text.size() + 1];
+				strcpy(content, text.data());
+				std::unique_ptr<char[]> content_ptr{content};
+				m->addFile(DirIter.filePath(), file.size(), std::move(content_ptr));
+			}
+		}
+		return m;
+	}
+	else
+	{
+		int errorCode = 0;
 
-	int errorCode = 0;
+		git_commit* gitCommit = parseCommit(revision);
+		git_tree* tree = nullptr;
+		errorCode = git_commit_tree(&tree, gitCommit);
+		checkError(errorCode);
 
-	git_commit* gitCommit = parseCommit(revision);
-	git_tree* tree = nullptr;
-	errorCode = git_commit_tree(&tree, gitCommit);
-	checkError(errorCode);
+		GitCommitExtract treeWalkData;
+		treeWalkData.repository_ = repository_;
+		treeWalkData.commit_ = new Commit{};
 
-	GitCommitExtract treeWalkData;
-	treeWalkData.repository_ = repository_;
-	treeWalkData.commit_ = new Commit{};
+		CommitMetaData info = getCommitInformation(revision);
+		treeWalkData.commit_->setMetaData(info);
 
-	CommitMetaData info = getCommitInformation(revision);
-	treeWalkData.commit_->setMetaData(info);
+		errorCode = git_tree_walk(tree, GIT_TREEWALK_PRE, treeWalkCommitExtractCallBack, &treeWalkData);
+		checkError(errorCode);
 
-	errorCode = git_tree_walk(tree, GIT_TREEWALK_PRE, treeWalkCommitExtractCallBack, &treeWalkData);
-	checkError(errorCode);
+		git_commit_free(gitCommit);
+		git_tree_free(tree);
 
-	git_commit_free(gitCommit);
-	git_tree_free(tree);
-
-	return treeWalkData.commit_;
+		return treeWalkData.commit_;
+	}
 }
 
 const CommitFile* GitRepository::getCommitFile(QString revision, QString relativePath) const

--- a/FilePersistence/src/version_control/GitRepository.cpp
+++ b/FilePersistence/src/version_control/GitRepository.cpp
@@ -328,7 +328,7 @@ const Commit* GitRepository::getCommit(QString revision) const
 			DirIter.next();
 			if (DirIter.fileInfo().isFile())
 			{
-				QFile file(DirIter.filePath());
+				QFile file(DirIter.filePath());	// projects/Testproject
 				if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) continue;
 				QByteArray text = file.readAll();
 				char *content = new char[text.size() + 1];

--- a/FilePersistence/src/version_control/GitRepository.cpp
+++ b/FilePersistence/src/version_control/GitRepository.cpp
@@ -318,7 +318,6 @@ CommitGraph GitRepository::commitGraph(QString startRevision, QString endRevisio
 
 const Commit* GitRepository::getCommit(QString revision) const
 {
-	Q_ASSERT(revision != WORKDIR);
 	Q_ASSERT(revision != INDEX);
 	if (revision == WORKDIR)
 	{
@@ -329,11 +328,11 @@ const Commit* GitRepository::getCommit(QString revision) const
 			DirIter.next();
 			if (DirIter.fileInfo().isFile())
 			{
-				QFile file(DirIter.filePath());	// projects/Testproject
+				QFile file(DirIter.filePath());
 				if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) continue;
 				QByteArray text = file.readAll();
 				char *content = new char[text.size() + 1];
-				strcpy(content, text.data());
+				strncpy(content, text.data(), text.size()+1);
 				std::unique_ptr<char[]> content_ptr{content};
 				m->addFile(DirIter.filePath(), file.size(), std::move(content_ptr));
 			}

--- a/FilePersistence/src/version_control/GitRepository.cpp
+++ b/FilePersistence/src/version_control/GitRepository.cpp
@@ -328,7 +328,7 @@ const Commit* GitRepository::getCommit(QString revision) const
 			DirIter.next();
 			if (DirIter.fileInfo().isFile())
 			{
-				QFile file(DirIter.filePath());	// projects/Testproject
+				QFile file(DirIter.filePath());
 				if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) continue;
 				QByteArray text = file.readAll();
 				char *content = new char[text.size() + 1];

--- a/InteractionBase/CMakeLists.txt
+++ b/InteractionBase/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(InteractionBase SHARED
 	src/commands/CAddNodeToViewByName.h
 	src/commands/CAddNodeToView.h
 	src/handlers/HViewItem.h
+	src/handlers/HArrowHandler.h
 	src/prompt/CommandMode.h
 	src/prompt/HPromptShell.h
 	src/prompt/Prompt.h
@@ -188,6 +189,7 @@ add_library(InteractionBase SHARED
 	src/handlers/HWebBrowserItem.cpp
 	src/handlers/HMovableItem.h
 	src/handlers/HMovableItem.cpp
+	src/handlers/HArrowHandler.cpp
 )
 
 envision_plugin(InteractionBase VisualizationBase FilePersistence)

--- a/InteractionBase/src/InteractionBasePlugin.cpp
+++ b/InteractionBase/src/InteractionBasePlugin.cpp
@@ -37,6 +37,7 @@
 #include "handlers/HInfoNode.h"
 #include "handlers/HViewItem.h"
 #include "handlers/HWebBrowserItem.h"
+#include "handlers/HArrowHandler.h"
 
 #include "vis/TextAndDescription.h"
 #include "vis/VViewSwitcherEntry.h"
@@ -73,6 +74,7 @@
 #include "VisualizationBase/src/items/ViewItem.h"
 #include "VisualizationBase/src/items/WebBrowserItem.h"
 #include "VisualizationBase/src/overlays/MessageOverlay.h"
+#include "VisualizationBase/src/overlays/ArrowOverlay.h"
 
 #include "SelfTest/src/TestManager.h"
 #include "Logger/src/Log.h"
@@ -105,6 +107,7 @@ bool InteractionBasePlugin::initialize(Core::EnvisionManager& envisionManager)
 	Visualization::ViewItem::setDefaultClassHandler(HViewItem::instance());
 	Visualization::WebBrowserItem::setDefaultClassHandler(HWebBrowserItem::instance());
 	Visualization::MessageOverlay::setDefaultClassHandler(HMovableItem::instance());
+	Visualization::ArrowOverlay::setDefaultClassHandler(HArrowHandler::instance());
 	ActionPrompt::setDefaultClassHandler(HActionPrompt::instance());
 
 	// We use to show the prompt. It can only be shown once the Scene is activated.

--- a/InteractionBase/src/handlers/HArrowHandler.cpp
+++ b/InteractionBase/src/handlers/HArrowHandler.cpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
 **
-** Copyright (c) 2015 ETH Zurich
+** Copyright (c) 2016 ETH Zurich
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -24,41 +24,31 @@
 **
 ***********************************************************************************************************************/
 
-#pragma once
+#include "HArrowHandler.h"
 
-#include "../visualizationbase_api.h"
-#include "../items/ItemStyle.h"
-#include "../overlays/Overlay.h"
-#include "ArrowOverlayStyle.h"
+#include "VisualizationBase/src/overlays/ArrowOverlay.h"
 
-namespace Visualization {
-
-/**
- * An overlay to draw an arrow from the first item to the second item.
- */
-class VISUALIZATIONBASE_API ArrowOverlay: public Super<Overlay<Item>>
+namespace Interaction
 {
-	ITEM_COMMON(ArrowOverlay)
 
-	public:
-		ArrowOverlay(Item* arrowFrom, Item* arrowTo, const StyleType* style = itemStyles().get());
-		virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
-		void setSelected(bool selected);
+HArrowHandler* HArrowHandler::instance()
+{
+	static HArrowHandler inst;
+	return &inst;
+}
 
-	protected:
-		virtual void determineChildren() override;
-		virtual void updateGeometry(int availableWidth, int availableHeight) override;
-		virtual QPainterPath shape() const override;
+void HArrowHandler::hoverEnterEvent(Visualization::Item* target, QGraphicsSceneHoverEvent*)
+{
+	Visualization::ArrowOverlay* arrowOverlay = static_cast<Visualization::ArrowOverlay*> (target);
+	arrowOverlay->setSelected(true);
+	arrowOverlay->setUpdateNeeded(Visualization::Item::StandardUpdate);
+}
 
-	private:
-		QPoint lineFrom_{};
-		QPoint lineTo_{};
-		bool invertArrow_{};
-		bool selected_{};
-		QPolygonF currentArrowOutline_{};
-
-};
-
-inline void ArrowOverlay::setSelected(bool selected) {selected_ = selected;}
+void HArrowHandler::hoverLeaveEvent(Visualization::Item* target, QGraphicsSceneHoverEvent*)
+{
+	Visualization::ArrowOverlay* arrowOverlay = static_cast<Visualization::ArrowOverlay*> (target);
+	arrowOverlay->setSelected(false);
+	arrowOverlay->setUpdateNeeded(Visualization::Item::StandardUpdate);
+}
 
 }

--- a/InteractionBase/src/handlers/HArrowHandler.cpp
+++ b/InteractionBase/src/handlers/HArrowHandler.cpp
@@ -40,14 +40,14 @@ HArrowHandler* HArrowHandler::instance()
 void HArrowHandler::hoverEnterEvent(Visualization::Item* target, QGraphicsSceneHoverEvent*)
 {
 	Visualization::ArrowOverlay* arrowOverlay = static_cast<Visualization::ArrowOverlay*> (target);
-	arrowOverlay->setSelected(true);
+	arrowOverlay->setHighlighted(true);
 	arrowOverlay->setUpdateNeeded(Visualization::Item::StandardUpdate);
 }
 
 void HArrowHandler::hoverLeaveEvent(Visualization::Item* target, QGraphicsSceneHoverEvent*)
 {
 	Visualization::ArrowOverlay* arrowOverlay = static_cast<Visualization::ArrowOverlay*> (target);
-	arrowOverlay->setSelected(false);
+	arrowOverlay->setHighlighted(false);
 	arrowOverlay->setUpdateNeeded(Visualization::Item::StandardUpdate);
 }
 

--- a/InteractionBase/src/handlers/HArrowHandler.h
+++ b/InteractionBase/src/handlers/HArrowHandler.h
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
 **
-** Copyright (c) 2015 ETH Zurich
+** Copyright (c) 2016 ETH Zurich
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -26,39 +26,20 @@
 
 #pragma once
 
-#include "../visualizationbase_api.h"
-#include "../items/ItemStyle.h"
-#include "../overlays/Overlay.h"
-#include "ArrowOverlayStyle.h"
+#include "../interactionbase_api.h"
 
-namespace Visualization {
+#include "InteractionBase/src/handlers/GenericHandler.h"
 
-/**
- * An overlay to draw an arrow from the first item to the second item.
- */
-class VISUALIZATIONBASE_API ArrowOverlay: public Super<Overlay<Item>>
+namespace Interaction
 {
-	ITEM_COMMON(ArrowOverlay)
 
+class INTERACTIONBASE_API HArrowHandler : public GenericHandler
+{
 	public:
-		ArrowOverlay(Item* arrowFrom, Item* arrowTo, const StyleType* style = itemStyles().get());
-		virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
-		void setSelected(bool selected);
+		static HArrowHandler* instance();
 
-	protected:
-		virtual void determineChildren() override;
-		virtual void updateGeometry(int availableWidth, int availableHeight) override;
-		virtual QPainterPath shape() const override;
-
-	private:
-		QPoint lineFrom_{};
-		QPoint lineTo_{};
-		bool invertArrow_{};
-		bool selected_{};
-		QPolygonF currentArrowOutline_{};
-
+		virtual void hoverEnterEvent(Visualization::Item *target, QGraphicsSceneHoverEvent *event) override;
+		virtual void hoverLeaveEvent(Visualization::Item *target, QGraphicsSceneHoverEvent *event) override;
 };
-
-inline void ArrowOverlay::setSelected(bool selected) {selected_ = selected;}
 
 }

--- a/OOInteraction/src/commands/CSceneHandlerItemTest.cpp
+++ b/OOInteraction/src/commands/CSceneHandlerItemTest.cpp
@@ -58,8 +58,8 @@ Interaction::CommandResult* CSceneHandlerItemTest::execute(Visualization::Item*,
 		const QStringList&, const std::unique_ptr<Visualization::Cursor>&)
 {
 
-	VersionControlUI::DiffManager diffManager{"f02f73470efdd7153b83637ed17d12cb9ad67561",
-															"a4d1df8c996ec791ea84cd6d8d06d496c4d0be53", "DiffTest",
+	VersionControlUI::DiffManager diffManager{"a1f5",
+															"f02f", "DiffTest",
 															Model::SymbolMatcher{"Class"}};
 
 	diffManager.visualize();

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -71,7 +71,7 @@ DiffManager::DiffManager(QString oldVersion, QString newVersion, QString project
 
 DiffSetup DiffManager::initializeDiffPrerequisites()
 {
-	DiffSetup diffSetup{};
+
 
 	QString projectsDir = "projects/" + project_;
 
@@ -79,6 +79,7 @@ DiffSetup DiffManager::initializeDiffPrerequisites()
 	if (!FilePersistence::GitRepository::repositoryExists(projectsDir))
 		throw VersionControlUIException{"Diff setup not possible. No repository found at " + projectsDir};
 
+	DiffSetup diffSetup{};
 	diffSetup.repository_ = new FilePersistence::GitRepository{projectsDir};;
 
 	// load newer version

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -218,6 +218,11 @@ bool DiffManager::findChangedNode(Model::TreeManager* treeManager, Model::NodeId
 			resultId = treeManager->nodeIdMap().id(changedNode);
 			return true;
 		}
+		else
+		{
+			resultId = treeManager->nodeIdMap().id(node);
+		}
+		return true;
 	}
 	return false;
 }

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -304,21 +304,6 @@ void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem
 	});
 }
 
-QString DiffManager::getObjectPath(Model::Node* node)
-{
-	if (!node) return "no node";
-	auto parent = node->parent();
-	QString objectPath = "";
-	while (parent)
-	{
-		if (parent->definesSymbol())
-			objectPath.prepend(parent->symbolName() + "/");
-		parent = parent->parent();
-	}
-
-	return objectPath;
-}
-
 Visualization::Item* DiffManager::addHighlightAndReturnItem(Model::Node* node, Visualization::ViewItem* viewItem,
                                                QString highlightOverlayName, QString highlightOverlayStyle)
 {
@@ -344,26 +329,7 @@ void DiffManager::visualizeChangedNodes(Model::TreeManager* oldVersionManager,
 		auto oldNode = const_cast<Model::Node*>(oldVersionManager->nodeIdMap().node(id));
 		auto newNode = const_cast<Model::Node*>(newVersionManager->nodeIdMap().node(id));
 
-		QString oldVersionObjectPath = getObjectPath(oldNode);
-		QString newVersionObjectPath = getObjectPath(newNode);
-
-		// TODO maybe add seperate field for typeName in visualization
-		QString componentType = (oldNode ? oldNode->typeName() : newNode->typeName());
-
-		// old version in left column
-		if (!oldNode)
-			oldNode = new Model::Text{"node in old version not found"};
-
-		// new version in right column
-		if (!newNode)
-			newNode = new Model::Text{"node in new version not found"};
-
-		auto diffNode = new DiffComparisonPair{};
-		diffNode->setOldVersionNode(oldNode);
-		diffNode->setNewVersionNode(newNode);
-		diffNode->setOldVersionObjectPath(new Model::Text{oldVersionObjectPath});
-		diffNode->setNewVersionObjectPath(new Model::Text{newVersionObjectPath});
-		diffNode->setComponentType(new Model::Text{componentType});
+		auto diffNode = new DiffComparisonPair{oldNode, newNode};
 
 		diffViewItem->insertNode(diffNode);
 	}

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -342,6 +342,12 @@ Visualization::Item* DiffManager::addHighlightAndReturnItem(Model::Node* node, V
 					Visualization::HighlightOverlay::itemStyles().get(highlightOverlayStyle)};
 			resultItem->addOverlay(overlay, highlightOverlayName);
 		}
+		else if (auto parent = DCast<Model::CompositeNode>(node->parent()))
+		{
+			auto index = parent->indexOf(node);
+			if (!parent->meta().attribute(index).name().startsWith("_"))
+				return addHighlightAndReturnItem(node->parent(), viewItem, highlightOverlayName, highlightOverlayStyle);
+		}
 	}
 	return resultItem;
 }

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -34,6 +34,7 @@
 #include "VisualizationBase/src/declarative/GridLayouter.h"
 #include "VisualizationBase/src/overlays/HighlightOverlay.h"
 #include "VisualizationBase/src/overlays/ArrowOverlay.h"
+#include "VisualizationBase/src/views/MainView.h"
 
 #include "FilePersistence/src/version_control/GitRepository.h"
 #include "FilePersistence/src/simple/SimpleTextFileStore.h"
@@ -302,6 +303,11 @@ void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem
 				item->setScale((1/factor) * std::pow(0.95, 1/factor));
 		}
 	});
+
+	// set zoom level further out and center the scene
+	Visualization::VisualizationManager::instance().mainView()->setScaleLevelAndZoom(7);
+	Visualization::VisualizationManager::instance().mainView()->
+			centerOn(Visualization::VisualizationManager::instance().mainView()->sceneRect().center());
 }
 
 Visualization::Item* DiffManager::addHighlightAndReturnItem(Model::Node* node, Visualization::ViewItem* viewItem,

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -120,7 +120,14 @@ void DiffManager::visualize()
 	Visualization::VisualizationManager::instance().mainScene()->listenToTreeManager(oldVersionManager);
 
 	auto diffViewItem = Visualization::VisualizationManager::instance().mainScene()->
-			viewItems()->newViewItem("DiffView");
+			viewItems()->viewItem("DiffView");
+
+	if (diffViewItem)
+		Visualization::VisualizationManager::instance().mainScene()->
+					viewItems()->removeViewItem(diffViewItem);
+
+	diffViewItem = Visualization::VisualizationManager::instance().mainScene()->
+				viewItems()->newViewItem("DiffView");
 
 	diffViewItem->setMajorAxis(Visualization::GridLayouter::NoMajor);
 

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -71,8 +71,6 @@ DiffManager::DiffManager(QString oldVersion, QString newVersion, QString project
 
 DiffSetup DiffManager::initializeDiffPrerequisites()
 {
-
-
 	QString projectsDir = "projects/" + project_;
 
 	// get GitRepository
@@ -91,7 +89,6 @@ DiffSetup DiffManager::initializeDiffPrerequisites()
 	Model::Reference::resolvePending();
 
 	return diffSetup;
-
 }
 
 void DiffManager::computeChangeNodesAndNodesToVisualize(FilePersistence::IdToChangeDescriptionHash changes,

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -132,6 +132,7 @@ void DiffManager::visualize()
 				viewItems()->newViewItem("DiffView");
 
 	diffViewItem->setMajorAxis(Visualization::GridLayouter::NoMajor);
+	diffViewItem->setZoomLabelsEnabled(false);
 
 	// add nodes to visualization, if not avaible show text
 	visualizeChangedNodes(oldVersionManager, changedNodesToVisualize, newVersionManager, diffViewItem);
@@ -305,7 +306,7 @@ void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem
 	});
 
 	// set zoom level further out and center the scene
-	Visualization::VisualizationManager::instance().mainView()->setScaleLevelAndZoom(7);
+	Visualization::VisualizationManager::instance().mainView()->zoom(7);
 	Visualization::VisualizationManager::instance().mainView()->
 			centerOn(Visualization::VisualizationManager::instance().mainView()->sceneRect().center());
 }

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -101,8 +101,6 @@ class VERSIONCONTROLUI_API DiffManager
 		static Visualization::Item* addHighlightAndReturnItem(Model::Node* node, Visualization::ViewItem* viewItem,
 																QString highlightOverlayName, QString highlightOverlayStyle);
 
-		QString getObjectPath(Model::Node* node);
-
 		QString oldVersion_;
 		QString newVersion_;
 		QString project_;

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -32,6 +32,7 @@
 #include "ModelBase/src/util/SymbolMatcher.h"
 
 #include "FilePersistence/src/version_control/ChangeDescription.h"
+#include "FilePersistence/src/version_control/Diff.h"
 
 
 namespace FilePersistence
@@ -48,6 +49,8 @@ namespace Visualization
 namespace VersionControlUI {
 
 struct ChangeWithNodes;
+struct DiffSetup;
+class DiffComparisonPair;
 
 class VERSIONCONTROLUI_API DiffManager
 {
@@ -56,6 +59,16 @@ class VERSIONCONTROLUI_API DiffManager
 		void visualize();
 
 	private:
+
+		DiffSetup initializeDiffPrerequisites();
+
+		/**
+		 * Inserts for entries of \a changes a ChangeWithNodes in \a changesWithNodes. Computes id of nodes which
+		 * should be visualized and inserts them in \a changedNodesToVisualize.
+		 */
+		void computeChangeNodesAndNodesToVisualize(FilePersistence::IdToChangeDescriptionHash changes,
+								QList<ChangeWithNodes>& changesWithNodes, QSet<Model::NodeIdType>& changedNodesToVisualize,
+																 DiffSetup& diffSetup);
 
 		/**
 		 * Deletes all nodes in \a container if their direct parent is also in \a container and has the same change type.
@@ -80,17 +93,15 @@ class VERSIONCONTROLUI_API DiffManager
 		static void createOverlaysForChanges(Visualization::ViewItem* diffViewItem, QList<ChangeWithNodes> changesWithNodes);
 
 		/**
-		 * Inserts the nodes with id from \a changedNodesToVisualize into the \a diffViewItem.
-		 * If a node isn't available in \a oldVersionManager or \a newVersionManager, it will add instead a text which
-		 * informs about this fact.
+		 * Returns a list of DiffComparisonPair created from the ids from \a diffComparisonPairNodeIds.
 		 */
-		void visualizeChangedNodes(Model::TreeManager* oldVersionManager, QSet<Model::NodeIdType> changedNodesToVisualize,
-											Model::TreeManager* newVersionManager, Visualization::ViewItem* diffViewItem);
+		QList<DiffComparisonPair*> createDiffComparisonPairs(DiffSetup& diffSetup,
+																			 QSet<Model::NodeIdType> diffComparisonPairNodeIds);
 
 		/**
 		 * Creates a TreeManager from \a version using \a repository.
 		 */
-		Model::TreeManager* createTreeManagerFromVersion(FilePersistence::GitRepository& repository, QString version);
+		Model::TreeManager* createTreeManagerFromVersion(FilePersistence::GitRepository* repository, QString version);
 
 		/**
 		 * Returns all items which have any of their parents present in \a items.
@@ -105,7 +116,6 @@ class VERSIONCONTROLUI_API DiffManager
 		QString newVersion_;
 		QString project_;
 		Model::SymbolMatcher contextUnitMatcher_;
-
 
 };
 

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -97,6 +97,10 @@ class VERSIONCONTROLUI_API DiffManager
 		 */
 		static QSet<Visualization::Item*> findAllItemsWithAncestorsIn(QSet<Visualization::Item*> items);
 
+
+		static Visualization::Item* addHighlightAndReturnItem(Model::Node* node, Visualization::ViewItem* viewItem,
+																QString highlightOverlayName, QString highlightOverlayStyle);
+
 		QString getObjectPath(Model::Node* node);
 
 		QString oldVersion_;

--- a/VersionControlUI/src/items/VDiffComparisonPair.cpp
+++ b/VersionControlUI/src/items/VDiffComparisonPair.cpp
@@ -33,6 +33,8 @@
 
 #include "VisualizationBase/src/items/VText.h"
 
+#include "../nodes/DiffComparisonPair.h"
+
 namespace VersionControlUI
 {
 
@@ -50,17 +52,18 @@ void VDiffComparisonPair::initializeForms()
 	auto newVersion = item(&I::newVersionNode_, [](I* v) {
 			return v->node()->newVersionNode();});
 
-	auto oldVersionObjectPath = item<Visualization::VText>(&I::oldVersionObjectPath_, [](I* v) {
-			return v->node()->oldVersionObjectPath();},
-			[](I* v) {return &v->style()->oldVersionObjectPath();});
-
-	auto newVersionObjectPath = item<Visualization::VText>(&I::newVersionObjectPath_, [](I* v) {
-			return v->node()->newVersionObjectPath();},
-			[](I* v) {return &v->style()->newVersionObjectPath();});
-
 	auto componentType = item<Visualization::VText>(&I::componentType_, [](I* v) {
 			return v->node()->componentType();},
 			[](I* v) {return &v->style()->componentType();});
+
+	auto noNodeFound = item<Visualization::Static>(&I::nodeNotFoundIcon_, &StyleType::nodeNotFoundIcon);
+
+
+	auto objectPath = item<Visualization::VText>(&I::singleObjectPath_, [](I* v) {
+			return v->node()->singleObjectPath();},
+			[](I* v) {return &v->style()->singleObjectPath();});
+
+	// form with both nodes and only one object path
 
 	auto infoGrid = (new Visualization::GridLayoutFormElement{})
 			->setHorizontalSpacing(50)
@@ -69,10 +72,23 @@ void VDiffComparisonPair::initializeForms()
 			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
 			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
 			->setColumnStretchFactor(0, 1)
-			->setColumnStretchFactor(1, 1)
-			->put(0, 0, oldVersionObjectPath)
-			->put(1, 0, newVersionObjectPath)
+			->put(0, 0, objectPath)
 			->put(0, 1, componentType);
+
+	auto diffGrid = (new Visualization::GridLayoutFormElement{})
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setColumnStretchFactor(1, 1)
+			->setRowStretchFactor(0, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
+			->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
+			->put(0, 0, oldVersion)
+			->put(1, 0, newVersion);
+
 	auto container = (new Visualization::GridLayoutFormElement{})
 				->setHorizontalSpacing(30)
 				->setVerticalSpacing(15)
@@ -81,15 +97,139 @@ void VDiffComparisonPair::initializeForms()
 				->setLeftMargin(10)
 				->setRightMargin(10)
 				->setColumnStretchFactor(0, 1)
-				->setColumnStretchFactor(1, 1)
 				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
 				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
-				->put(0, 0, infoGrid)
-				->setCellSpanning(2, 1)
-				->put(0, 1, oldVersion)
-				->put(1, 1, newVersion);
+				->setRowStretchFactor(0, 1)
+				->setRowStretchFactor(1, 1)
+				->put(0, 0, infoGrid->clone())
+				->put(0, 1, diffGrid->clone());
 
-	addForm(container);
+
+	addForm(container->clone());
+
+	// form with only new node available
+
+	diffGrid = (new Visualization::GridLayoutFormElement{})
+				->setHorizontalSpacing(50)
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->setColumnStretchFactor(0, 1)
+				->setColumnStretchFactor(1, 1)
+				->setRowStretchFactor(0, 1)
+				->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Center)
+				->put(0, 0, noNodeFound)
+				->put(1, 0, newVersion);
+
+	container = (new Visualization::GridLayoutFormElement{})
+				->setHorizontalSpacing(30)
+				->setVerticalSpacing(15)
+				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setColumnStretchFactor(0, 1)
+				->setRowStretchFactor(0, 1)
+				->setRowStretchFactor(1, 1)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->put(0, 0, infoGrid->clone())
+				->put(0, 1, diffGrid->clone());
+
+	addForm(container->clone());
+
+	// form with only old node available
+
+	diffGrid = (new Visualization::GridLayoutFormElement{})
+				->setHorizontalSpacing(50)
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->setColumnStretchFactor(0, 1)
+				->setColumnStretchFactor(1, 1)
+				->setRowStretchFactor(0, 1)
+				->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Center)
+				->put(0, 0, oldVersion)
+				->put(1, 0, noNodeFound);
+
+	container = (new Visualization::GridLayoutFormElement{})
+				->setHorizontalSpacing(30)
+				->setVerticalSpacing(15)
+				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setColumnStretchFactor(0, 1)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->put(0, 0, infoGrid->clone())
+				->put(0, 1, diffGrid->clone());
+
+	addForm(container->clone());
+
+	// form with two object paths and two nodes
+
+	auto oldVersionObjectPath = item<Visualization::VText>(&I::oldVersionObjectPath_, [](I* v) {
+			return v->node()->oldVersionObjectPath();},
+			[](I* v) {return &v->style()->oldVersionObjectPath();});
+
+	auto newVersionObjectPath = item<Visualization::VText>(&I::newVersionObjectPath_, [](I* v) {
+			return v->node()->newVersionObjectPath();},
+			[](I* v) {return &v->style()->newVersionObjectPath();});
+
+	infoGrid = (new Visualization::GridLayoutFormElement{})
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setColumnStretchFactor(1, 1)
+			->put(0, 0, oldVersionObjectPath)
+			->put(1, 0, newVersionObjectPath);
+
+	auto infoWithComponentTypeGrid = (new Visualization::GridLayoutFormElement{})
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setRowStretchFactor(0, 1)
+			->put(0, 0, infoGrid->clone())
+			->put(0, 1, componentType);
+
+	diffGrid = (new Visualization::GridLayoutFormElement{})
+				->setHorizontalSpacing(50)
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->setColumnStretchFactor(0, 1)
+				->setColumnStretchFactor(1, 1)
+				->setRowStretchFactor(0, 1)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
+				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
+				->put(0, 0, oldVersion)
+				->put(1, 0, newVersion);
+
+	container = (new Visualization::GridLayoutFormElement{})
+				->setHorizontalSpacing(30)
+				->setVerticalSpacing(15)
+				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setColumnStretchFactor(0, 1)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+				->put(0, 0, infoWithComponentTypeGrid->clone())
+				->put(0, 1, diffGrid->clone());
+
+	addForm(container->clone());
 
 }
 
@@ -112,11 +252,17 @@ void VDiffComparisonPair::scaleVisualizations()
 	if (componentType_)
 		componentType_->setScale(scale);
 
+	if (singleObjectPath_)
+		singleObjectPath_->setScale(scale);
+
 	if (oldVersionObjectPath_)
 		oldVersionObjectPath_->setScale(scale);
 
 	if (newVersionObjectPath_)
 		newVersionObjectPath_->setScale(scale);
+
+	if (nodeNotFoundIcon_)
+		nodeNotFoundIcon_->setScale(scale);
 }
 
 void VDiffComparisonPair::determineChildren()
@@ -124,4 +270,24 @@ void VDiffComparisonPair::determineChildren()
 	Super::determineChildren();
 	scaleVisualizations();
 }
+
+int VDiffComparisonPair::determineForm()
+{
+	static const int FORM_WITH_SINGLE_OBJECT_PATH = 0;
+	static const int FORM_CONTAINING_ONLY_NEW_NODE = 1;
+	static const int FORM_CONTAINING_ONLY_OLD_NODE = 2;
+	static const int FORM_WITH_TWO_OBJECT_PATHS = 3;
+
+	DiffComparisonPair* associatedNode = node();
+	if (associatedNode->twoObjectPathsDefined())
+		return FORM_WITH_TWO_OBJECT_PATHS;
+	else
+		if (!associatedNode->oldVersionNode())
+			return FORM_CONTAINING_ONLY_NEW_NODE;
+		else if (!associatedNode->newVersionNode())
+			return FORM_CONTAINING_ONLY_OLD_NODE;
+		else
+			return FORM_WITH_SINGLE_OBJECT_PATH;
+}
+
 }

--- a/VersionControlUI/src/items/VDiffComparisonPair.cpp
+++ b/VersionControlUI/src/items/VDiffComparisonPair.cpp
@@ -98,9 +98,8 @@ bool VDiffComparisonPair::isSensitiveToScale() const
 	return true;
 }
 
-void VDiffComparisonPair::determineChildren()
+void VDiffComparisonPair::scaleVisualizations()
 {
-	Super::determineChildren();
 	qreal factor = Visualization::VisualizationManager::instance().mainScene()->mainViewScalingFactor();
 	qreal scale;
 	if (factor >= 1.0)
@@ -109,16 +108,20 @@ void VDiffComparisonPair::determineChildren()
 		scale = 1.0/factor;
 	else
 		scale = 1.0;
-				//item->setScale((1/factor) * std::pow(0.95, 1/factor));
+
 	if (componentType_)
 		componentType_->setScale(scale);
+
 	if (oldVersionObjectPath_)
-	{
-		oldVersionObjectPath_->setTextFormat(Qt::RichText);
 		oldVersionObjectPath_->setScale(scale);
-	}
+
 	if (newVersionObjectPath_)
 		newVersionObjectPath_->setScale(scale);
 }
 
+void VDiffComparisonPair::determineChildren()
+{
+	Super::determineChildren();
+	scaleVisualizations();
+}
 }

--- a/VersionControlUI/src/items/VDiffComparisonPair.cpp
+++ b/VersionControlUI/src/items/VDiffComparisonPair.cpp
@@ -26,8 +26,11 @@
 
 #include "VDiffComparisonPair.h"
 
+#include "VisualizationBase/src/VisualizationManager.h"
 #include "VisualizationBase/src/declarative/DeclarativeItem.hpp"
+
 #include "ModelBase/src/nodes/Text.h"
+
 #include "VisualizationBase/src/items/VText.h"
 
 namespace VersionControlUI
@@ -55,18 +58,67 @@ void VDiffComparisonPair::initializeForms()
 			return v->node()->newVersionObjectPath();},
 			[](I* v) {return &v->style()->newVersionObjectPath();});
 
+	auto componentType = item<Visualization::VText>(&I::componentType_, [](I* v) {
+			return v->node()->componentType();},
+			[](I* v) {return &v->style()->componentType();});
+
+	auto infoGrid = (new Visualization::GridLayoutFormElement{})
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setColumnStretchFactor(1, 1)
+			->put(0, 0, oldVersionObjectPath)
+			->put(1, 0, newVersionObjectPath)
+			->put(0, 1, componentType);
 	auto container = (new Visualization::GridLayoutFormElement{})
 				->setHorizontalSpacing(30)
 				->setVerticalSpacing(15)
 				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
 				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->put(0, 0, oldVersionObjectPath)
-				->put(1, 0, newVersionObjectPath)
+				->setLeftMargin(10)
+				->setRightMargin(10)
+				->setColumnStretchFactor(0, 1)
+				->setColumnStretchFactor(1, 1)
+				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
+				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
+				->put(0, 0, infoGrid)
+				->setCellSpanning(2, 1)
 				->put(0, 1, oldVersion)
 				->put(1, 1, newVersion);
 
 	addForm(container);
 
+}
+
+bool VDiffComparisonPair::isSensitiveToScale() const
+{
+	return true;
+}
+
+void VDiffComparisonPair::determineChildren()
+{
+	Super::determineChildren();
+	qreal factor = Visualization::VisualizationManager::instance().mainScene()->mainViewScalingFactor();
+	qreal scale;
+	if (factor >= 1.0)
+		scale = 1.0;
+	else if (factor >= 0.03)
+		scale = 1.0/factor;
+	else
+		scale = 1.0;
+				//item->setScale((1/factor) * std::pow(0.95, 1/factor));
+	if (componentType_)
+		componentType_->setScale(scale);
+	if (oldVersionObjectPath_)
+	{
+		oldVersionObjectPath_->setTextFormat(Qt::RichText);
+		oldVersionObjectPath_->setScale(scale);
+	}
+	if (newVersionObjectPath_)
+		newVersionObjectPath_->setScale(scale);
 }
 
 }

--- a/VersionControlUI/src/items/VDiffComparisonPair.cpp
+++ b/VersionControlUI/src/items/VDiffComparisonPair.cpp
@@ -52,10 +52,6 @@ void VDiffComparisonPair::initializeForms()
 	auto newVersion = item(&I::newVersionNode_, [](I* v) {
 			return v->node()->newVersionNode();});
 
-	auto componentType = item<Visualization::VText>(&I::componentType_, [](I* v) {
-			return v->node()->componentType();},
-			[](I* v) {return &v->style()->componentType();});
-
 	auto noNodeFound = item<Visualization::Static>(&I::nodeNotFoundIcon_, &StyleType::nodeNotFoundIcon);
 
 
@@ -72,8 +68,7 @@ void VDiffComparisonPair::initializeForms()
 			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
 			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
 			->setColumnStretchFactor(0, 1)
-			->put(0, 0, objectPath)
-			->put(0, 1, componentType);
+			->put(0, 0, objectPath);
 
 	auto diffGrid = (new Visualization::GridLayoutFormElement{})
 			->setHorizontalSpacing(50)
@@ -90,19 +85,19 @@ void VDiffComparisonPair::initializeForms()
 			->put(1, 0, newVersion);
 
 	auto container = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(30)
-				->setVerticalSpacing(15)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setColumnStretchFactor(0, 1)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
-				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
-				->setRowStretchFactor(0, 1)
-				->setRowStretchFactor(1, 1)
-				->put(0, 0, infoGrid->clone())
-				->put(0, 1, diffGrid->clone());
+			->setHorizontalSpacing(30)
+			->setVerticalSpacing(15)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setColumnStretchFactor(0, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
+			->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
+			->setRowStretchFactor(0, 1)
+			->setRowStretchFactor(1, 1)
+			->put(0, 0, infoGrid->clone())
+			->put(0, 1, diffGrid->clone());
 
 
 	addForm(container->clone());
@@ -110,64 +105,64 @@ void VDiffComparisonPair::initializeForms()
 	// form with only new node available
 
 	diffGrid = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(50)
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setColumnStretchFactor(0, 1)
-				->setColumnStretchFactor(1, 1)
-				->setRowStretchFactor(0, 1)
-				->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Center)
-				->put(0, 0, noNodeFound)
-				->put(1, 0, newVersion);
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setColumnStretchFactor(1, 1)
+			->setRowStretchFactor(0, 1)
+			->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Center)
+			->put(0, 0, noNodeFound)
+			->put(1, 0, newVersion);
 
 	container = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(30)
-				->setVerticalSpacing(15)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setColumnStretchFactor(0, 1)
-				->setRowStretchFactor(0, 1)
-				->setRowStretchFactor(1, 1)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->put(0, 0, infoGrid->clone())
-				->put(0, 1, diffGrid->clone());
+			->setHorizontalSpacing(30)
+			->setVerticalSpacing(15)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setColumnStretchFactor(0, 1)
+			->setRowStretchFactor(0, 1)
+			->setRowStretchFactor(1, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->put(0, 0, infoGrid->clone())
+			->put(0, 1, diffGrid->clone());
 
 	addForm(container->clone());
 
 	// form with only old node available
 
 	diffGrid = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(50)
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setColumnStretchFactor(0, 1)
-				->setColumnStretchFactor(1, 1)
-				->setRowStretchFactor(0, 1)
-				->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Center)
-				->put(0, 0, oldVersion)
-				->put(1, 0, noNodeFound);
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setColumnStretchFactor(1, 1)
+			->setRowStretchFactor(0, 1)
+			->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Center)
+			->put(0, 0, oldVersion)
+			->put(1, 0, noNodeFound);
 
 	container = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(30)
-				->setVerticalSpacing(15)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setColumnStretchFactor(0, 1)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->put(0, 0, infoGrid->clone())
-				->put(0, 1, diffGrid->clone());
+			->setHorizontalSpacing(30)
+			->setVerticalSpacing(15)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setColumnStretchFactor(0, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->put(0, 0, infoGrid->clone())
+			->put(0, 1, diffGrid->clone());
 
 	addForm(container->clone());
 
@@ -200,36 +195,35 @@ void VDiffComparisonPair::initializeForms()
 			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
 			->setColumnStretchFactor(0, 1)
 			->setRowStretchFactor(0, 1)
-			->put(0, 0, infoGrid->clone())
-			->put(0, 1, componentType);
+			->put(0, 0, infoGrid);
 
 	diffGrid = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(50)
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setColumnStretchFactor(0, 1)
-				->setColumnStretchFactor(1, 1)
-				->setRowStretchFactor(0, 1)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
-				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
-				->put(0, 0, oldVersion)
-				->put(1, 0, newVersion);
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setColumnStretchFactor(1, 1)
+			->setRowStretchFactor(0, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Right)
+			->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Left)
+			->put(0, 0, oldVersion)
+			->put(1, 0, newVersion);
 
 	container = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(30)
-				->setVerticalSpacing(15)
-				->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->setLeftMargin(10)
-				->setRightMargin(10)
-				->setColumnStretchFactor(0, 1)
-				->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
-				->put(0, 0, infoWithComponentTypeGrid->clone())
-				->put(0, 1, diffGrid->clone());
+			->setHorizontalSpacing(30)
+			->setVerticalSpacing(15)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setColumnStretchFactor(0, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->put(0, 0, infoWithComponentTypeGrid)
+			->put(0, 1, diffGrid);
 
-	addForm(container->clone());
+	addForm(container);
 
 }
 
@@ -278,13 +272,12 @@ int VDiffComparisonPair::determineForm()
 	static const int FORM_CONTAINING_ONLY_OLD_NODE = 2;
 	static const int FORM_WITH_TWO_OBJECT_PATHS = 3;
 
-	DiffComparisonPair* associatedNode = node();
-	if (associatedNode->twoObjectPathsDefined())
+	if (node()->twoObjectPathsDefined())
 		return FORM_WITH_TWO_OBJECT_PATHS;
 	else
-		if (!associatedNode->oldVersionNode())
+		if (!node()->oldVersionNode())
 			return FORM_CONTAINING_ONLY_NEW_NODE;
-		else if (!associatedNode->newVersionNode())
+		else if (!node()->newVersionNode())
 			return FORM_CONTAINING_ONLY_OLD_NODE;
 		else
 			return FORM_WITH_SINGLE_OBJECT_PATH;

--- a/VersionControlUI/src/items/VDiffComparisonPair.h
+++ b/VersionControlUI/src/items/VDiffComparisonPair.h
@@ -62,6 +62,7 @@ class VERSIONCONTROLUI_API VDiffComparisonPair : public Super<Visualization::Ite
 		Visualization::VText* newVersionObjectPath_{};
 
 		Visualization::VText* componentType_{};
+		void scaleVisualizations();
 };
 
 }

--- a/VersionControlUI/src/items/VDiffComparisonPair.h
+++ b/VersionControlUI/src/items/VDiffComparisonPair.h
@@ -35,6 +35,7 @@
 
 #include "VisualizationBase/src/items/Item.h"
 #include "VisualizationBase/src/items/VText.h"
+#include "VisualizationBase/src/items/Static.h"
 
 #include "../nodes/DiffComparisonPair.h"
 
@@ -53,6 +54,7 @@ class VERSIONCONTROLUI_API VDiffComparisonPair : public Super<Visualization::Ite
 		static void initializeForms();
 		virtual bool isSensitiveToScale() const override;
 		virtual void determineChildren() override;
+		int determineForm() override;
 
 	private:
 		Visualization::Item* oldVersionNode_{};
@@ -60,8 +62,12 @@ class VERSIONCONTROLUI_API VDiffComparisonPair : public Super<Visualization::Ite
 
 		Visualization::VText* oldVersionObjectPath_{};
 		Visualization::VText* newVersionObjectPath_{};
+		Visualization::VText* singleObjectPath_{};
+
+		Visualization::Static* nodeNotFoundIcon_{};
 
 		Visualization::VText* componentType_{};
+
 		void scaleVisualizations();
 };
 

--- a/VersionControlUI/src/items/VDiffComparisonPair.h
+++ b/VersionControlUI/src/items/VDiffComparisonPair.h
@@ -54,7 +54,7 @@ class VERSIONCONTROLUI_API VDiffComparisonPair : public Super<Visualization::Ite
 		static void initializeForms();
 		virtual bool isSensitiveToScale() const override;
 		virtual void determineChildren() override;
-		int determineForm() override;
+		virtual int determineForm() override;
 
 	private:
 		Visualization::Item* oldVersionNode_{};

--- a/VersionControlUI/src/items/VDiffComparisonPair.h
+++ b/VersionControlUI/src/items/VDiffComparisonPair.h
@@ -51,12 +51,17 @@ class VERSIONCONTROLUI_API VDiffComparisonPair : public Super<Visualization::Ite
 	public:
 		VDiffComparisonPair(Visualization::Item* parent, NodeType* node, const StyleType* style = itemStyles().get());
 		static void initializeForms();
+		virtual bool isSensitiveToScale() const override;
+		virtual void determineChildren() override;
 
 	private:
 		Visualization::Item* oldVersionNode_{};
 		Visualization::Item* newVersionNode_{};
+
 		Visualization::VText* oldVersionObjectPath_{};
 		Visualization::VText* newVersionObjectPath_{};
+
+		Visualization::VText* componentType_{};
 };
 
 }

--- a/VersionControlUI/src/items/VDiffComparisonPairStyle.h
+++ b/VersionControlUI/src/items/VDiffComparisonPairStyle.h
@@ -41,5 +41,6 @@ class VERSIONCONTROLUI_API VDiffComparisonPairStyle : public Super<Visualization
 
 		Property<Visualization::TextStyle> oldVersionObjectPath{this, "oldVersionObjectPath"};
 		Property<Visualization::TextStyle> newVersionObjectPath{this, "newVersionObjectPath"};
+		Property<Visualization::TextStyle> componentType{this, "componentType"};
 };
 }

--- a/VersionControlUI/src/items/VDiffComparisonPairStyle.h
+++ b/VersionControlUI/src/items/VDiffComparisonPairStyle.h
@@ -30,6 +30,7 @@
 
 #include "VisualizationBase/src/declarative/DeclarativeItemBaseStyle.h"
 #include "VisualizationBase/src/items/TextStyle.h"
+#include "VisualizationBase/src/items/Static.h"
 
 namespace VersionControlUI
 {
@@ -41,6 +42,8 @@ class VERSIONCONTROLUI_API VDiffComparisonPairStyle : public Super<Visualization
 
 		Property<Visualization::TextStyle> oldVersionObjectPath{this, "oldVersionObjectPath"};
 		Property<Visualization::TextStyle> newVersionObjectPath{this, "newVersionObjectPath"};
+		Property<Visualization::TextStyle> singleObjectPath{this, "singleObjectPath"};
 		Property<Visualization::TextStyle> componentType{this, "componentType"};
+		Property<Visualization::StaticStyle> nodeNotFoundIcon{this, "nodeNotFoundIcon"};
 };
 }

--- a/VersionControlUI/src/nodes/DiffComparisonPair.cpp
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.cpp
@@ -37,31 +37,33 @@ DiffComparisonPair::DiffComparisonPair(Model::Node* oldVersionNode, Model::Node*
 	oldVersionNode_ = oldVersionNode;
 	newVersionNode_ = newVersionNode;
 
-	setUpObjectPath();
+	computeObjectPath();
 
-	setUpComponentType();
+	computeComponentName();
 
 }
 
-void DiffComparisonPair::setUpObjectPath()
+void DiffComparisonPair::computeObjectPath()
 {
-	QString oldVersionObjectPath = computeObjectPath(oldVersionNode_);
-	QString newVersionObjectPath = computeObjectPath(newVersionNode_);
+	auto oldVersionObjectPath = computeObjectPath(oldVersionNode_);
+	auto newVersionObjectPath = computeObjectPath(newVersionNode_);
+	auto componentName = computeComponentName();
+
 	if (oldVersionObjectPath == newVersionObjectPath)
 	{
-		singleObjectPath_ = new Model::Text{oldVersionObjectPath};
+		singleObjectPath_ = new Model::Text{oldVersionObjectPath+componentName};
 		twoObjectPathsDefined_ = false;
 	}
 	else if (oldVersionObjectPath == "" || newVersionObjectPath == "")
 	{
 		auto objectPath = oldVersionObjectPath == "" ? newVersionObjectPath : oldVersionObjectPath;
-		singleObjectPath_ = new Model::Text{objectPath};
+		singleObjectPath_ = new Model::Text{objectPath+componentName};
 		twoObjectPathsDefined_ = false;
 	}
 	else
 	{
-		oldVersionObjectPath_ = new Model::Text{oldVersionObjectPath};
-		newVersionObjectPath_ = new Model::Text{newVersionObjectPath};
+		oldVersionObjectPath_ = new Model::Text{oldVersionObjectPath+componentName};
+		newVersionObjectPath_ = new Model::Text{newVersionObjectPath+componentName};
 		twoObjectPathsDefined_ = true;
 	}
 }
@@ -81,10 +83,10 @@ QString DiffComparisonPair::computeObjectPath(Model::Node* node)
 	return objectPath;
 }
 
-void DiffComparisonPair::setUpComponentType()
+QString DiffComparisonPair::computeComponentName()
 {
 	Model::Node* nodeToComputeComponentType = nullptr;
-	QString componentType = "unknown";
+	QString componentName = "";
 
 	if (oldVersionNode_)
 		nodeToComputeComponentType = oldVersionNode_;
@@ -98,22 +100,16 @@ void DiffComparisonPair::setUpComponentType()
 
 	if (searchCompositeNode)
 	{
-		Model::CompositeNode* compositeNode = DCast<Model::CompositeNode>(searchCompositeNode);
-		if (compositeNode == nodeToComputeComponentType)
-		{
-			componentType = compositeNode->typeName();
-		} else
+		auto compositeNode = DCast<Model::CompositeNode>(searchCompositeNode);
+		if (compositeNode != nodeToComputeComponentType)
 		{
 			auto index = compositeNode->indexOf(nodeToComputeComponentType);
-			componentType = compositeNode->meta().attribute(index).name();
+			componentName = compositeNode->meta().attribute(index).name();
 		}
-
 	}
-	// TODO maybe first char of componentType toUpper?
-	componentType_ = new Model::Text{componentType};
+	return componentName;
 }
 
-// TODO force top constructor, is this right way? or remove macro which introduces the constructor?
 DiffComparisonPair::DiffComparisonPair(Model::Node *)
 	:Super{}
 {

--- a/VersionControlUI/src/nodes/DiffComparisonPair.cpp
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.cpp
@@ -25,14 +25,99 @@
  **********************************************************************************************************************/
 #include "DiffComparisonPair.h"
 
+#include "ModelBase/src/nodes/composite/CompositeNode.h"
+
 namespace VersionControlUI
 {
 
 DEFINE_NODE_TYPE_REGISTRATION_METHODS(DiffComparisonPair)
 
+DiffComparisonPair::DiffComparisonPair(Model::Node* oldVersionNode, Model::Node* newVersionNode) : Super{}
+{
+	oldVersionNode_ = oldVersionNode;
+	newVersionNode_ = newVersionNode;
+
+	setUpObjectPath();
+
+	setUpComponentType();
+
+}
+
+void DiffComparisonPair::setUpObjectPath()
+{
+	QString oldVersionObjectPath = computeObjectPath(oldVersionNode_);
+	QString newVersionObjectPath = computeObjectPath(newVersionNode_);
+	if (oldVersionObjectPath == newVersionObjectPath)
+	{
+		singleObjectPath_ = new Model::Text{oldVersionObjectPath};
+		twoObjectPathsDefined_ = false;
+	}
+	else if (oldVersionObjectPath == "" || newVersionObjectPath == "")
+	{
+		auto objectPath = oldVersionObjectPath == "" ? newVersionObjectPath : oldVersionObjectPath;
+		singleObjectPath_ = new Model::Text{objectPath};
+		twoObjectPathsDefined_ = false;
+	}
+	else
+	{
+		oldVersionObjectPath_ = new Model::Text{oldVersionObjectPath};
+		newVersionObjectPath_ = new Model::Text{newVersionObjectPath};
+		twoObjectPathsDefined_ = true;
+	}
+}
+
+QString DiffComparisonPair::computeObjectPath(Model::Node* node)
+{
+	if (!node) return "";
+	auto parent = node->parent();
+	QString objectPath = "";
+	while (parent)
+	{
+		if (parent->definesSymbol())
+			objectPath.prepend(parent->symbolName() + "/");
+		parent = parent->parent();
+	}
+
+	return objectPath;
+}
+
+void DiffComparisonPair::setUpComponentType()
+{
+	Model::Node* nodeToComputeComponentType = nullptr;
+	QString componentType = "unknown";
+
+	if (oldVersionNode_)
+		nodeToComputeComponentType = oldVersionNode_;
+	else
+		nodeToComputeComponentType = newVersionNode_;
+
+	auto searchCompositeNode = nodeToComputeComponentType;
+
+	while (searchCompositeNode && !DCast<Model::CompositeNode>(searchCompositeNode))
+		searchCompositeNode = searchCompositeNode->parent();
+
+	if (searchCompositeNode)
+	{
+		Model::CompositeNode* compositeNode = DCast<Model::CompositeNode>(searchCompositeNode);
+		if (compositeNode == nodeToComputeComponentType)
+		{
+			componentType = compositeNode->typeName();
+		} else
+		{
+			auto index = compositeNode->indexOf(nodeToComputeComponentType);
+			componentType = compositeNode->meta().attribute(index).name();
+		}
+
+	}
+	// TODO maybe first char of componentType toUpper?
+	componentType_ = new Model::Text{componentType};
+}
+
+// TODO force top constructor, is this right way? or remove macro which introduces the constructor?
 DiffComparisonPair::DiffComparisonPair(Model::Node *)
 	:Super{}
 {
+	Q_ASSERT(false);
 }
 
 DiffComparisonPair::DiffComparisonPair(Model::Node *, Model::PersistentStore &, bool)
@@ -47,5 +132,6 @@ QJsonValue DiffComparisonPair::toJson() const
 {
 	return QJsonValue{};
 }
+
 
 }

--- a/VersionControlUI/src/nodes/DiffComparisonPair.h
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.h
@@ -58,13 +58,11 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 
 			Model::Text* singleObjectPath();
 
-			Model::Text* componentType();
-
 			bool twoObjectPathsDefined();
 
 
 		private:
-			bool twoObjectPathsDefined_;
+			bool twoObjectPathsDefined_{};
 
 			Model::Node* oldVersionNode_{};
 			Model::Node* newVersionNode_{};
@@ -74,12 +72,9 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 
 			Model::Text* singleObjectPath_{};
 
-			Model::Text* componentType_{};
-
 			QString computeObjectPath(Model::Node* node);
-
-			void setUpComponentType();
-			void setUpObjectPath();
+			QString computeComponentName();
+			void computeObjectPath();
 };
 
 inline Model::Node* DiffComparisonPair::newVersionNode() {return newVersionNode_;}
@@ -89,8 +84,6 @@ inline Model::Text* DiffComparisonPair::newVersionObjectPath() {return newVersio
 inline Model::Text* DiffComparisonPair::oldVersionObjectPath() {return oldVersionObjectPath_;}
 
 inline Model::Text* DiffComparisonPair::singleObjectPath() {return singleObjectPath_;}
-
-inline Model::Text* DiffComparisonPair::componentType() {return componentType_;}
 
 inline bool DiffComparisonPair::twoObjectPathsDefined() {return twoObjectPathsDefined_;}
 

--- a/VersionControlUI/src/nodes/DiffComparisonPair.h
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.h
@@ -67,13 +67,14 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 
 
 		private:
-			Model::Node* oldVersionNode_;
-			Model::Node* newVersionNode_;
+			Model::Node* oldVersionNode_{};
+			Model::Node* newVersionNode_{};
 
-			Model::Text* newVersionObjectPath_;
-			Model::Text* oldVersionObjectPath_;
+			Model::Text* newVersionObjectPath_{};
+			Model::Text* oldVersionObjectPath_{};
 
-			Model::Text* componentType_;
+
+			Model::Text* componentType_{};
 
 
 };

--- a/VersionControlUI/src/nodes/DiffComparisonPair.h
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.h
@@ -52,6 +52,8 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 			void setNewVersionObjectPath(Model::Text* newVersionObjectPath);
 			void setOldVersionObjectPath(Model::Text* oldVersionObjectPath);
 
+			void setComponentType(Model::Text* componentType);
+
 
 			virtual QJsonValue toJson() const override;
 
@@ -61,27 +63,37 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 			Model::Text* newVersionObjectPath();
 			Model::Text* oldVersionObjectPath();
 
+			Model::Text* componentType();
+
 
 		private:
 			Model::Node* oldVersionNode_;
 			Model::Node* newVersionNode_;
+
 			Model::Text* newVersionObjectPath_;
 			Model::Text* oldVersionObjectPath_;
+
+			Model::Text* componentType_;
 
 
 };
 
 inline void DiffComparisonPair::setOldVersionNode(Model::Node* oldVersionNode) {oldVersionNode_ = oldVersionNode;}
 inline void DiffComparisonPair::setNewVersionNode(Model::Node* newVersionNode) {newVersionNode_ = newVersionNode;}
+
 inline void DiffComparisonPair::setNewVersionObjectPath(Model::Text* newVersionObjectPath)
 {newVersionObjectPath_ = newVersionObjectPath;}
 inline void DiffComparisonPair::setOldVersionObjectPath(Model::Text* oldVersionObjectPath)
 {oldVersionObjectPath_ = oldVersionObjectPath;}
 
+inline void DiffComparisonPair::setComponentType(Model::Text* componentType) {componentType_ = componentType; }
 
 inline Model::Node* DiffComparisonPair::newVersionNode() {return newVersionNode_;}
 inline Model::Node* DiffComparisonPair::oldVersionNode() {return oldVersionNode_;}
+
 inline Model::Text* DiffComparisonPair::newVersionObjectPath() {return newVersionObjectPath_;}
 inline Model::Text* DiffComparisonPair::oldVersionObjectPath() {return oldVersionObjectPath_;}
+
+inline Model::Text* DiffComparisonPair::componentType() {return componentType_;}
 
 }

--- a/VersionControlUI/src/nodes/DiffComparisonPair.h
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.h
@@ -46,14 +46,7 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 		NODE_DECLARE_STANDARD_METHODS(DiffComparisonPair)
 
 		public:
-			void setOldVersionNode(Model::Node* oldVersionNode);
-			void setNewVersionNode(Model::Node* newVersionNode);
-
-			void setNewVersionObjectPath(Model::Text* newVersionObjectPath);
-			void setOldVersionObjectPath(Model::Text* oldVersionObjectPath);
-
-			void setComponentType(Model::Text* componentType);
-
+			DiffComparisonPair(Model::Node* oldVersionNode, Model::Node* newVersionNode);
 
 			virtual QJsonValue toJson() const override;
 
@@ -63,31 +56,31 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 			Model::Text* newVersionObjectPath();
 			Model::Text* oldVersionObjectPath();
 
+			Model::Text* singleObjectPath();
+
 			Model::Text* componentType();
+
+			bool twoObjectPathsDefined();
 
 
 		private:
+			bool twoObjectPathsDefined_;
+
 			Model::Node* oldVersionNode_{};
 			Model::Node* newVersionNode_{};
 
 			Model::Text* newVersionObjectPath_{};
 			Model::Text* oldVersionObjectPath_{};
 
+			Model::Text* singleObjectPath_{};
 
 			Model::Text* componentType_{};
 
+			QString computeObjectPath(Model::Node* node);
 
+			void setUpComponentType();
+			void setUpObjectPath();
 };
-
-inline void DiffComparisonPair::setOldVersionNode(Model::Node* oldVersionNode) {oldVersionNode_ = oldVersionNode;}
-inline void DiffComparisonPair::setNewVersionNode(Model::Node* newVersionNode) {newVersionNode_ = newVersionNode;}
-
-inline void DiffComparisonPair::setNewVersionObjectPath(Model::Text* newVersionObjectPath)
-{newVersionObjectPath_ = newVersionObjectPath;}
-inline void DiffComparisonPair::setOldVersionObjectPath(Model::Text* oldVersionObjectPath)
-{oldVersionObjectPath_ = oldVersionObjectPath;}
-
-inline void DiffComparisonPair::setComponentType(Model::Text* componentType) {componentType_ = componentType; }
 
 inline Model::Node* DiffComparisonPair::newVersionNode() {return newVersionNode_;}
 inline Model::Node* DiffComparisonPair::oldVersionNode() {return oldVersionNode_;}
@@ -95,6 +88,10 @@ inline Model::Node* DiffComparisonPair::oldVersionNode() {return oldVersionNode_
 inline Model::Text* DiffComparisonPair::newVersionObjectPath() {return newVersionObjectPath_;}
 inline Model::Text* DiffComparisonPair::oldVersionObjectPath() {return oldVersionObjectPath_;}
 
+inline Model::Text* DiffComparisonPair::singleObjectPath() {return singleObjectPath_;}
+
 inline Model::Text* DiffComparisonPair::componentType() {return componentType_;}
+
+inline bool DiffComparisonPair::twoObjectPathsDefined() {return twoObjectPathsDefined_;}
 
 }

--- a/VersionControlUI/styles/item/VDiffComparisonPair/default
+++ b/VersionControlUI/styles/item/VDiffComparisonPair/default
@@ -12,52 +12,11 @@
 			<color>#e6e6e6</color>
 		</outline>
 	</shape>
-	<oldVersionObjectPath prototypes="item/Text/default">
-		<pen>
-			<style>1</style>
-			<color>#000000</color>
-		</pen>
-		<font>
-			<size>15</size>
-			<weight>75</weight>
-			<style>0</style>
-			<underline>false</underline>
-		</font>
-	</oldVersionObjectPath>
-	<newVersionObjectPath prototypes="item/Text/default">
-		<pen>
-			<style>1</style>
-			<color>#000000</color>
-		</pen>
-		<font>
-			<size>15</size>
-			<weight>30</weight>
-			<style>0</style>
-			<underline>false</underline>
-		</font>
-	</newVersionObjectPath>
-	<singleObjectPath prototypes="item/Text/default">
-		<pen>
-			<style>1</style>
-			<color>#000000</color>
-		</pen>
-		<font>
-			<size>15</size>
-			<weight>30</weight>
-			<style>0</style>
-			<underline>false</underline>
-		</font>
-	</singleObjectPath>
-	<componentType prototypes="item/Text/default">
-		<pen>
-			<style>1</style>
-			<color>#000000</color>
-		</pen>
-		<font>
-			<size>15</size>
-			<weight>30</weight>
-			<style>0</style>
-			<underline>false</underline>
-		</font>
-	</componentType>
+	<oldVersionObjectPath prototypes="text" />
+	<newVersionObjectPath prototypes="text" />
+	<singleObjectPath prototypes="text" />
+	<componentType prototypes="text" />
+	<nodeNotFoundIcon prototypes="item/Symbol/keyword">
+		<symbol>no node</symbol>
+	</nodeNotFoundIcon>
 </style>

--- a/VersionControlUI/styles/item/VDiffComparisonPair/default
+++ b/VersionControlUI/styles/item/VDiffComparisonPair/default
@@ -12,40 +12,52 @@
 			<color>#e6e6e6</color>
 		</outline>
 	</shape>
-<oldVersionObjectPath prototypes="item/Text/default">
-	<pen>
-		<style>1</style>
-		<color>#000000</color>
-	</pen>
-	<font>
-		<size>15</size>
-		<weight>75</weight>
-		<style>0</style>
-		<underline>false</underline>
-	</font>
-</oldVersionObjectPath>
-<newVersionObjectPath prototypes="item/Text/default">
-	<pen>
-		<style>1</style>
-		<color>#000000</color>
-	</pen>
-	<font>
-		<size>15</size>
-		<weight>30</weight>
-		<style>0</style>
-		<underline>false</underline>
-	</font>
-</newVersionObjectPath>
-<componentType prototypes="item/Text/default">
-	<pen>
-		<style>1</style>
-		<color>#000000</color>
-	</pen>
-	<font>
-		<size>15</size>
-		<weight>30</weight>
-		<style>0</style>
-		<underline>false</underline>
-	</font>
-</componentType>
+	<oldVersionObjectPath prototypes="item/Text/default">
+		<pen>
+			<style>1</style>
+			<color>#000000</color>
+		</pen>
+		<font>
+			<size>15</size>
+			<weight>75</weight>
+			<style>0</style>
+			<underline>false</underline>
+		</font>
+	</oldVersionObjectPath>
+	<newVersionObjectPath prototypes="item/Text/default">
+		<pen>
+			<style>1</style>
+			<color>#000000</color>
+		</pen>
+		<font>
+			<size>15</size>
+			<weight>30</weight>
+			<style>0</style>
+			<underline>false</underline>
+		</font>
+	</newVersionObjectPath>
+	<singleObjectPath prototypes="item/Text/default">
+		<pen>
+			<style>1</style>
+			<color>#000000</color>
+		</pen>
+		<font>
+			<size>15</size>
+			<weight>30</weight>
+			<style>0</style>
+			<underline>false</underline>
+		</font>
+	</singleObjectPath>
+	<componentType prototypes="item/Text/default">
+		<pen>
+			<style>1</style>
+			<color>#000000</color>
+		</pen>
+		<font>
+			<size>15</size>
+			<weight>30</weight>
+			<style>0</style>
+			<underline>false</underline>
+		</font>
+	</componentType>
 </style>

--- a/VersionControlUI/styles/item/VDiffComparisonPair/default
+++ b/VersionControlUI/styles/item/VDiffComparisonPair/default
@@ -2,23 +2,50 @@
 <style prototypes="item/DeclarativeItemBase/default">
 	<shape prototypes="shape/Box/default">
 		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#e6e6e6</color>
+		</backgroundBrush>
 		<outline>
 			<width>10.0</width>
 			<style>1</style>
-			<color>#ff000000</color>
+			<color>#e6e6e6</color>
 		</outline>
 	</shape>
 <oldVersionObjectPath prototypes="item/Text/default">
 	<pen>
 		<style>1</style>
-		<color>#0000ff</color>
+		<color>#000000</color>
 	</pen>
 	<font>
 		<size>15</size>
 		<weight>75</weight>
 		<style>0</style>
-		<underline>true</underline>
+		<underline>false</underline>
 	</font>
 </oldVersionObjectPath>
-<newVersionObjectPath prototypes="item/Text/default" />
+<newVersionObjectPath prototypes="item/Text/default">
+	<pen>
+		<style>1</style>
+		<color>#000000</color>
+	</pen>
+	<font>
+		<size>15</size>
+		<weight>30</weight>
+		<style>0</style>
+		<underline>false</underline>
+	</font>
+</newVersionObjectPath>
+<componentType prototypes="item/Text/default">
+	<pen>
+		<style>1</style>
+		<color>#000000</color>
+	</pen>
+	<font>
+		<size>15</size>
+		<weight>30</weight>
+		<style>0</style>
+		<underline>false</underline>
+	</font>
+</componentType>
 </style>

--- a/VersionControlUI/styles/item/VDiffComparisonPair/text
+++ b/VersionControlUI/styles/item/VDiffComparisonPair/text
@@ -1,0 +1,12 @@
+<style prototypes="item/Text/default">
+	<pen>
+		<style>1</style>
+		<color>#000000</color>
+	</pen>
+	<font>
+		<size>15</size>
+		<weight>75</weight>
+		<style>0</style>
+		<underline>false</underline>
+	</font>
+</style>

--- a/VisualizationBase/src/ViewItemManager.cpp
+++ b/VisualizationBase/src/ViewItemManager.cpp
@@ -135,6 +135,24 @@ void ViewItemManager::removeAllViewItems()
 	currentViewItem_ = nullptr;
 }
 
+
+void ViewItemManager::removeViewItem(ViewItem* view)
+{
+	for (auto& vector : viewItems_)
+	{
+		auto iter = vector.begin();
+		while (iter != vector.end())
+		{
+			if (*iter == view)
+			{
+				vector.erase(iter);
+				return;
+			}
+			iter++;
+		}
+	}
+}
+
 void ViewItemManager::saveView(ViewItem* view, Model::TreeManager* manager) const
 {
 	auto json = view->toJson().toJson();

--- a/VisualizationBase/src/ViewItemManager.cpp
+++ b/VisualizationBase/src/ViewItemManager.cpp
@@ -145,6 +145,7 @@ void ViewItemManager::removeViewItem(ViewItem* view)
 		{
 			if (*iter == view)
 			{
+				scene_->removeTopLevelItem(*iter);
 				vector.erase(iter);
 				return;
 			}

--- a/VisualizationBase/src/ViewItemManager.h
+++ b/VisualizationBase/src/ViewItemManager.h
@@ -82,6 +82,10 @@ class VISUALIZATIONBASE_API ViewItemManager
 		 * Removes all existing ViewItems from the manager.
 		 */
 		void removeAllViewItems();
+		/**
+		 * Removes \a view from the manager.
+		 */
+		void removeViewItem(ViewItem* view);
 
 		/**
 		 * Saves the given view persistently on disk, using the given manager.

--- a/VisualizationBase/src/items/ViewItem.cpp
+++ b/VisualizationBase/src/items/ViewItem.cpp
@@ -49,7 +49,6 @@ ViewItem::ViewItem(Item* parent, QString name, StyleType* style) :
 		Super{parent, style}, name_{name}
 {
 	Q_ASSERT(isValidName(name));
-	zoomLabelsEnabled_ = true;
 }
 
 void ViewItem::initializeForms()

--- a/VisualizationBase/src/items/ViewItem.cpp
+++ b/VisualizationBase/src/items/ViewItem.cpp
@@ -49,6 +49,7 @@ ViewItem::ViewItem(Item* parent, QString name, StyleType* style) :
 		Super{parent, style}, name_{name}
 {
 	Q_ASSERT(isValidName(name));
+	zoomLabelsEnabled_ = true;
 }
 
 void ViewItem::initializeForms()

--- a/VisualizationBase/src/items/ViewItem.h
+++ b/VisualizationBase/src/items/ViewItem.h
@@ -177,7 +177,7 @@ class VISUALIZATIONBASE_API ViewItem : public Super<DeclarativeItem<ViewItem>> {
 
 		QVector<QVector<Model::Node*>> nodesGetter();
 
-		bool zoomLabelsEnabled_{};
+		bool zoomLabelsEnabled_{true};
 };
 
 inline const QString& ViewItem::name() const { return name_; }

--- a/VisualizationBase/src/items/ViewItem.h
+++ b/VisualizationBase/src/items/ViewItem.h
@@ -135,6 +135,10 @@ class VISUALIZATIONBASE_API ViewItem : public Super<DeclarativeItem<ViewItem>> {
 
 		virtual void determineChildren() override;
 		virtual void updateGeometry(int availableWidth, int availableHeight) override;
+
+		bool zoomLabelsEnabled();
+		void setZoomLabelsEnabled(bool zoomLabelsEnabled);
+
 	private:
 		friend class ViewItemManager;
 		/**
@@ -172,9 +176,12 @@ class VISUALIZATIONBASE_API ViewItem : public Super<DeclarativeItem<ViewItem>> {
 		void ensureColumnExists(int column);
 
 		QVector<QVector<Model::Node*>> nodesGetter();
+
+		bool zoomLabelsEnabled_{};
 };
 
 inline const QString& ViewItem::name() const { return name_; }
 inline QString ViewItem::fullLayerName(const QString& localLayer) const { return name() + "_" + localLayer; }
-
+inline bool ViewItem::zoomLabelsEnabled() { return zoomLabelsEnabled_;}
+inline void ViewItem::setZoomLabelsEnabled(bool zoomLabelsEnabled) {zoomLabelsEnabled_ = zoomLabelsEnabled;}
 }

--- a/VisualizationBase/src/overlays/ArrowOverlay.cpp
+++ b/VisualizationBase/src/overlays/ArrowOverlay.cpp
@@ -26,6 +26,7 @@
 
 #include "ArrowOverlay.h"
 #include "../utils/Drawing.h"
+#include "../VisualizationManager.h"
 
 namespace Visualization {
 
@@ -34,12 +35,28 @@ DEFINE_ITEM_COMMON(ArrowOverlay, "item")
 ArrowOverlay::ArrowOverlay(Item* arrowFrom, Item* arrowTo, const StyleType* style)
 	: Super{{arrowFrom, arrowTo}, style}
 {
+	setAcceptHoverEvents(true);
+	activateDefaultArrowStyle();
+}
+
+void ArrowOverlay::activateDefaultArrowStyle()
+{
+	currentArrowBrush_ = this->style()->arrowBrush();
+	currentArrowPen_ = this->style()->linePen();
+	currentArrowWidth_ = this->style()->width();
+}
+
+void ArrowOverlay::activateSelectedArrowStyle()
+{
+	currentArrowBrush_ = this->style()->selectedArrowBrush();
+	currentArrowPen_ = this->style()->selectedLinePen();
+	currentArrowWidth_ = this->style()->selectedWidth();
 }
 
 void ArrowOverlay::paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *)
 {
-	Drawing::drawArrow(painter, lineFrom_, lineTo_, style()->arrowBrush(), style()->linePen(),
-						invertArrow_, !invertArrow_, style()->width());
+	currentArrowOutline_ = Drawing::drawArrow(painter, lineFrom_, lineTo_, currentArrowBrush_, currentArrowPen_,
+						invertArrow_, !invertArrow_, currentArrowWidth_);
 }
 
 void ArrowOverlay::determineChildren(){}
@@ -77,6 +94,24 @@ void ArrowOverlay::updateGeometry(int, int)
 						first->scenePos().y() + first->heightInScene() / 2 - leftTopCorner.y()}.toPoint();
 	lineTo_ = QPointF{second->scenePos().x() - leftTopCorner.x(),
 					 second->scenePos().y() + second->heightInScene() / 2 - leftTopCorner.y()}.toPoint();
+}
+
+void ArrowOverlay::hoverEnterEvent(QGraphicsSceneHoverEvent *) {
+	activateSelectedArrowStyle();
+	setUpdateNeeded(StandardUpdate);
+}
+
+void ArrowOverlay::hoverLeaveEvent(QGraphicsSceneHoverEvent *) {
+	activateDefaultArrowStyle();
+	setUpdateNeeded(StandardUpdate);
+}
+
+
+QPainterPath ArrowOverlay::shape() const
+{
+	QPainterPath painterPath;
+	painterPath.addPolygon(currentArrowOutline_);
+	return painterPath;
 }
 
 }

--- a/VisualizationBase/src/overlays/ArrowOverlay.cpp
+++ b/VisualizationBase/src/overlays/ArrowOverlay.cpp
@@ -36,27 +36,19 @@ ArrowOverlay::ArrowOverlay(Item* arrowFrom, Item* arrowTo, const StyleType* styl
 	: Super{{arrowFrom, arrowTo}, style}
 {
 	setAcceptHoverEvents(true);
-	activateDefaultArrowStyle();
-}
-
-void ArrowOverlay::activateDefaultArrowStyle()
-{
-	currentArrowBrush_ = this->style()->arrowBrush();
-	currentArrowPen_ = this->style()->linePen();
-	currentArrowWidth_ = this->style()->width();
-}
-
-void ArrowOverlay::activateSelectedArrowStyle()
-{
-	currentArrowBrush_ = this->style()->selectedArrowBrush();
-	currentArrowPen_ = this->style()->selectedLinePen();
-	currentArrowWidth_ = this->style()->selectedWidth();
+	selected_ = false;
 }
 
 void ArrowOverlay::paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *)
 {
-	currentArrowOutline_ = Drawing::drawArrow(painter, lineFrom_, lineTo_, currentArrowBrush_, currentArrowPen_,
-						invertArrow_, !invertArrow_, currentArrowWidth_);
+	if (selected_)
+		currentArrowOutline_ = Drawing::drawArrow(painter, lineFrom_, lineTo_, style()->selectedArrowBrush(),
+																style()->selectedLinePen(), invertArrow_, !invertArrow_,
+																style()->selectedWidth());
+	else
+		currentArrowOutline_ = Drawing::drawArrow(painter, lineFrom_, lineTo_, style()->arrowBrush(),
+																style()->linePen(), invertArrow_, !invertArrow_,
+																style()->width());
 }
 
 void ArrowOverlay::determineChildren(){}
@@ -95,17 +87,6 @@ void ArrowOverlay::updateGeometry(int, int)
 	lineTo_ = QPointF{second->scenePos().x() - leftTopCorner.x(),
 					 second->scenePos().y() + second->heightInScene() / 2 - leftTopCorner.y()}.toPoint();
 }
-
-void ArrowOverlay::hoverEnterEvent(QGraphicsSceneHoverEvent *) {
-	activateSelectedArrowStyle();
-	setUpdateNeeded(StandardUpdate);
-}
-
-void ArrowOverlay::hoverLeaveEvent(QGraphicsSceneHoverEvent *) {
-	activateDefaultArrowStyle();
-	setUpdateNeeded(StandardUpdate);
-}
-
 
 QPainterPath ArrowOverlay::shape() const
 {

--- a/VisualizationBase/src/overlays/ArrowOverlay.cpp
+++ b/VisualizationBase/src/overlays/ArrowOverlay.cpp
@@ -41,9 +41,9 @@ ArrowOverlay::ArrowOverlay(Item* arrowFrom, Item* arrowTo, const StyleType* styl
 void ArrowOverlay::paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *)
 {
 	if (highlighted_)
-		currentArrowOutline_ = Drawing::drawArrow(painter, lineFrom_, lineTo_, style()->selectedArrowBrush(),
-																style()->selectedLinePen(), invertArrow_, !invertArrow_,
-																style()->selectedWidth());
+		currentArrowOutline_ = Drawing::drawArrow(painter, lineFrom_, lineTo_, style()->highlightedArrowBrush(),
+																style()->highlightedLinePen(), invertArrow_, !invertArrow_,
+																style()->highlightedWidth());
 	else
 		currentArrowOutline_ = Drawing::drawArrow(painter, lineFrom_, lineTo_, style()->arrowBrush(),
 																style()->linePen(), invertArrow_, !invertArrow_,

--- a/VisualizationBase/src/overlays/ArrowOverlay.cpp
+++ b/VisualizationBase/src/overlays/ArrowOverlay.cpp
@@ -50,15 +50,16 @@ void ArrowOverlay::updateGeometry(int, int)
 	//Find the space the line will occupy in the scene
 	auto first = firstAssociatedItem();
 	auto second = secondAssociatedItem();
+
 	auto leftTopCorner = QPointF{
-				std::min(first->scenePos().x() + first->widthInLocal(),
-							second->scenePos().x() + second->widthInLocal()),
-				std::min(first->scenePos().y() + first->heightInLocal() / 2,
-							second->scenePos().y() + second->heightInLocal() / 2)}.toPoint();
+				std::min(first->scenePos().x() + first->widthInScene(),
+							second->scenePos().x() + second->widthInScene()),
+				std::min(first->scenePos().y() + first->heightInScene() / 2,
+							second->scenePos().y() + second->heightInScene() / 2)}.toPoint();
 	auto rightBottomCorner = QPointF{
 				std::max(first->scenePos().x(), second->scenePos().x()),
-				std::max(first->scenePos().y() + first->heightInLocal() / 2,
-							second->scenePos().y() + second->heightInLocal() / 2)}.toPoint();
+				std::max(first->scenePos().y() + first->heightInScene() / 2,
+							second->scenePos().y() + second->heightInScene() / 2)}.toPoint();
 
 	setPos(leftTopCorner.x(), leftTopCorner.y());
 	setSize(rightBottomCorner.x() - leftTopCorner.x(),
@@ -72,10 +73,10 @@ void ArrowOverlay::updateGeometry(int, int)
 		first = temp;
 		invertArrow_ = true;
 	}
-	lineFrom_ = QPointF{first->scenePos().x() + first->widthInLocal() - leftTopCorner.x(),
-						first->scenePos().y() + first->heightInLocal() / 2 - leftTopCorner.y()}.toPoint();
+	lineFrom_ = QPointF{first->scenePos().x() + first->widthInScene() - leftTopCorner.x(),
+						first->scenePos().y() + first->heightInScene() / 2 - leftTopCorner.y()}.toPoint();
 	lineTo_ = QPointF{second->scenePos().x() - leftTopCorner.x(),
-					 second->scenePos().y() + second->heightInLocal() / 2 - leftTopCorner.y()}.toPoint();
+					 second->scenePos().y() + second->heightInScene() / 2 - leftTopCorner.y()}.toPoint();
 }
 
 }

--- a/VisualizationBase/src/overlays/ArrowOverlay.cpp
+++ b/VisualizationBase/src/overlays/ArrowOverlay.cpp
@@ -36,12 +36,11 @@ ArrowOverlay::ArrowOverlay(Item* arrowFrom, Item* arrowTo, const StyleType* styl
 	: Super{{arrowFrom, arrowTo}, style}
 {
 	setAcceptHoverEvents(true);
-	selected_ = false;
 }
 
 void ArrowOverlay::paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *)
 {
-	if (selected_)
+	if (highlighted_)
 		currentArrowOutline_ = Drawing::drawArrow(painter, lineFrom_, lineTo_, style()->selectedArrowBrush(),
 																style()->selectedLinePen(), invertArrow_, !invertArrow_,
 																style()->selectedWidth());

--- a/VisualizationBase/src/overlays/ArrowOverlay.h
+++ b/VisualizationBase/src/overlays/ArrowOverlay.h
@@ -43,7 +43,7 @@ class VISUALIZATIONBASE_API ArrowOverlay: public Super<Overlay<Item>>
 	public:
 		ArrowOverlay(Item* arrowFrom, Item* arrowTo, const StyleType* style = itemStyles().get());
 		virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
-		void setHighlighted(bool selected);
+		void setHighlighted(bool highlighted);
 
 	protected:
 		virtual void determineChildren() override;

--- a/VisualizationBase/src/overlays/ArrowOverlay.h
+++ b/VisualizationBase/src/overlays/ArrowOverlay.h
@@ -47,11 +47,22 @@ class VISUALIZATIONBASE_API ArrowOverlay: public Super<Overlay<Item>>
 	protected:
 		virtual void determineChildren() override;
 		virtual void updateGeometry(int availableWidth, int availableHeight) override;
+		virtual void hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+		virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
+		virtual QPainterPath shape() const override;
 
 	private:
 		QPoint lineFrom_{};
 		QPoint lineTo_{};
 		bool invertArrow_{};
+		QBrush currentArrowBrush_{};
+		QPen currentArrowPen_{};
+		int currentArrowWidth_{};
+		QPolygonF currentArrowOutline_{};
+
+		void activateDefaultArrowStyle();
+		void activateSelectedArrowStyle();
+
 };
 
 }

--- a/VisualizationBase/src/overlays/ArrowOverlay.h
+++ b/VisualizationBase/src/overlays/ArrowOverlay.h
@@ -43,7 +43,7 @@ class VISUALIZATIONBASE_API ArrowOverlay: public Super<Overlay<Item>>
 	public:
 		ArrowOverlay(Item* arrowFrom, Item* arrowTo, const StyleType* style = itemStyles().get());
 		virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
-		void setSelected(bool selected);
+		void setHighlighted(bool selected);
 
 	protected:
 		virtual void determineChildren() override;
@@ -54,11 +54,11 @@ class VISUALIZATIONBASE_API ArrowOverlay: public Super<Overlay<Item>>
 		QPoint lineFrom_{};
 		QPoint lineTo_{};
 		bool invertArrow_{};
-		bool selected_{};
+		bool highlighted_{false};
 		QPolygonF currentArrowOutline_{};
 
 };
 
-inline void ArrowOverlay::setSelected(bool selected) {selected_ = selected;}
+inline void ArrowOverlay::setHighlighted(bool highlighted) {highlighted_ = highlighted;}
 
 }

--- a/VisualizationBase/src/overlays/ArrowOverlayStyle.h
+++ b/VisualizationBase/src/overlays/ArrowOverlayStyle.h
@@ -40,6 +40,9 @@ class VISUALIZATIONBASE_API ArrowOverlayStyle : public Super<ItemStyle>
 		Property<QPen> linePen{this, "linePen"};
 		Property<QBrush> arrowBrush{this, "arrowBrush"};
 		Property<int> width{this, "width"};
+		Property<QPen> selectedLinePen{this, "selectedLinePen"};
+		Property<QBrush> selectedArrowBrush{this, "selectedArrowBrush"};
+		Property<int> selectedWidth{this, "selectedWidth"};
 };
 
 }

--- a/VisualizationBase/src/overlays/ArrowOverlayStyle.h
+++ b/VisualizationBase/src/overlays/ArrowOverlayStyle.h
@@ -40,9 +40,9 @@ class VISUALIZATIONBASE_API ArrowOverlayStyle : public Super<ItemStyle>
 		Property<QPen> linePen{this, "linePen"};
 		Property<QBrush> arrowBrush{this, "arrowBrush"};
 		Property<int> width{this, "width"};
-		Property<QPen> selectedLinePen{this, "selectedLinePen"};
-		Property<QBrush> selectedArrowBrush{this, "selectedArrowBrush"};
-		Property<int> selectedWidth{this, "selectedWidth"};
+		Property<QPen> highlightedLinePen{this, "highlightedLinePen"};
+		Property<QBrush> highlightedArrowBrush{this, "highlightedArrowBrush"};
+		Property<int> highlightedWidth{this, "highlightedWidth"};
 };
 
 }

--- a/VisualizationBase/src/overlays/Overlay.h
+++ b/VisualizationBase/src/overlays/Overlay.h
@@ -70,7 +70,7 @@ inline Overlay<Super>::Overlay(QList<Item*> associatedItems, const typename Supe
 	Q_ASSERT(!associatedItems_.isEmpty());
 
 	Super::setFlags(0);
-	Super::setAcceptedMouseButtons(0);
+	Super::setAcceptedMouseButtons(Qt::NoButton);
 	Super::setZValue(Super::LAYER_OVERLAY_Z);
 	Super::setItemCategory(Scene::SelectionItemCategory);
 }

--- a/VisualizationBase/src/overlays/ZoomLabelOverlay.cpp
+++ b/VisualizationBase/src/overlays/ZoomLabelOverlay.cpp
@@ -36,6 +36,9 @@
 #include "OverlayAccessor.h"
 #include "../views/MainView.h"
 
+#include "VisualizationBase/src/VisualizationManager.h"
+#include "VisualizationBase/src/items/ViewItem.h"
+
 namespace Visualization {
 
 DEFINE_ITEM_COMMON(ZoomLabelOverlay, "item")
@@ -132,6 +135,11 @@ const TextStyle* ZoomLabelOverlay::associatedItemTextStyle() const
 
 QList<Item*> ZoomLabelOverlay::itemsThatShouldHaveZoomLabel(Scene* scene)
 {
+	// TODO at the moment only one viewItem is used for diffs, maybe changes in future
+	// disable zoom labels for diff views
+	if (Visualization::VisualizationManager::instance().mainScene()->currentViewItem()->name().contains("DiffView"))
+		return {};
+
 	QList<Item*> result;
 
 	const double OVERLAY_SCALE_TRESHOLD = 0.5;

--- a/VisualizationBase/src/overlays/ZoomLabelOverlay.cpp
+++ b/VisualizationBase/src/overlays/ZoomLabelOverlay.cpp
@@ -135,9 +135,8 @@ const TextStyle* ZoomLabelOverlay::associatedItemTextStyle() const
 
 QList<Item*> ZoomLabelOverlay::itemsThatShouldHaveZoomLabel(Scene* scene)
 {
-	// TODO at the moment only one viewItem is used for diffs, maybe changes in future
-	// disable zoom labels for diff views
-	if (Visualization::VisualizationManager::instance().mainScene()->currentViewItem()->name().contains("DiffView"))
+	// disable zoom labels if wished by view item
+	if (!Visualization::VisualizationManager::instance().mainScene()->currentViewItem()->zoomLabelsEnabled())
 		return {};
 
 	QList<Item*> result;

--- a/VisualizationBase/src/utils/Drawing.cpp
+++ b/VisualizationBase/src/utils/Drawing.cpp
@@ -25,8 +25,26 @@
 ***********************************************************************************************************************/
 #include "Drawing.h"
 
-void Drawing::drawArrow(QPainter* painter, QPointF begin, QPointF end, const QBrush& arrowBrush, const QPen& linePen,
-						bool startArrow, bool endArrow, int outlineSize)
+QPolygonF Drawing::arrowSelectionPolygon(double angle, QPointF begin, QPointF end)
+{
+
+	const int selectionWidth = 20;
+	QPolygonF arrowSeletionOutline;
+	qreal radAngle = angle* M_PI / 180;
+	qreal xDistance = selectionWidth * sin(radAngle);
+	qreal yDistance = selectionWidth * cos(radAngle);
+	QPointF posOffset = QPointF(xDistance, yDistance);
+	QPointF negOffset = QPointF(-xDistance, -yDistance);
+	arrowSeletionOutline << begin + posOffset
+								<< begin + negOffset
+								<< end + negOffset
+								<< end + posOffset;
+
+	return arrowSeletionOutline;
+}
+
+QPolygonF Drawing::drawArrow(QPainter* painter, QPointF begin, QPointF end, const QBrush& arrowBrush,
+									  const QPen& linePen, bool startArrow, bool endArrow, int outlineSize)
 {
 	painter->setBrush(arrowBrush);
 	painter->setPen(Qt::NoPen);
@@ -52,6 +70,10 @@ void Drawing::drawArrow(QPainter* painter, QPointF begin, QPointF end, const QBr
 
 	painter->setPen(linePen);
 	painter->drawLine(begin, end);
+
+	QPolygonF arrowSeletionOutline = arrowSelectionPolygon(-angle, end, begin);
+
+	return arrowSeletionOutline;
 }
 
 QPointF Drawing::drawHead(QPainter *painter, QMatrix matrix, QPolygonF arrowHead, QPointF beginOrEnd, double angle)

--- a/VisualizationBase/src/utils/Drawing.h
+++ b/VisualizationBase/src/utils/Drawing.h
@@ -42,9 +42,10 @@ class VISUALIZATIONBASE_API Drawing
 		 * @param endArrow Is there an arrow to the end point?
 		 * @param outlineSize The size of the arrow head
 		 */
-		static void drawArrow(QPainter* painter, QPointF begin, QPointF end, const QBrush& arrowBrush,
+		static QPolygonF drawArrow(QPainter* painter, QPointF begin, QPointF end, const QBrush& arrowBrush,
 									 const QPen& linePen,  bool startArrow, bool endArrow, int outlineSize);
 
 	private:
 		static QPointF drawHead(QPainter* painter, QMatrix matrix, QPolygonF arrowHead, QPointF beginOrEnd, double angle);
+		static QPolygonF arrowSelectionPolygon(double angle, QPointF end, QPointF begin);
 };

--- a/VisualizationBase/src/views/MainView.cpp
+++ b/VisualizationBase/src/views/MainView.cpp
@@ -128,8 +128,7 @@ void MainView::wheelEvent(QWheelEvent *event)
 			auto itemsAtEvent = items(event->pos());
 			auto iter = itemsAtEvent.begin();
 			// avoid zooming in on Overlays
-			// TODO cast *iter to Item to use DCast or is this fine?
-			while (iter != itemsAtEvent.end() && dynamic_cast<Overlay<Item>*>(*iter)) iter++;
+			while (iter != itemsAtEvent.end() && (*iter)->acceptedMouseButtons() == 0) iter++;
 			if (iter != itemsAtEvent.end())
 			{
 				itemUnderCursor = *iter;

--- a/VisualizationBase/src/views/MainView.cpp
+++ b/VisualizationBase/src/views/MainView.cpp
@@ -30,9 +30,6 @@
 #include "../items/Item.h"
 #include "../VisualizationBasePlugin.h"
 #include "../VisualizationManager.h"
-#include "../overlays/Overlay.h"
-#include "../overlays/HighlightOverlay.h"
-#include "../overlays/ArrowOverlay.h"
 
 #include "Logger/src/Timer.h"
 #include "Logger/src/Log.h"
@@ -128,7 +125,7 @@ void MainView::wheelEvent(QWheelEvent *event)
 			auto itemsAtEvent = items(event->pos());
 			auto iter = itemsAtEvent.begin();
 			// avoid zooming in on Overlays
-			while (iter != itemsAtEvent.end() && (*iter)->acceptedMouseButtons() == 0) iter++;
+			while (iter != itemsAtEvent.end() && (*iter)->acceptedMouseButtons() == Qt::NoButton) iter++;
 			if (iter != itemsAtEvent.end())
 			{
 				itemUnderCursor = *iter;

--- a/VisualizationBase/src/views/MainView.cpp
+++ b/VisualizationBase/src/views/MainView.cpp
@@ -37,7 +37,7 @@
 namespace Visualization {
 
 MainView::MainView(Scene *scene) :
-	View(scene, nullptr), miniMap{new MiniMap{scene, this}}, scaleLevel{SCALING_FACTOR}
+	View(scene, nullptr), miniMap{new MiniMap{scene, this}}, scaleLevel_{SCALING_FACTOR}
 {
 	setRenderHint(QPainter::Antialiasing);
 	setRenderHint(QPainter::TextAntialiasing);
@@ -134,32 +134,10 @@ void MainView::wheelEvent(QWheelEvent *event)
 			}
 		}
 
-		if ( event->delta() > 0 ) --scaleLevel;
-		else ++scaleLevel;
+		if ( event->delta() > 0 ) --scaleLevel_;
+		else ++scaleLevel_;
 
-		if ( scaleLevel <= 0 )
-		{
-			// Nothing changes, we're already at the bottom
-			scaleLevel = 1;
-			return;
-		}
-		qreal factor = scaleFactor();
-
-		// Prevent zooming-out so far that the scrollbars disappear.
-		// This is OK, since the scene's extent is artifically enlarged and it is still possible to see the
-		// entire scene at once, even with scrollbars.
-		if (sceneRect().width()*factor <= viewport()->width() || sceneRect().height()*factor <= viewport()->height())
-		{
-			// Nothing changes, we're already at the largest zoom level.
-			--scaleLevel;
-			return;
-		}
-
-		setTransform(QTransform::fromScale(factor, factor));
-
-		if ( miniMap ) miniMap->visibleRectChanged();
-
-		scene()->setMainViewScalingFactor(factor);
+		zoomAccordingToScaleLevel();
 
 		if (ITEM_STRUCTURE_AWARE_ZOOM_ANCHORING && itemUnderCursor)
 		{
@@ -191,11 +169,45 @@ void MainView::wheelEvent(QWheelEvent *event)
 		View::wheelEvent(event);
 }
 
+void MainView::setScaleLevelAndZoom(int scaleLevel)
+{
+	scaleLevel_ = scaleLevel;
+	zoomAccordingToScaleLevel();
+
+}
+
+void MainView::zoomAccordingToScaleLevel()
+{
+	if ( scaleLevel_ <= 0 )
+	{
+		// Nothing changes, we're already at the bottom
+		scaleLevel_ = 1;
+		return;
+	}
+	qreal factor = scaleFactor();
+
+	// Prevent zooming-out so far that the scrollbars disappear.
+	// This is OK, since the scene's extent is artifically enlarged and it is still possible to see the
+	// entire scene at once, even with scrollbars.
+	if (sceneRect().width()*factor <= viewport()->width() || sceneRect().height()*factor <= viewport()->height())
+	{
+		// Nothing changes, we're already at the largest zoom level.
+		--scaleLevel_;
+		return;
+	}
+
+	setTransform(QTransform::fromScale(factor, factor));
+
+	if ( miniMap ) miniMap->visibleRectChanged();
+
+	scene()->setMainViewScalingFactor(factor);
+}
+
 qreal MainView::scaleFactor() const
 {
-	if (scaleLevel < SCALING_FACTOR)
-		return SCALING_FACTOR / (qreal) scaleLevel;
-	else return std::pow(2, SCALING_FACTOR - scaleLevel);
+	if (scaleLevel_ < SCALING_FACTOR)
+		return SCALING_FACTOR / (qreal) scaleLevel_;
+	else return std::pow(2, SCALING_FACTOR - scaleLevel_);
 }
 
 void MainView::scrollContentsBy(int dx, int dy)

--- a/VisualizationBase/src/views/MainView.cpp
+++ b/VisualizationBase/src/views/MainView.cpp
@@ -169,7 +169,7 @@ void MainView::wheelEvent(QWheelEvent *event)
 		View::wheelEvent(event);
 }
 
-void MainView::setScaleLevelAndZoom(int scaleLevel)
+void MainView::zoom(int scaleLevel)
 {
 	scaleLevel_ = scaleLevel;
 	zoomAccordingToScaleLevel();

--- a/VisualizationBase/src/views/MainView.h
+++ b/VisualizationBase/src/views/MainView.h
@@ -43,6 +43,8 @@ class VISUALIZATIONBASE_API MainView: public View
 
 		void setMiniMapSize(int width, int height);
 
+		void setScaleLevelAndZoom(int scaleLevel);
+
 		static const int MINIMAP_DEFAULT_WIDTH = 200;
 		static const int MINIMAP_DEFAULT_HEIGHT = 200;
 		static const int PNG_SCREENSHOT_SCALE = 8;
@@ -68,7 +70,7 @@ class VISUALIZATIONBASE_API MainView: public View
 
 		static const int SCALING_FACTOR = 2;
 		static const bool ITEM_STRUCTURE_AWARE_ZOOM_ANCHORING = true;
-		int scaleLevel;
+		int scaleLevel_{};
 
 		bool showTimers_{false};
 		QList<QLabel*> infoLabels_; ///< Information text displayed in the top left corner
@@ -78,6 +80,8 @@ class VISUALIZATIONBASE_API MainView: public View
 
 		void updateInfoLabels();
 		bool setCursorAndOwnerIgnoreScaleForScreenShot(bool ignore, bool modifyOwner);
+
+		void zoomAccordingToScaleLevel();
 };
 
 }

--- a/VisualizationBase/src/views/MainView.h
+++ b/VisualizationBase/src/views/MainView.h
@@ -43,7 +43,7 @@ class VISUALIZATIONBASE_API MainView: public View
 
 		void setMiniMapSize(int width, int height);
 
-		void setScaleLevelAndZoom(int scaleLevel);
+		void zoom(int scaleLevel);
 
 		static const int MINIMAP_DEFAULT_WIDTH = 200;
 		static const int MINIMAP_DEFAULT_HEIGHT = 200;

--- a/VisualizationBase/src/views/MainView.h
+++ b/VisualizationBase/src/views/MainView.h
@@ -67,6 +67,7 @@ class VISUALIZATIONBASE_API MainView: public View
 		MiniMap* miniMap;
 
 		static const int SCALING_FACTOR = 2;
+		static const bool ITEM_STRUCTURE_AWARE_ZOOM_ANCHORING = true;
 		int scaleLevel;
 
 		bool showTimers_{false};

--- a/VisualizationBase/styles/item/ArrowOverlay/default
+++ b/VisualizationBase/styles/item/ArrowOverlay/default
@@ -1,5 +1,5 @@
 <!DOCTYPE EnvisionVisualizationStyle>
-<style prototypes="../Item/default,selectedArrow">
+<style prototypes="../Item/default,highlightedArrow">
 	<linePen>
 		<width>1.0</width>
 		<style>1</style>

--- a/VisualizationBase/styles/item/ArrowOverlay/highlightedArrow
+++ b/VisualizationBase/styles/item/ArrowOverlay/highlightedArrow
@@ -1,15 +1,15 @@
 <!DOCTYPE EnvisionVisualizationStyle>
 <style>
-	<selectedLinePen>
+	<highlightedLinePen>
 		<width>50.0</width>
 		<style>1</style>
 		<color>#000000</color>
 		<capStyle>0</capStyle>
 		<joinStyle>0</joinStyle>
-	</selectedLinePen>
-	<selectedArrowBrush>
+	</highlightedLinePen>
+	<highlightedArrowBrush>
 		<style>1</style>
 		<color>#000000</color>
-	</selectedArrowBrush>
-	<selectedWidth>50</selectedWidth>
+	</highlightedArrowBrush>
+	<highlightedWidth>50</highlightedWidth>
 </style>

--- a/VisualizationBase/styles/item/ArrowOverlay/selectedArrow
+++ b/VisualizationBase/styles/item/ArrowOverlay/selectedArrow
@@ -1,15 +1,15 @@
 <!DOCTYPE EnvisionVisualizationStyle>
-<style prototypes="../Item/default,selectedArrow">
-	<linePen>
-		<width>1.0</width>
+<style>
+	<selectedLinePen>
+		<width>50.0</width>
 		<style>1</style>
 		<color>#000000</color>
 		<capStyle>0</capStyle>
 		<joinStyle>0</joinStyle>
-	</linePen>
-	<arrowBrush>
+	</selectedLinePen>
+	<selectedArrowBrush>
 		<style>1</style>
 		<color>#000000</color>
-	</arrowBrush>
-	<width>1</width>
+	</selectedArrowBrush>
+	<selectedWidth>50</selectedWidth>
 </style>


### PR DESCRIPTION
Please check the generalised code for loadNodeData
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62790453%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62790472%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62790820%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62790938%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62790991%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62791141%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62791154%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62791159%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62791505%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62791529%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62791565%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23issuecomment-218361581%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62821178%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62853397%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62853986%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62856651%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62857573%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63033942%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63033970%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63034801%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63035851%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63035897%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63036143%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63036460%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23issuecomment-218790863%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63212816%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63213002%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23issuecomment-219095676%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23issuecomment-219862155%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23issuecomment-218361581%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ok%2C%20I%27ve%20looked%20at%20all%20the%20code%20and%20it%20needs%20more%20work.%20Rebase%20on%20the%20latest%20changes%20and%20fix%20the%20issues%20I%20mentioned.%20Please%20be%20more%20meticulous%20when%20you%20write%20code%2C%20don%27t%20use%200%20and%201%20as%20booleans%20and%20do%20follow%20Envision%27s%20naming%20conventions%20%28camelCase%20and%20%60_%60%20suffix%20for%20fields%20only%29%22%2C%20%22created_at%22%3A%20%222016-05-11T04%3A54%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Btw%20for%20some%20reason%20this%20branch%20cannot%20be%20merged.%20I%20guess%20you%20need%20to%20rebase%20on%20the%20latest%20version%20and%20make%20sure%20there%20are%20no%20conflicts.%20If%20you%20need%20help%2C%20you%20could%20ask%20Manuel%20to%20have%20a%20look.%22%2C%20%22created_at%22%3A%20%222016-05-12T15%3A20%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Alright%2C%20only%20two%20minor%20things%2C%20please%20fix%20those%20and%20I%20will%20merge.%5Cr%5Cn%5Cr%5CnI%20know%20this%20is%20taking%20a%20long%20time%2C%20but%20I%20want%20to%20make%20sure%20that%20I%20point%20out%20all%20of%20the%20small%20things%2C%20so%20that%20future%20commits%20will%20go%20smoother.%22%2C%20%22created_at%22%3A%20%222016-05-13T16%3A39%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Alright%2C%20I%27ll%20close%20this%20since%20%23382%20includes%20all%20of%20this%20stuff.%22%2C%20%22created_at%22%3A%20%222016-05-17T21%3A37%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20d88dbe9a7830937b28ff1525a28c75ad54ba9996%20FilePersistence/src/version_control/GitRepository.cpp%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63213002%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Actually%2C%20please%20use%20the%20more%20secure%20version%20of%20this%20function%3A%20http%3A//www.cplusplus.com/reference/cstring/strncpy/%22%2C%20%22created_at%22%3A%20%222016-05-13T16%3A35%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitRepository.cpp%3AL318-369%22%7D%2C%20%22Pull%20656f417888a7cd04ca51846b34b9a7e10d3d3137%20FilePersistence/src/precompiled.h%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62790453%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20prefix%20all%20of%20these%20with%20%60%3CQtCore/...%3E%60%22%2C%20%22created_at%22%3A%20%222016-05-11T04%3A29%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Look%20at%20other%20precompiled%20headers%20that%20include%20Qt%20headers.%22%2C%20%22created_at%22%3A%20%222016-05-11T04%3A29%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/precompiled.h%3AL54-63%22%7D%2C%20%22Pull%20656f417888a7cd04ca51846b34b9a7e10d3d3137%20FilePersistence/src/version_control/Commit.h%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62790938%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Once%20again%2C%20please%20do%20not%20use%200%20or%201%20for%20boolean%20variables.%22%2C%20%22created_at%22%3A%20%222016-05-11T04%3A39%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.h%3AL80-89%22%7D%2C%20%22Pull%209d9eeeb020478ca52106a242907130969eb1ea9a%20FilePersistence/src/version_control/GitRepository.cpp%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63035897%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%7B%20on%20new%20line%22%2C%20%22created_at%22%3A%20%222016-05-12T15%3A00%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitRepository.cpp%3AL318-366%22%7D%2C%20%22Pull%209d9eeeb020478ca52106a242907130969eb1ea9a%20FilePersistence/src/version_control/GitRepository.cpp%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63035851%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20the%20memory%20operations%20here%20are%20not%20quite%20right.%20You%20are%20just%20referencing%20arr.data%28%29%20which%20will%20be%20destroyed%20once%20arr%20gets%20out%20of%20scope.%20you%20need%20to%20copy%20it%20instead.%20See%20here%20for%20how%20to%20copy%3A%5Cr%5Cnhttp%3A//doc.qt.io/qt-5/qbytearray.html%23data%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-05-12T15%3A00%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitRepository.cpp%3AL318-366%22%7D%2C%20%22Pull%20d88dbe9a7830937b28ff1525a28c75ad54ba9996%20FilePersistence/src/version_control/GitRepository.cpp%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63212816%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20do%20not%20leave%20random%20comments%20in%20the%20code.%20%22%2C%20%22created_at%22%3A%20%222016-05-13T16%3A33%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitRepository.cpp%3AL318-369%22%7D%2C%20%22Pull%209d9eeeb020478ca52106a242907130969eb1ea9a%20FilePersistence/src/version_control/Commit.cpp%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63033970%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22space%20before%20%60return%60%22%2C%20%22created_at%22%3A%20%222016-05-12T14%3A50%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-155%22%7D%2C%20%22Pull%20656f417888a7cd04ca51846b34b9a7e10d3d3137%20FilePersistence/src/version_control/Commit.cpp%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62791159%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22do%20not%20use%200%20and%201%20for%20booleans.%22%2C%20%22created_at%22%3A%20%222016-05-11T04%3A43%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-189%22%7D%2C%20%22Pull%20656f417888a7cd04ca51846b34b9a7e10d3d3137%20FilePersistence/src/version_control/Commit.cpp%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62791154%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22do%20not%20use%200%20and%201%20for%20booleans.%22%2C%20%22created_at%22%3A%20%222016-05-11T04%3A43%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-189%22%7D%2C%20%22Pull%20656f417888a7cd04ca51846b34b9a7e10d3d3137%20FilePersistence/src/version_control/Commit.cpp%2054%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62791565%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20this%20approach%20going%20to%20work%20for%20arbitrarily%20nested%20directories%3F%22%2C%20%22created_at%22%3A%20%222016-05-11T04%3A52%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20I%20see%20it%20now.%20Thanks.%22%2C%20%22created_at%22%3A%20%222016-05-11T14%3A06%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-189%22%7D%2C%20%22Pull%209d9eeeb020478ca52106a242907130969eb1ea9a%20FilePersistence/src/version_control/GitRepository.cpp%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63036143%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20this%20case%20%28unlike%20the%20code%20you%20copied%20from%2C%20that%20uses%20an%20external%20library%20-%20libgit2%29%20you%20do%20not%20need%20to%20manually%20provide%20a%20deleter%2C%20and%20should%20definitely%20not%20call%20%60free%60.%20Simply%20remove%20the%20last%20argument%20of%20the%20constructor%20to%20%60content_ptr%60.%22%2C%20%22created_at%22%3A%20%222016-05-12T15%3A02%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22also%20%60content_ptr%60%20should%20wrap%20the%20%60content%60%20variable%20not%20%60arr.data%60.%22%2C%20%22created_at%22%3A%20%222016-05-12T15%3A04%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitRepository.cpp%3AL318-366%22%7D%2C%20%22Pull%209d9eeeb020478ca52106a242907130969eb1ea9a%20FilePersistence/src/version_control/GitRepository.cpp%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63034801%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3F%3F%3F%20This%20should%20be%20%60Commit%2A%20m%20%3D%20new%20Commit%7B%7D%60%20or%20even%20better%20%60auto%20result%20%3D%20new%20Commit%7B%7D%60.%20Either%20way%20it%20should%20be%20initialized.%20Right%20now%20you%27re%20writing%20somewhere%20in%20zero%20memory.%20Did%20you%20test%20this%20code%3F%22%2C%20%22created_at%22%3A%20%222016-05-12T14%3A55%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/GitRepository.cpp%3AL318-366%22%7D%2C%20%22Pull%20656f417888a7cd04ca51846b34b9a7e10d3d3137%20FilePersistence/src/version_control/Commit.cpp%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62791141%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22do%20not%20use%200%20and%201%20for%20booleans.%22%2C%20%22created_at%22%3A%20%222016-05-11T04%3A43%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-189%22%7D%2C%20%22Pull%20656f417888a7cd04ca51846b34b9a7e10d3d3137%20FilePersistence/src/version_control/Commit.cpp%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r62790820%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20do%20not%20use%20the%20%60_%60%20prefix%20for%20local%20variables.%20Only%20for%20fields.%22%2C%20%22created_at%22%3A%20%222016-05-11T04%3A36%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20do%20not%20need%20two%20additional%20parameters%20connected%20to%20working%20directory.%20One%20string%20should%20be%20enough.%20If%20the%20string%20is%20null%20%28%60QString.isNull%28%29%60%29%20then%20it%27s%20not%20a%20working%20directory%2C%20otherwise%20it%20is.%22%2C%20%22created_at%22%3A%20%222016-05-11T04%3A40%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%2C%20actually%20modifying%20this%20function%20is%20not%20the%20correct%20thing%20to%20do.%20Right%20now%2C%20the%20only%20place%20in%20Envision%20where%20we%20create%20objects%20of%20type%20%60Commit%60%20is%20%60GitRepository%3A%3AgetCommit%60.%20That%20one%20method%20explicitly%20prevents%20commits%20from%20being%20created%20from%20the%20working%20directory%20%28the%20first%20%60Q_ASSERT%60%29.%20The%20correct%20thing%20to%20do%20is%20to%20modify%20%20%60GitRepository%3A%3AgetCommit%60%20to%20also%20be%20able%20to%20return%20%60Commit%60%20objects%20that%20correspond%20to%20the%20current%20working%20directory.%20Then%20the%20code%20here%20should%20be%20almost%20untouched.%5Cr%5Cn%5Cr%5CnIn%20%60GitRepository%3A%3AgetCommit%60%20you%20need%20to%20make%20an%20explicit%20test%20whether%20the%20input%20is%20a%20working%20directory%20and%20if%20so%20walk%20the%20files%20similarly%20to%20how%20you%20do%20here.%22%2C%20%22created_at%22%3A%20%222016-05-11T04%3A51%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60Id%60%20should%20be%20%60id%60%20-%20observe%20the%20correct%20camel%20case%20rules%20for%20Envision.%22%2C%20%22created_at%22%3A%20%222016-05-11T04%3A51%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22How%20can%20I%20get%20CommitMetaData%28sha_%20and%20other%20info%29%20for%20Commit%20object%20while%20traversing%20the%20files%3F%20Rest%20of%20the%20issues%20are%20are%20resolved%22%2C%20%22created_at%22%3A%20%222016-05-11T09%3A56%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11445667%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Vaishal-shah%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%2C%20you%20can%27t%20get%20a%20sha%20as%20it%20is%20not%20yet%20really%20committed%20%28so%20it%27s%20a%20bit%20of%20a%20fake%20commit%29.%20But%20that%20should%20not%20be%20necessary%2C%20just%20don%27t%20set%20these%20properties%20of%20the%20Commit%2C%20I%20don%27t%20think%20they%20are%20needed%20for%20our%20algorithm.%22%2C%20%22created_at%22%3A%20%222016-05-11T14%3A03%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%2C%20should%20I%20return%20a%20NULL%20commit%20from%20getCommit%3F%22%2C%20%22created_at%22%3A%20%222016-05-11T14%3A21%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11445667%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Vaishal-shah%22%7D%7D%2C%20%7B%22body%22%3A%20%22Errr%2C%20no.%20You%20return%20a%20commit%20which%20has%20all%20the%20files%20%28which%20is%20mainly%20what%20we%20care%20about%29%20and%20as%20much%20other%20data%20as%20you%20can%20logically%20get%2C%20and%20leave%20the%20parts%20of%20the%20commit%20that%20make%20no%20sense%20%28e.g.%20sha%29%20unset.%22%2C%20%22created_at%22%3A%20%222016-05-11T14%3A25%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-189%22%7D%2C%20%22Pull%209d9eeeb020478ca52106a242907130969eb1ea9a%20FilePersistence/src/version_control/Commit.cpp%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/378%23discussion_r63033942%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22don%27t%20use%20tabs%20witin%20lines%2C%20use%20a%20space%20before%20%60return%60%22%2C%20%22created_at%22%3A%20%222016-05-12T14%3A50%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL103-155%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 656f417888a7cd04ca51846b34b9a7e10d3d3137 FilePersistence/src/precompiled.h 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r62790453'>File: FilePersistence/src/precompiled.h:L54-63</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please prefix all of these with `<QtCore/...>`
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Look at other precompiled headers that include Qt headers.
- [x] <a href='#crh-comment-Pull 656f417888a7cd04ca51846b34b9a7e10d3d3137 FilePersistence/src/version_control/Commit.cpp 46'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r62790820'>File: FilePersistence/src/version_control/Commit.cpp:L103-189</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please do not use the `_` prefix for local variables. Only for fields.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> We do not need two additional parameters connected to working directory. One string should be enough. If the string is null (`QString.isNull()`) then it's not a working directory, otherwise it is.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> So, actually modifying this function is not the correct thing to do. Right now, the only place in Envision where we create objects of type `Commit` is `GitRepository::getCommit`. That one method explicitly prevents commits from being created from the working directory (the first `Q_ASSERT`). The correct thing to do is to modify  `GitRepository::getCommit` to also be able to return `Commit` objects that correspond to the current working directory. Then the code here should be almost untouched.
  In `GitRepository::getCommit` you need to make an explicit test whether the input is a working directory and if so walk the files similarly to how you do here.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `Id` should be `id` - observe the correct camel case rules for Envision.
- <a href='https://github.com/Vaishal-shah'><img border=0 src='https://avatars.githubusercontent.com/u/11445667?v=3' height=16 width=16'></a> How can I get CommitMetaData(sha_ and other info) for Commit object while traversing the files? Rest of the issues are are resolved
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Well, you can't get a sha as it is not yet really committed (so it's a bit of a fake commit). But that should not be necessary, just don't set these properties of the Commit, I don't think they are needed for our algorithm.
- <a href='https://github.com/Vaishal-shah'><img border=0 src='https://avatars.githubusercontent.com/u/11445667?v=3' height=16 width=16'></a> So, should I return a NULL commit from getCommit?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Errr, no. You return a commit which has all the files (which is mainly what we care about) and as much other data as you can logically get, and leave the parts of the commit that make no sense (e.g. sha) unset.
- [x] <a href='#crh-comment-Pull 656f417888a7cd04ca51846b34b9a7e10d3d3137 FilePersistence/src/version_control/Commit.h 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r62790938'>File: FilePersistence/src/version_control/Commit.h:L80-89</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Once again, please do not use 0 or 1 for boolean variables.
- [x] <a href='#crh-comment-Pull 656f417888a7cd04ca51846b34b9a7e10d3d3137 FilePersistence/src/version_control/Commit.cpp 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r62791141'>File: FilePersistence/src/version_control/Commit.cpp:L103-189</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> do not use 0 and 1 for booleans.
- [x] <a href='#crh-comment-Pull 656f417888a7cd04ca51846b34b9a7e10d3d3137 FilePersistence/src/version_control/Commit.cpp 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r62791154'>File: FilePersistence/src/version_control/Commit.cpp:L103-189</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> do not use 0 and 1 for booleans.
- [x] <a href='#crh-comment-Pull 656f417888a7cd04ca51846b34b9a7e10d3d3137 FilePersistence/src/version_control/Commit.cpp 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r62791159'>File: FilePersistence/src/version_control/Commit.cpp:L103-189</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> do not use 0 and 1 for booleans.
- [x] <a href='#crh-comment-Pull 656f417888a7cd04ca51846b34b9a7e10d3d3137 FilePersistence/src/version_control/Commit.cpp 54'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r62791565'>File: FilePersistence/src/version_control/Commit.cpp:L103-189</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Is this approach going to work for arbitrarily nested directories?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> OK, I see it now. Thanks.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#issuecomment-218361581'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Ok, I've looked at all the code and it needs more work. Rebase on the latest changes and fix the issues I mentioned. Please be more meticulous when you write code, don't use 0 and 1 as booleans and do follow Envision's naming conventions (camelCase and `_` suffix for fields only)
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Btw for some reason this branch cannot be merged. I guess you need to rebase on the latest version and make sure there are no conflicts. If you need help, you could ask Manuel to have a look.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Alright, only two minor things, please fix those and I will merge.
  I know this is taking a long time, but I want to make sure that I point out all of the small things, so that future commits will go smoother.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Alright, I'll close this since #382 includes all of this stuff.
- [x] <a href='#crh-comment-Pull 9d9eeeb020478ca52106a242907130969eb1ea9a FilePersistence/src/version_control/Commit.cpp 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r63033942'>File: FilePersistence/src/version_control/Commit.cpp:L103-155</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> don't use tabs witin lines, use a space before `return`
- [x] <a href='#crh-comment-Pull 9d9eeeb020478ca52106a242907130969eb1ea9a FilePersistence/src/version_control/Commit.cpp 22'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r63033970'>File: FilePersistence/src/version_control/Commit.cpp:L103-155</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> space before `return`
- [x] <a href='#crh-comment-Pull 9d9eeeb020478ca52106a242907130969eb1ea9a FilePersistence/src/version_control/GitRepository.cpp 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r63034801'>File: FilePersistence/src/version_control/GitRepository.cpp:L318-366</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> ??? This should be `Commit* m = new Commit{}` or even better `auto result = new Commit{}`. Either way it should be initialized. Right now you're writing somewhere in zero memory. Did you test this code?
- [x] <a href='#crh-comment-Pull 9d9eeeb020478ca52106a242907130969eb1ea9a FilePersistence/src/version_control/GitRepository.cpp 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r63035851'>File: FilePersistence/src/version_control/GitRepository.cpp:L318-366</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, the memory operations here are not quite right. You are just referencing arr.data() which will be destroyed once arr gets out of scope. you need to copy it instead. See here for how to copy:
  http://doc.qt.io/qt-5/qbytearray.html#data
- [x] <a href='#crh-comment-Pull 9d9eeeb020478ca52106a242907130969eb1ea9a FilePersistence/src/version_control/GitRepository.cpp 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r63035897'>File: FilePersistence/src/version_control/GitRepository.cpp:L318-366</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> { on new line
- [x] <a href='#crh-comment-Pull 9d9eeeb020478ca52106a242907130969eb1ea9a FilePersistence/src/version_control/GitRepository.cpp 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r63036143'>File: FilePersistence/src/version_control/GitRepository.cpp:L318-366</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> In this case (unlike the code you copied from, that uses an external library - libgit2) you do not need to manually provide a deleter, and should definitely not call `free`. Simply remove the last argument of the constructor to `content_ptr`.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> also `content_ptr` should wrap the `content` variable not `arr.data`.
- [x] <a href='#crh-comment-Pull d88dbe9a7830937b28ff1525a28c75ad54ba9996 FilePersistence/src/version_control/GitRepository.cpp 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r63212816'>File: FilePersistence/src/version_control/GitRepository.cpp:L318-369</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please do not leave random comments in the code.
- [x] <a href='#crh-comment-Pull d88dbe9a7830937b28ff1525a28c75ad54ba9996 FilePersistence/src/version_control/GitRepository.cpp 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/378#discussion_r63213002'>File: FilePersistence/src/version_control/GitRepository.cpp:L318-369</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Actually, please use the more secure version of this function: http://www.cplusplus.com/reference/cstring/strncpy/

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/378?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/378?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/378'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
