### PR TITLE
Gm code review

### DIFF
--- a/CodeReview/CMakeLists.txt
+++ b/CodeReview/CMakeLists.txt
@@ -13,6 +13,9 @@ add_library(CodeReview SHARED
 	src/overlays/CodeReviewCommentOverlay.h
 	src/overlays/CodeReviewCommentOverlayStyle.h
 	src/handlers/HReviewableItem.h
+	src/nodes/CommentedNode.h
+	src/items/VCommentedNode.h
+	src/items/VCommentedNodeStyle.h
 	src/CodeReviewException.cpp
 	src/CodeReviewPlugin.cpp
 	src/CodeReviewManager.cpp
@@ -20,6 +23,9 @@ add_library(CodeReview SHARED
 	src/overlays/CodeReviewCommentOverlay.cpp
 	src/overlays/CodeReviewCommentOverlayStyle.cpp
 	src/handlers/HReviewableItem.cpp
+	src/nodes/CommentedNode.cpp
+	src/items/VCommentedNode.cpp
+	src/items/VCommentedNodeStyle.cpp
 	test/SimpleTest.cpp
 )
 envision_plugin(CodeReview OOInteraction VersionControlUI)

--- a/CodeReview/src/CodeReviewManager.cpp
+++ b/CodeReview/src/CodeReviewManager.cpp
@@ -23,3 +23,27 @@
  ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **
  **********************************************************************************************************************/
+
+#include "CodeReviewManager.h"
+
+namespace CodeReview {
+
+// TODO use versions to have a one code review manager for any combination of two versions
+CodeReviewManager::CodeReviewManager(QString, QString)
+{}
+
+CodeReviewManager& CodeReviewManager::instance()
+{
+	// TODO add handling to create instances per version combination
+	static CodeReviewManager manager{"", ""};
+	return manager;
+}
+
+CommentedNode* CodeReviewManager::commentedNode(QString nodeId)
+{
+	if (!commentedNodes_.contains(nodeId))
+		commentedNodes_.insert(nodeId, new CommentedNode{nodeId});
+	return commentedNodes_.value(nodeId);
+}
+
+}

--- a/CodeReview/src/CodeReviewManager.cpp
+++ b/CodeReview/src/CodeReviewManager.cpp
@@ -41,9 +41,12 @@ CodeReviewManager& CodeReviewManager::instance()
 
 CommentedNode* CodeReviewManager::commentedNode(QString nodeId)
 {
-	if (!commentedNodes_.contains(nodeId))
-		commentedNodes_.insert(nodeId, new CommentedNode{nodeId});
-	return commentedNodes_.value(nodeId);
+	auto iter = commentedNodes_.constFind(nodeId);
+	if (iter != commentedNodes_.constEnd()) return *iter;
+
+	auto commentedNode = new CommentedNode{nodeId};
+	commentedNodes_.insert(nodeId, commentedNode);
+	return commentedNode;
 }
 
 }

--- a/CodeReview/src/CodeReviewManager.h
+++ b/CodeReview/src/CodeReviewManager.h
@@ -23,3 +23,24 @@
  ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **
  **********************************************************************************************************************/
+
+#pragma once
+
+#include "codereview_api.h"
+
+#include "nodes/CommentedNode.h"
+
+namespace CodeReview {
+
+class CODEREVIEW_API CodeReviewManager
+{
+	public:
+		CommentedNode* commentedNode(QString nodeId);
+		static CodeReviewManager& instance();
+
+	private:
+		QHash<QString, CommentedNode*> commentedNodes_;
+		CodeReviewManager(QString oldVersion, QString newVersion);
+};
+
+}

