### PR TITLE
Code for Faster diff

### DIFF
--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -103,7 +103,7 @@ bool Commit::getFileContent(QString fileName, const char*& content, int& content
 		return false;
 }
 
-bool Commit::isValidMatch(const char* content, const char* indexOfId, int& start, int& end,
+bool Commit::isValidMatch(const char* content, qint64 size, const char* indexOfId, int& start, int& end,
 								  bool findChildrenByParentId) const
 {
 	start = indexOfId-content;
@@ -118,7 +118,7 @@ bool Commit::isValidMatch(const char* content, const char* indexOfId, int& start
 	start++;
 
 	// end is the character after the line containing id
-	while (content[end] != '\0' && content[end] != '\n')
+	while (end < size && content[end] != '\n')
 	{
 		// String is of the form {id} {*.}
 		if (findChildrenByParentId && content[end] == '{') return false;
@@ -137,7 +137,7 @@ QStringList Commit::nodeLinesFromId(Model::NodeIdType id, bool findChildrenByPar
 		while (pointer)
 		{
 			int start, end;
-			if (isValidMatch(file->content(), pointer, start, end, findChildrenByParentId))
+			if (isValidMatch(file->content(), file->size_, pointer, start, end, findChildrenByParentId))
 			{
 				char *data = new char[end-start+1];
 				strncpy(data, file->content()+start, end-start);

--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -133,20 +133,22 @@ QStringList Commit::nodeLinesFromId(Model::NodeIdType id, bool findChildrenByPar
 	QStringList matches;
 	for (auto file : files())
 	{
-		int indexOfId = 0;
-		auto content = QString::fromUtf8(file->content());
-
-		indexOfId = content.indexOf(idText, indexOfId);
-		if (indexOfId != -1)
+		if (strstr(file->content(), idText.toLatin1().constData()))
 		{
-			int start, end;
-			if (isValidMatch(content, indexOfId, start, end, findChildrenByParentId))
+			int indexOfId = 0;
+			auto content = QString::fromUtf8(file->content());
+			indexOfId = content.indexOf(idText, indexOfId);
+			if (indexOfId != -1)
 			{
-				QString match = file->relativePath_ + ":" + content.mid(start, end-start);
-				matches << match;
+				int start, end;
+				if (isValidMatch(content, indexOfId, start, end, findChildrenByParentId))
+				{
+					QString match = file->relativePath_ + ":" + content.mid(start, end-start);
+					matches << match;
+				}
+				// Find the next match
+				indexOfId = indexOfId + 1;
 			}
-			// Find the next match
-			indexOfId = indexOfId + 1;
 		}
 	}
 	return matches;

--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -133,11 +133,11 @@ QStringList Commit::nodeLinesFromId(Model::NodeIdType id, bool findChildrenByPar
 	QStringList matches;
 	for (auto file : files())
 	{
-		const char *pointer = strstr(file->content(), idText.constData());
-		while (pointer)
+		const char *matchingLocation = strstr(file->content(), idText.constData());
+		while (matchingLocation)
 		{
 			int start, end;
-			if (isValidMatch(file->content(), file->size_, pointer, start, end, findChildrenByParentId))
+			if (isValidMatch(file->content(), file->size_, matchingLocation, start, end, findChildrenByParentId))
 			{
 				char *data = new char[end-start+1];
 				strncpy(data, file->content()+start, end-start);
@@ -147,8 +147,8 @@ QStringList Commit::nodeLinesFromId(Model::NodeIdType id, bool findChildrenByPar
 				matches << match;
 			}
 			// Find the next match
-			pointer++;
-			pointer = strstr(pointer, idText.constData());
+			matchingLocation++;
+			matchingLocation = strstr(matchingLocation, idText.constData());
 		}
 	}
 	return matches;

--- a/FilePersistence/src/version_control/Commit.h
+++ b/FilePersistence/src/version_control/Commit.h
@@ -80,7 +80,7 @@ class FILEPERSISTENCE_API Commit
 		void addFile(QString relativePath, qint64 size, std::unique_ptr<char[], CommitFileContentDeleter> content);
 
 		bool getFileContent(QString fileName, const char*& content, int& contentSize, bool exactFileNameMatching) const;
-		bool isValidMatch(const char* content, const char* indexOfId, int& start, int& end,
+		bool isValidMatch(const char* content, qint64 size, const char* indexOfId, int& start, int& end,
 								bool findChildrenByParentId) const;
 		QStringList nodeLinesFromId(Model::NodeIdType id, bool findChildrenByParentId = false) const;
 

--- a/FilePersistence/src/version_control/Commit.h
+++ b/FilePersistence/src/version_control/Commit.h
@@ -80,7 +80,8 @@ class FILEPERSISTENCE_API Commit
 		void addFile(QString relativePath, qint64 size, std::unique_ptr<char[], CommitFileContentDeleter> content);
 
 		bool getFileContent(QString fileName, const char*& content, int& contentSize, bool exactFileNameMatching) const;
-		bool isValidMatch(const char* content, int indexOfId, int& start, int& end, bool findChildrenByParentId) const;
+		bool isValidMatch(const char* content, const char* indexOfId, int& start, int& end,
+								bool findChildrenByParentId) const;
 		QStringList nodeLinesFromId(Model::NodeIdType id, bool findChildrenByParentId = false) const;
 
 

--- a/FilePersistence/src/version_control/Commit.h
+++ b/FilePersistence/src/version_control/Commit.h
@@ -80,7 +80,7 @@ class FILEPERSISTENCE_API Commit
 		void addFile(QString relativePath, qint64 size, std::unique_ptr<char[], CommitFileContentDeleter> content);
 
 		bool getFileContent(QString fileName, const char*& content, int& contentSize, bool exactFileNameMatching) const;
-		bool isValidMatch(QString content, int indexOfId, int& start, int& end, bool findChildrenByParentId) const;
+		bool isValidMatch(const char* content, int indexOfId, int& start, int& end, bool findChildrenByParentId) const;
 		QStringList nodeLinesFromId(Model::NodeIdType id, bool findChildrenByParentId = false) const;
 
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64180225%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64180443%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64409698%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64410032%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64411051%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64469633%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64526561%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64526689%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20fc9a53930b187f6efaf579ee3614c84ecd4ff319%20FilePersistence/src/version_control/Commit.cpp%2044%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64410032%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Here%20also%20pass%20%60file-%3Esize_%60%20and%20use%20that%20to%20check%20for%20the%20end.%22%2C%20%22created_at%22%3A%20%222016-05-24T15%3A08%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL129-155%22%7D%2C%20%22Pull%206bde9c563bf032a106a61a05e4307e51722dbb34%20FilePersistence/src/version_control/Commit.cpp%2051%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64469633%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40Vaishal-shah%20/%20%40dimitar-asenov%20should%20be%3A%20delete%5B%5D%20data%20%28clang%2B%2B3.8%20flags%20this%20as%20error%29%22%2C%20%22created_at%22%3A%20%222016-05-24T20%3A38%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3530769%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lukedirtwalker%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20yes%20of%20course.%20Thanks%20%40lukedirtwalker.%5Cr%5Cn%5Cr%5Cn%40Vaishal-shah%3A%20could%20you%20please%20submit%20a%20PR%20fixing%20this%3F%20However%20instead%20of%20simply%20putting%20the%20missing%20%60%5B%5D%60%2C%20let%27s%20make%20the%20code%20better%20by%20using%20%60QByteArray%60%20that%20will%20take%20care%20of%20memory%20management%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20QString%20match%7Bfile-%3ErelativePath_%7D%3B%5Cr%5Cn%20%20%20%20match%20%3C%3C%20QByteArray%7Bfile-%3Econtent%28%29%2Bstart%2C%20end-start%7D%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-05-25T07%3A28%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22actually%20the%20first%20line%20should%20be%20%60QString%20match%7Bfile-%3ErelativePath_%20%2B%20%5C%22%3A%5C%22%7D%3B%60%22%2C%20%22created_at%22%3A%20%222016-05-25T07%3A29%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL129-155%22%7D%2C%20%22Pull%20fc9a53930b187f6efaf579ee3614c84ecd4ff319%20FilePersistence/src/version_control/Commit.cpp%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64411051%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Don%27t%20use%20names%20like%20%60pointer%60%20which%20don%27t%20tell%20us%20anything%20about%20their%20content.%20Better%3A%20%60matchingLocation%60%22%2C%20%22created_at%22%3A%20%222016-05-24T15%3A13%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL129-155%22%7D%2C%20%22Pull%20fc9a53930b187f6efaf579ee3614c84ecd4ff319%20FilePersistence/src/version_control/Commit.cpp%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64409698%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20condition%20is%20not%20good%2C%20you%20need%20a%20separate%20parameter%20to%20the%20%60isValidMatch%60%20function%20that%20tells%20you%20what%20the%20size%20of%20the%20content%20is%20and%20you%20should%20check%20that%20here.%20You%20can%20get%20the%20size%20directly%20from%20the%20commit%20object.%22%2C%20%22created_at%22%3A%20%222016-05-24T15%3A07%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL118-125%22%7D%2C%20%22Pull%2003e1d902a40b637951ecc2f09b1676aa32df680b%20FilePersistence/src/version_control/Commit.cpp%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64180225%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Here%2C%20instead%20of%20converting%20the%20entire%20file%20to%20QString%2C%20search%20for%20the%20previous%20%27%5C%5Cn%27%20%28or%20the%20beginning%20of%20the%20file%2C%20whichever%20comes%20first%29%20and%20the%20following%20%27%5C%5Cn%27%20%28or%20the%20end%20of%20the%20file%29%20and%20the%20only%20convert%20this%20line%20to%20UTF%208.%20You%20will%20need%20to%20modify%20the%20%60isValidMatch%60%20method%20to%20use%20this%20new%20interface.%22%2C%20%22created_at%22%3A%20%222016-05-23T07%3A46%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL133-155%22%7D%2C%20%22Pull%2003e1d902a40b637951ecc2f09b1676aa32df680b%20FilePersistence/src/version_control/Commit.cpp%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/385%23discussion_r64180443%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20I%20just%20realized%20that%20neither%20this%20new%20version%2C%20nor%20the%20old%20version%20actually%20makes%20use%20of%20this%20%60indexOfId%60.%20Indeed%20we%20need%20to%20have%20a%20loop%20somewhere%20that%20keeps%20searching%20after%20we%27ve%20already%20found%20a%20string%2C%20in%20case%20the%20first%20thing%20we%20find%2C%20wasn%27t%20the%20correct%20node.%20This%20loop%20should%20continue%20searching%20using%20%60strstr%60%20for%20efficiency%2C%20starting%20after%20the%20currently%20found%20substring.%22%2C%20%22created_at%22%3A%20%222016-05-23T07%3A48%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL133-155%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 03e1d902a40b637951ecc2f09b1676aa32df680b FilePersistence/src/version_control/Commit.cpp 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/385#discussion_r64180225'>File: FilePersistence/src/version_control/Commit.cpp:L133-155</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Here, instead of converting the entire file to QString, search for the previous '\n' (or the beginning of the file, whichever comes first) and the following '\n' (or the end of the file) and the only convert this line to UTF 8. You will need to modify the `isValidMatch` method to use this new interface.
- [x] <a href='#crh-comment-Pull 03e1d902a40b637951ecc2f09b1676aa32df680b FilePersistence/src/version_control/Commit.cpp 27'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/385#discussion_r64180443'>File: FilePersistence/src/version_control/Commit.cpp:L133-155</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, I just realized that neither this new version, nor the old version actually makes use of this `indexOfId`. Indeed we need to have a loop somewhere that keeps searching after we've already found a string, in case the first thing we find, wasn't the correct node. This loop should continue searching using `strstr` for efficiency, starting after the currently found substring.
- [x] <a href='#crh-comment-Pull fc9a53930b187f6efaf579ee3614c84ecd4ff319 FilePersistence/src/version_control/Commit.cpp 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/385#discussion_r64409698'>File: FilePersistence/src/version_control/Commit.cpp:L118-125</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> this condition is not good, you need a separate parameter to the `isValidMatch` function that tells you what the size of the content is and you should check that here. You can get the size directly from the commit object.
- [x] <a href='#crh-comment-Pull fc9a53930b187f6efaf579ee3614c84ecd4ff319 FilePersistence/src/version_control/Commit.cpp 44'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/385#discussion_r64410032'>File: FilePersistence/src/version_control/Commit.cpp:L129-155</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Here also pass `file->size_` and use that to check for the end.
- [x] <a href='#crh-comment-Pull fc9a53930b187f6efaf579ee3614c84ecd4ff319 FilePersistence/src/version_control/Commit.cpp 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/385#discussion_r64411051'>File: FilePersistence/src/version_control/Commit.cpp:L129-155</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Don't use names like `pointer` which don't tell us anything about their content. Better: `matchingLocation`
- [ ] <a href='#crh-comment-Pull 6bde9c563bf032a106a61a05e4307e51722dbb34 FilePersistence/src/version_control/Commit.cpp 51'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/385#discussion_r64469633'>File: FilePersistence/src/version_control/Commit.cpp:L129-155</a></b>
- <a href='https://github.com/lukedirtwalker'><img border=0 src='https://avatars.githubusercontent.com/u/3530769?v=3' height=16 width=16'></a> @Vaishal-shah / @dimitar-asenov should be: delete[] data (clang++3.8 flags this as error)
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Oh, yes of course. Thanks @lukedirtwalker.
  @Vaishal-shah: could you please submit a PR fixing this? However instead of simply putting the missing `[]`, let's make the code better by using `QByteArray` that will take care of memory management:
  QString match{file->relativePath_};
  match << QByteArray{file->content()+start, end-start};
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> actually the first line should be `QString match{file->relativePath_ + ":"};`

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/385?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/385?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/385'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
