### PR TITLE
Make CodeReviewCommentOverlay movable

### DIFF
--- a/CodeReview/CMakeLists.txt
+++ b/CodeReview/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(CodeReview SHARED
 	src/overlays/CodeReviewCommentOverlay.h
 	src/overlays/CodeReviewCommentOverlayStyle.h
 	src/handlers/HReviewableItem.h
+	src/handlers/HCodeReviewOverlay.h
 	src/nodes/CommentedNode.h
 	src/nodes/ReviewComment.h
 	src/items/VCommentedNode.h
@@ -26,6 +27,7 @@ add_library(CodeReview SHARED
 	src/overlays/CodeReviewCommentOverlay.cpp
 	src/overlays/CodeReviewCommentOverlayStyle.cpp
 	src/handlers/HReviewableItem.cpp
+	src/handlers/HCodeReviewOverlay.cpp
 	src/nodes/CommentedNode.cpp
 	src/nodes/ReviewComment.cpp
 	src/items/VCommentedNode.cpp

--- a/CodeReview/src/handlers/HCodeReviewOverlay.cpp
+++ b/CodeReview/src/handlers/HCodeReviewOverlay.cpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -24,41 +24,28 @@
  **
  **********************************************************************************************************************/
 
-#include "handlers/HReviewableItem.h"
+#include "HCodeReviewOverlay.h"
 
-#include "CodeReviewPlugin.h"
-#include "SelfTest/src/TestManager.h"
-#include "Logger/src/Log.h"
-
-#include "overlays/CodeReviewCommentOverlay.h"
-
-#include "handlers/HCodeReviewOverlay.h"
-
-#include "VersionControlUI/src/items/VDiffComparisonPair.h"
+#include "../commands/CCodeReviewComment.h"
 
 namespace CodeReview {
 
-Logger::Log& CodeReviewPlugin::log()
+HCodeReviewOverlay* HCodeReviewOverlay::instance()
 {
-	static auto log = Logger::Log::getLogger("PLUGIN_NAME_LOWER");
-	return *log;
+	static HCodeReviewOverlay h;
+	return &h;
 }
 
-bool CodeReviewPlugin::initialize(Core::EnvisionManager&)
+void HCodeReviewOverlay::mouseMoveEvent(Visualization::Item *target, QGraphicsSceneMouseEvent *event)
 {
-	VersionControlUI::VDiffComparisonPair::setDefaultClassHandler(HReviewableItem::instance());
-	CodeReviewCommentOverlay::setDefaultClassHandler(HCodeReviewOverlay::instance());
-	return true;
-}
+	HMovableItem::mouseMoveEvent(target, event);
+	if (event->buttons() & Qt::LeftButton && target)
+	{
+		auto overlay = static_cast<CodeReviewCommentOverlay*>(target);
+		QPointF diff{(event->scenePos() - event->buttonDownScenePos(Qt::LeftButton))};
+		overlay->updateOffsetItemLocal(itemPosition() + diff);
+	}
 
-void CodeReviewPlugin::unload()
-{
-}
-
-void CodeReviewPlugin::selfTest(QString testid)
-{
-	if (testid.isEmpty()) SelfTest::TestManager<CodeReviewPlugin>::runAllTests().printResultStatistics();
-	else SelfTest::TestManager<CodeReviewPlugin>::runTest(testid).printResultStatistics();
 }
 
 }

--- a/CodeReview/src/handlers/HCodeReviewOverlay.cpp
+++ b/CodeReview/src/handlers/HCodeReviewOverlay.cpp
@@ -39,7 +39,7 @@ HCodeReviewOverlay* HCodeReviewOverlay::instance()
 void HCodeReviewOverlay::mouseMoveEvent(Visualization::Item *target, QGraphicsSceneMouseEvent *event)
 {
 	HMovableItem::mouseMoveEvent(target, event);
-	if (event->buttons() & Qt::LeftButton && target)
+	if (event->buttons() == Qt::LeftButton && target)
 	{
 		auto overlay = static_cast<CodeReviewCommentOverlay*>(target);
 		QPointF diff{(event->scenePos() - event->buttonDownScenePos(Qt::LeftButton))};

--- a/CodeReview/src/handlers/HCodeReviewOverlay.h
+++ b/CodeReview/src/handlers/HCodeReviewOverlay.h
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
  **
- ** Copyright (c) 2011, 2015 ETH Zurich
+ ** Copyright (c) 2011, 2016 ETH Zurich
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -24,41 +24,24 @@
  **
  **********************************************************************************************************************/
 
-#include "handlers/HReviewableItem.h"
+#pragma once
 
-#include "CodeReviewPlugin.h"
-#include "SelfTest/src/TestManager.h"
-#include "Logger/src/Log.h"
+#include "../codereview_api.h"
 
-#include "overlays/CodeReviewCommentOverlay.h"
+#include "../overlays/CodeReviewCommentOverlay.h"
 
-#include "handlers/HCodeReviewOverlay.h"
-
-#include "VersionControlUI/src/items/VDiffComparisonPair.h"
+#include "InteractionBase/src/handlers/HMovableItem.h"
 
 namespace CodeReview {
 
-Logger::Log& CodeReviewPlugin::log()
-{
-	static auto log = Logger::Log::getLogger("PLUGIN_NAME_LOWER");
-	return *log;
-}
+class CODEREVIEW_API HCodeReviewOverlay : public Interaction::HMovableItem {
 
-bool CodeReviewPlugin::initialize(Core::EnvisionManager&)
-{
-	VersionControlUI::VDiffComparisonPair::setDefaultClassHandler(HReviewableItem::instance());
-	CodeReviewCommentOverlay::setDefaultClassHandler(HCodeReviewOverlay::instance());
-	return true;
-}
+	public:
+		static HCodeReviewOverlay* instance();
 
-void CodeReviewPlugin::unload()
-{
-}
+	private:
+		virtual void mouseMoveEvent(Visualization::Item *target, QGraphicsSceneMouseEvent *event) override;
+};
 
-void CodeReviewPlugin::selfTest(QString testid)
-{
-	if (testid.isEmpty()) SelfTest::TestManager<CodeReviewPlugin>::runAllTests().printResultStatistics();
-	else SelfTest::TestManager<CodeReviewPlugin>::runTest(testid).printResultStatistics();
-}
 
 }

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -34,6 +34,8 @@
 
 #include "VisualizationBase/src/VisualizationManager.h"
 
+#include "../handlers/HCodeReviewOverlay.h"
+
 namespace CodeReview
 {
 
@@ -45,19 +47,24 @@ CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associat
 {
 	setAcceptedMouseButtons(Qt::AllButtons);
 	setFlag(QGraphicsItem::ItemIgnoresTransformations);
+	offsetItemLocal_ = QPoint{0, associatedItem->heightInLocal()};
 }
 
 void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableHeight)
 {
 	Super::updateGeometry(availableWidth, availableHeight);
-	qreal height = associatedItem()->heightInScene();
-	setPos(associatedItem()->scenePos() + QPointF{0, height});
+	setPos(associatedItem()->mapToScene(offsetItemLocal_));
 }
 
 void CodeReviewCommentOverlay::initializeForms()
 {
 	addForm(item(&I::commentedNodeItem_, [](I* v) {return v->commentedNode_;}));
 
+}
+
+void CodeReviewCommentOverlay::updateOffsetItemLocal(QPointF scenePos)
+{
+	offsetItemLocal_ = CodeReviewCommentOverlay::associatedItem()->mapFromScene(scenePos);
 }
 
 }

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.h
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.h
@@ -50,12 +50,16 @@ class CODEREVIEW_API CodeReviewCommentOverlay :
 
 		static void initializeForms();
 
+		void updateOffsetItemLocal(QPointF scenePos);
+
 	protected:
 		virtual void updateGeometry(int availableWidth, int availableHeight) override;
 
 	private:
 		CommentedNode* commentedNode_{};
 		Visualization::Item* commentedNodeItem_{};
+
+		QPointF offsetItemLocal_;
 
 };
 

--- a/InteractionBase/src/commands/CAddNodeToViewByName.cpp
+++ b/InteractionBase/src/commands/CAddNodeToViewByName.cpp
@@ -55,13 +55,17 @@ CommandResult* CAddNodeToViewByName::execute(Visualization::Item* source, Visual
 
 	if (layoutCursor && cursor->owner() == currentView && cursor->type() != Visualization::Cursor::BoxCursor)
 	{
-		if ((cursor->type() == Visualization::Cursor::HorizontalCursor
-			 && currentView->majorAxis() == Visualization::GridLayouter::ColumnMajor) ||
-			 (cursor->type() == Visualization::Cursor::VerticalCursor
-						  && currentView->majorAxis() != Visualization::GridLayouter::ColumnMajor) )
+		if (cursor->type() == Visualization::Cursor::HorizontalCursor
+			 && currentView->majorAxis() == Visualization::GridLayouter::ColumnMajor)
 		{
 			indexToInsert.major_ = layoutCursor->x();
 			indexToInsert.minor_ = layoutCursor->y();
+		}
+		else if (cursor->type() == Visualization::Cursor::VerticalCursor
+								 && currentView->majorAxis() != Visualization::GridLayouter::ColumnMajor)
+		{
+			indexToInsert.major_ = layoutCursor->y();
+			indexToInsert.minor_ = layoutCursor->x();
 		}
 		else if (cursor->type() == Visualization::Cursor::VerticalCursor
 					&& currentView->majorAxis() == Visualization::GridLayouter::ColumnMajor)

--- a/InteractionBase/src/handlers/HMovableItem.h
+++ b/InteractionBase/src/handlers/HMovableItem.h
@@ -40,10 +40,13 @@ class INTERACTIONBASE_API HMovableItem : public GenericHandler
 		virtual void mousePressEvent(Visualization::Item* target, QGraphicsSceneMouseEvent *event) override;
 		virtual void mouseMoveEvent(Visualization::Item *target, QGraphicsSceneMouseEvent *event) override;
 
+		QPointF itemPosition();
 	private:
 		QPointF itemPosition_;
 
 		void move(Visualization::Item* item, const QPointF& to);
 };
+
+inline QPointF HMovableItem::itemPosition(){ return itemPosition_;}
 
 }


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/386%23discussion_r64338567%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/386%23issuecomment-221192302%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/386%23issuecomment-221192302%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Updated.%5Cr%5Cn%5Cr%5CnAlso%20added%20a%20commit%20for%20the%20handling%20of%20HorizontalCursor%20in%20ColumnMajor%20grid%20in%20CAddNodeToViewByName.%22%2C%20%22created_at%22%3A%20%222016-05-24T07%3A50%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%204268390ede5432013a62175117f50055c22947e8%20CodeReview/src/handlers/HCodeReviewOverlay.cpp%2042%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/386%23discussion_r64338567%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20not%20make%20this%20check%20stricter%3A%20%60buttons%28%29%20%3D%3D%20Qt%3A%3ALeftButton%60%3F%22%2C%20%22created_at%22%3A%20%222016-05-24T07%3A15%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/handlers/HCodeReviewOverlay.cpp%3AL1-52%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 4268390ede5432013a62175117f50055c22947e8 CodeReview/src/handlers/HCodeReviewOverlay.cpp 42'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/386#discussion_r64338567'>File: CodeReview/src/handlers/HCodeReviewOverlay.cpp:L1-52</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> why not make this check stricter: `buttons() == Qt::LeftButton`?
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/386#issuecomment-221192302'>General Comment</a></b>
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Updated.
  Also added a commit for the handling of HorizontalCursor in ColumnMajor grid in CAddNodeToViewByName.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/386?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/386?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/386'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