--- a/CodeReview/src/commands/CCodeReviewComment.cpp
+++ b/CodeReview/src/commands/CCodeReviewComment.cpp
@@ -58,7 +58,9 @@ Interaction::CommandResult* CCodeReviewComment::execute(Visualization::Item* sou
 				const QStringList&, const std::unique_ptr<Visualization::Cursor>&)
 {
 	for (auto manager : Model::AllTreeManagers::instance().loadedManagers())
-		if (manager->nodeIdMap().contains(source->node()))
+	{
+		auto id = manager->nodeIdMap().idIfExists(source->node());
+		if (!id.isNull())
 		{
 			auto id = manager->nodeIdMap().id(source->node()).toString();
 			auto commentedNode = CodeReviewManager::instance().commentedNode(id);
@@ -72,6 +74,7 @@ Interaction::CommandResult* CCodeReviewComment::execute(Visualization::Item* sou
 			}
 			break;
 		}
+	}
 
 	return new Interaction::CommandResult{};
 }

--- a/CodeReview/src/commands/CCodeReviewComment.h
+++ b/CodeReview/src/commands/CCodeReviewComment.h
@@ -43,7 +43,6 @@ class CODEREVIEW_API CCodeReviewComment : public Interaction::Command
 
 		virtual QList<Interaction::CommandSuggestion*> suggest(Visualization::Item* source, Visualization::Item* target,
 				const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>& cursor) override;
-
 };
 
 }

--- a/CodeReview/src/items/VCommentedNode.cpp
+++ b/CodeReview/src/items/VCommentedNode.cpp
@@ -1,0 +1,57 @@
+/***********************************************************************************************************************
+ **
+ ** Copyright (c) 2011, 2016 ETH Zurich
+ ** All rights reserved.
+ **
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ ** following conditions are met:
+ **
+ **    * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ **      following disclaimer.
+ **    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ **      following disclaimer in the documentation and/or other materials provided with the distribution.
+ **    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+ **      derived from this software without specific prior written permission.
+ **
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ ** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ ** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ ** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ ** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **
+ **********************************************************************************************************************/
+
+#include "VCommentedNode.h"
+
+#include "VisualizationBase/src/VisualizationManager.h"
+#include "VisualizationBase/src/declarative/DeclarativeItem.hpp"
+
+#include "ModelBase/src/nodes/Node.h"
+#include "ModelBase/src/nodes/Text.h"
+#include "ModelBase/src/model/AllTreeManagers.h"
+
+#include "VisualizationBase/src/items/VText.h"
+#include "VisualizationBase/src/items/ViewItem.h"
+#include "VisualizationBase/src/items/Item.h"
+
+namespace CodeReview
+{
+
+DEFINE_ITEM_COMMON(VCommentedNode, "item")
+
+VCommentedNode::VCommentedNode(Visualization::Item* parent, NodeType* node, const StyleType* style)
+	: Super{parent, node, style}
+{
+}
+
+void VCommentedNode::initializeForms()
+{
+	auto comment = item(&I::comment_, [](I* v) {
+			return v->node()->commentNodes();});
+	addForm(comment);
+}
+
+}

--- a/CodeReview/src/items/VCommentedNode.h
+++ b/CodeReview/src/items/VCommentedNode.h
@@ -1,0 +1,60 @@
+/***********************************************************************************************************************
+ **
+ ** Copyright (c) 2011, 2016 ETH Zurich
+ ** All rights reserved.
+ **
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ ** following conditions are met:
+ **
+ **    * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ **      following disclaimer.
+ **    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ **      following disclaimer in the documentation and/or other materials provided with the distribution.
+ **    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+ **      derived from this software without specific prior written permission.
+ **
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ ** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ ** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ ** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ ** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **
+ **********************************************************************************************************************/
+
+#pragma once
+
+#include "../codereview_api.h"
+
+#include "VisualizationBase/src/items/ItemWithNode.h"
+#include "VisualizationBase/src/declarative/DeclarativeItem.h"
+#include "VisualizationBase/src/declarative/DeclarativeItemBaseStyle.h"
+#include "VCommentedNodeStyle.h"
+
+#include "../nodes/CommentedNode.h"
+
+#include "VisualizationBase/src/items/Item.h"
+
+
+namespace CodeReview
+{
+
+class CommentedNode;
+
+class CODEREVIEW_API VCommentedNode : public Super<Visualization::ItemWithNode<VCommentedNode,
+		Visualization::DeclarativeItem<VCommentedNode>, CommentedNode>>
+{
+	ITEM_COMMON(VCommentedNode)
+
+	public:
+		VCommentedNode(Visualization::Item* parent, NodeType* node, const StyleType* style = itemStyles().get());
+		static void initializeForms();
+
+	private:
+		Visualization::Item* comment_{};
+
+};
+
+}

--- a/CodeReview/src/items/VCommentedNodeStyle.cpp
+++ b/CodeReview/src/items/VCommentedNodeStyle.cpp
@@ -1,0 +1,34 @@
+/***********************************************************************************************************************
+ **
+ ** Copyright (c) 2011, 2016 ETH Zurich
+ ** All rights reserved.
+ **
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ ** following conditions are met:
+ **
+ **    * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ **      following disclaimer.
+ **    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ **      following disclaimer in the documentation and/or other materials provided with the distribution.
+ **    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+ **      derived from this software without specific prior written permission.
+ **
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ ** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ ** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ ** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ ** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **
+ **********************************************************************************************************************/
+
+#include "VCommentedNodeStyle.h"
+
+namespace CodeReview
+{
+
+VCommentedNodeStyle::~VCommentedNodeStyle(){}
+
+}

--- a/CodeReview/src/items/VCommentedNodeStyle.h
+++ b/CodeReview/src/items/VCommentedNodeStyle.h
@@ -1,0 +1,43 @@
+/***********************************************************************************************************************
+ **
+ ** Copyright (c) 2011, 2016 ETH Zurich
+ ** All rights reserved.
+ **
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ ** following conditions are met:
+ **
+ **    * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ **      following disclaimer.
+ **    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ **      following disclaimer in the documentation and/or other materials provided with the distribution.
+ **    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+ **      derived from this software without specific prior written permission.
+ **
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ ** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ ** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ ** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ ** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **
+ **********************************************************************************************************************/
+
+#pragma once
+
+#include "../codereview_api.h"
+
+#include "VisualizationBase/src/declarative/DeclarativeItemBaseStyle.h"
+
+namespace CodeReview
+{
+
+class CODEREVIEW_API VCommentedNodeStyle : public Super<Visualization::DeclarativeItemBaseStyle>
+{
+	public:
+		virtual ~VCommentedNodeStyle() override;
+
+};
+
+}

--- a/CodeReview/src/nodes/CommentedNode.cpp
+++ b/CodeReview/src/nodes/CommentedNode.cpp
@@ -1,0 +1,44 @@
+/***********************************************************************************************************************
+ **
+ ** Copyright (c) 2011, 2016 ETH Zurich
+ ** All rights reserved.
+ **
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ ** following conditions are met:
+ **
+ **    * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ **      following disclaimer.
+ **    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ **      following disclaimer in the documentation and/or other materials provided with the distribution.
+ **    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+ **      derived from this software without specific prior written permission.
+ **
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ ** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ ** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ ** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ ** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **
+ **********************************************************************************************************************/
+#include "CommentedNode.h"
+
+#include "ModelBase/src/nodes/composite/CompositeNode.h"
+
+namespace CodeReview
+{
+
+DEFINE_COMPOSITE_EMPTY_CONSTRUCTORS(CommentedNode)
+DEFINE_COMPOSITE_TYPE_REGISTRATION_METHODS(CommentedNode)
+
+DEFINE_ATTRIBUTE(CommentedNode, nodeId, Text, false, false, true)
+DEFINE_ATTRIBUTE(CommentedNode, commentNodes, TypedListOfCommentNode, false, false, true)
+
+CommentedNode::CommentedNode(QString associatedNodeId) : Super{nullptr, CommentedNode::getMetaData()}
+{
+	setNodeId(new Model::Text{associatedNodeId});
+}
+
+}

--- a/CodeReview/src/nodes/CommentedNode.h
+++ b/CodeReview/src/nodes/CommentedNode.h
@@ -1,0 +1,55 @@
+/***********************************************************************************************************************
+ **
+ ** Copyright (c) 2011, 2016 ETH Zurich
+ ** All rights reserved.
+ **
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ ** following conditions are met:
+ **
+ **    * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ **      following disclaimer.
+ **    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ **      following disclaimer in the documentation and/or other materials provided with the distribution.
+ **    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+ **      derived from this software without specific prior written permission.
+ **
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ ** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ ** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ ** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ ** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **
+ **********************************************************************************************************************/
+#pragma once
+
+#include "../codereview_api.h"
+
+#include "ModelBase/src/nodes/nodeMacros.h"
+
+#include "Comments/src/nodes/CommentNode.h"
+
+namespace CodeReview
+{
+class CommentedNode;
+}
+
+extern template class CODEREVIEW_API Model::TypedList<CodeReview::CommentedNode>;
+
+namespace CodeReview {
+
+class CODEREVIEW_API CommentedNode : public Super<Model::CompositeNode>
+{
+	COMPOSITENODE_DECLARE_STANDARD_METHODS(CommentedNode)
+
+	ATTRIBUTE(Model::Text, nodeId, setNodeId)
+	ATTRIBUTE(Model::TypedList<Comments::CommentNode>, commentNodes, setCommentNodes)
+
+	public:
+		CommentedNode(QString associatedNodeId);
+
+};
+
+}

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -39,25 +39,24 @@ namespace CodeReview
 
 DEFINE_ITEM_COMMON(CodeReviewCommentOverlay, "item")
 
-CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associatedItem, const StyleType* style) :
-	Super{{associatedItem}, style}
+CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associatedItem,
+																	CommentedNode* commentedNode, const StyleType* style) :
+	Super{{associatedItem}, style}, commentedNode_{commentedNode}
 {
 	setAcceptedMouseButtons(Qt::AllButtons);
 	setFlag(QGraphicsItem::ItemIgnoresTransformations);
-
-	commentInput_ = new Visualization::Text{this, ""};
-	commentInput_->setEditable(true);
 }
 
 void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableHeight)
 {
 	Super::updateGeometry(availableWidth, availableHeight);
-	setPos(associatedItem()->scenePos());
+	qreal height = associatedItem()->heightInScene();
+	setPos(associatedItem()->scenePos() + QPointF{0, height});
 }
 
 void CodeReviewCommentOverlay::initializeForms()
 {
-	addForm(item<Visualization::Text>(&I::commentInput_,  &StyleType::commentInput));
+	addForm(item(&I::commentedNodeItem_, [](I* v) {return v->commentedNode_;}));
 
 }
 

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.h
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.h
@@ -32,6 +32,8 @@
 #include "VisualizationBase/src/overlays/Overlay.h"
 #include "VisualizationBase/src/declarative/DeclarativeItem.h"
 
+#include "../nodes/CommentedNode.h"
+
 #include "CodeReviewCommentOverlayStyle.h"
 
 namespace CodeReview
@@ -43,7 +45,8 @@ class CODEREVIEW_API CodeReviewCommentOverlay :
 	ITEM_COMMON(CodeReviewCommentOverlay)
 
 	public:
-		CodeReviewCommentOverlay(Item* associatedItem, const StyleType* style = itemStyles().get());
+		CodeReviewCommentOverlay(Visualization::Item* associatedItem, CommentedNode* commentedNode,
+										 const StyleType* style = itemStyles().get());
 
 		static void initializeForms();
 
@@ -51,7 +54,8 @@ class CODEREVIEW_API CodeReviewCommentOverlay :
 		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
-		Visualization::Text* commentInput_{};
+		CommentedNode* commentedNode_{};
+		Visualization::Item* commentedNodeItem_{};
 
 };
 

--- a/CodeReview/styles/item/VCommentedNode/default
+++ b/CodeReview/styles/item/VCommentedNode/default
@@ -1,0 +1,11 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/DeclarativeItemBase/default">
+	<shape prototypes="shape/Box/default">
+		Box
+		<cornerRadius>2</cornerRadius>
+		<backgroundBrush>
+			<style>1</style>
+			<color>#ffffff</color>
+		</backgroundBrush>
+	</shape>
+</style>

--- a/ModelBase/src/persistence/NodeIdMap.h
+++ b/ModelBase/src/persistence/NodeIdMap.h
@@ -44,15 +44,15 @@ class MODELBASE_API NodeIdMap {
 
 		void remove(const Node* node);
 
-		bool contains(const Node* node);
+		NodeIdType idIfExists(Node* node);
 
 	private:
 		QHash<const Node*, NodeIdType> nodeToId;
 		QHash<NodeIdType, const Node*> idToNode;
 };
 
-inline bool NodeIdMap::contains(const Node* node) { return nodeToId.contains(node);}
 inline NodeIdType NodeIdMap::generateNewId() { return QUuid::createUuid(); }
 inline const Node* NodeIdMap::node(NodeIdType id) { return idToNode.value(id);}
+inline NodeIdType NodeIdMap::idIfExists(Node* node) { return nodeToId.value(node); }
 
 }

--- a/ModelBase/src/persistence/NodeIdMap.h
+++ b/ModelBase/src/persistence/NodeIdMap.h
@@ -44,11 +44,14 @@ class MODELBASE_API NodeIdMap {
 
 		void remove(const Node* node);
 
+		bool contains(const Node* node);
+
 	private:
 		QHash<const Node*, NodeIdType> nodeToId;
 		QHash<NodeIdType, const Node*> idToNode;
 };
 
+inline bool NodeIdMap::contains(const Node* node) { return nodeToId.contains(node);}
 inline NodeIdType NodeIdMap::generateNewId() { return QUuid::createUuid(); }
 inline const Node* NodeIdMap::node(NodeIdType id) { return idToNode.value(id);}
 

--- a/OOInteraction/src/commands/CommandHelper.h
+++ b/OOInteraction/src/commands/CommandHelper.h
@@ -26,6 +26,8 @@
 
 #pragma once
 
+#include "../oointeraction_api.h"
+
 #include "OOModel/src/declarations/Project.h"
 #include "OOModel/src/declarations/Module.h"
 #include "OOModel/src/declarations/Class.h"

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -265,19 +265,19 @@ void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem
 		{
 			case FilePersistence::ChangeType::Deletion:
 				highlightOverlayName = "delete_highlights";
-				highlightOverlayStyle = "delete_no_bg_solid_outline";
+				highlightOverlayStyle = "delete_light_bg_fine_outline";
 				break;
 			case FilePersistence::ChangeType::Insertion:
 				highlightOverlayName = "insert_highlights";
-				highlightOverlayStyle = "insert_no_bg_solid_outline";
+				highlightOverlayStyle = "insert_light_bg_fine_outline";
 				break;
 			case FilePersistence::ChangeType::Move:
 				highlightOverlayName = "move_highlights";
-				highlightOverlayStyle = "move_no_bg_solid_outline";
+				highlightOverlayStyle = "move_light_bg_fine_outline";
 				break;
 			case FilePersistence::ChangeType::Stationary:
 				highlightOverlayName = "modify_highlights";
-				highlightOverlayStyle = "modify_no_bg_solid_outline";
+				highlightOverlayStyle = "modify_light_bg_fine_outline";
 				break;
 			case FilePersistence::ChangeType::Unclassified:
 				Q_ASSERT(false);

--- a/VersionControlUI/styles/item/HighlightOverlay/delete_light_bg_fine_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/delete_light_bg_fine_outline
@@ -1,0 +1,15 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#20ff0000</color>
+		</backgroundBrush>
+		<outline>
+			<width>1.0</width>
+			<style>1</style>
+			<color>#ffff0000</color>
+		</outline>
+	</shape>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/insert_light_bg_fine_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/insert_light_bg_fine_outline
@@ -1,0 +1,15 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#20009900</color>
+		</backgroundBrush>
+		<outline>
+			<width>1.0</width>
+			<style>1</style>
+			<color>#ff009900</color>
+		</outline>
+	</shape>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/modify_light_bg_fine_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/modify_light_bg_fine_outline
@@ -1,0 +1,15 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#20ffff00</color>
+		</backgroundBrush>
+		<outline>
+			<width>1.0</width>
+			<style>1</style>
+			<color>#ffe6e600</color> 
+		</outline>
+	</shape>
+</style>

--- a/VersionControlUI/styles/item/HighlightOverlay/move_light_bg_fine_outline
+++ b/VersionControlUI/styles/item/HighlightOverlay/move_light_bg_fine_outline
@@ -1,0 +1,15 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="default">
+        <shape prototypes="shape/Box/default">
+		Box
+		<backgroundBrush>
+			<style>1</style>
+			<color>#200000ff</color>
+		</backgroundBrush>
+		<outline>
+			<width>1.0</width>
+			<style>1</style>
+			<color>#ff0000ff</color>
+		</outline>
+	</shape>
+</style>


### PR DESCRIPTION
- Add CommentedNode which associates a Node with CommentedNodes
- Use CommentedNode in CodeReviewCommentOverlay
- Implement first Iteration of CodeReviewManager
- Extend NodeIdMap with contains() method
- Add new styles for HighlightOverlay
- Add missing import
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23discussion_r63030939%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23discussion_r63031052%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23discussion_r63031212%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23discussion_r63031615%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23discussion_r63031853%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23discussion_r63032065%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23issuecomment-218779674%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23discussion_r63032832%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23issuecomment-218796123%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23issuecomment-218779674%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Alright%2C%20I%27m%20done%20with%20this%20review.%22%2C%20%22created_at%22%3A%20%222016-05-12T14%3A44%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%2C%20updated.%22%2C%20%22created_at%22%3A%20%222016-05-12T15%3A37%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%200e2877af1633f268265f2897e74fdede4306cbc0%20CodeReview/src/CodeReviewManager.cpp%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23discussion_r63031212%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20should%20use%20%60find%60%20since%20now%2C%20you%27re%20searching%20for%20the%20node%20twice%2C%20doing%20identical%20work%2C%20once%20for%20%60contains%60%20and%20for%20%60value%60.%22%2C%20%22created_at%22%3A%20%222016-05-12T14%3A35%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/CodeReviewManager.cpp%3AL23-50%22%7D%2C%20%22Pull%200e2877af1633f268265f2897e74fdede4306cbc0%20CodeReview/src/CodeReviewManager.cpp%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23discussion_r63030939%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20you%20really%20shouldn%27t%20use%20the%20name%20%60instance%60.%20This%20is%20most%20often%20associated%20with%20singletons%20and%20you%20have%20something%20else%20here.%22%2C%20%22created_at%22%3A%20%222016-05-12T14%3A34%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20can%20leave%20it%20for%20now%2C%20but%20if%20you%20do%20change%20it%20to%20return%20multiple%20instances%2C%20definitely%20use%20a%20different%20name.%22%2C%20%22created_at%22%3A%20%222016-05-12T14%3A35%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20I%27ll%20keep%20that%20in%20mind%20for%20the%20next%20iteration.%22%2C%20%22created_at%22%3A%20%222016-05-12T14%3A38%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/CodeReviewManager.cpp%3AL23-50%22%7D%2C%20%22Pull%200e2877af1633f268265f2897e74fdede4306cbc0%20CodeReview/src/commands/CCodeReviewComment.cpp%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23discussion_r63032065%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20a%20comment%20highlight%20already%20exists%2C%20should%20we%20really%20be%20creating%20any%20new%20comment%20nodes%3F%20Shouldn%27t%20this%20be%20a%20noop%20in%20that%20case%3F%22%2C%20%22created_at%22%3A%20%222016-05-12T14%3A40%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20way%20you%20can%20have%20sort%20of%20a%20%5C%22thread%5C%22%20for%20a%20node.%20It%20displays%20a%20list%20with%20the%20comments%20which%20gives%20the%20impression%20that%20multiple%20authors%20are%20discussing%20an%20issue.%20Of%20course%20you%20can%20just%20edit%20the%20first%20comment%20and%20don%27t%20add%20anything%20new.%20So%20it%27s%20not%20needed%20and%20more%20of%20a%20test%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-05-12T14%3A45%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CCodeReviewComment.cpp%3AL54-78%22%7D%2C%20%22Pull%200e2877af1633f268265f2897e74fdede4306cbc0%20CodeReview/src/commands/CCodeReviewComment.cpp%2031%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/380%23discussion_r63031853%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Like%20above%2C%20do%20not%20use%20contains%20since%20then%20you%27ll%20do%20the%20same%20work%20twice%20in%20%60id%60.%20Implement%20a%20different%20method%20that%20only%20returns%20the%20node%20if%20it%20doesn%27t%20exist%20and%20returns%20%60nullptr%60%20otherwise%20%28unlike%20the%20current%20%60id%60%29%20make%20sure%20the%20current%20%60id%60%20uses%20that%20other%20method.%22%2C%20%22created_at%22%3A%20%222016-05-12T14%3A39%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CCodeReviewComment.cpp%3AL54-78%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 0e2877af1633f268265f2897e74fdede4306cbc0 CodeReview/src/CodeReviewManager.cpp 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/380#discussion_r63030939'>File: CodeReview/src/CodeReviewManager.cpp:L23-50</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, you really shouldn't use the name `instance`. This is most often associated with singletons and you have something else here.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You can leave it for now, but if you do change it to return multiple instances, definitely use a different name.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> OK, I'll keep that in mind for the next iteration.
- [ ] <a href='#crh-comment-Pull 0e2877af1633f268265f2897e74fdede4306cbc0 CodeReview/src/CodeReviewManager.cpp 22'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/380#discussion_r63031212'>File: CodeReview/src/CodeReviewManager.cpp:L23-50</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You should use `find` since now, you're searching for the node twice, doing identical work, once for `contains` and for `value`.
- [ ] <a href='#crh-comment-Pull 0e2877af1633f268265f2897e74fdede4306cbc0 CodeReview/src/commands/CCodeReviewComment.cpp 31'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/380#discussion_r63031853'>File: CodeReview/src/commands/CCodeReviewComment.cpp:L54-78</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Like above, do not use contains since then you'll do the same work twice in `id`. Implement a different method that only returns the node if it doesn't exist and returns `nullptr` otherwise (unlike the current `id`) make sure the current `id` uses that other method.
- [ ] <a href='#crh-comment-Pull 0e2877af1633f268265f2897e74fdede4306cbc0 CodeReview/src/commands/CCodeReviewComment.cpp 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/380#discussion_r63032065'>File: CodeReview/src/commands/CCodeReviewComment.cpp:L54-78</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> If a comment highlight already exists, should we really be creating any new comment nodes? Shouldn't this be a noop in that case?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> This way you can have sort of a "thread" for a node. It displays a list with the comments which gives the impression that multiple authors are discussing an issue. Of course you can just edit the first comment and don't add anything new. So it's not needed and more of a test :)
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/380#issuecomment-218779674'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Alright, I'm done with this review.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Thanks, updated.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/380?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/380?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/380'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
