### PR TITLE
Gm wfpr

### DIFF
--- a/CodeReview/src/commands/CCodeReviewComment.cpp
+++ b/CodeReview/src/commands/CCodeReviewComment.cpp
@@ -58,13 +58,15 @@ bool CCodeReviewComment::canInterpret(Visualization::Item*, Visualization::Item*
 Interaction::CommandResult* CCodeReviewComment::execute(Visualization::Item* source, Visualization::Item*,
 				const QStringList&, const std::unique_ptr<Visualization::Cursor>&)
 {
+	auto ancestorWithNodeItem = source->findAncestorWithNode();
+
 	for (auto manager : Model::AllTreeManagers::instance().loadedManagers())
 	{
-		auto id = manager->nodeIdMap().idIfExists(source->node());
+		auto id = manager->nodeIdMap().idIfExists(ancestorWithNodeItem->node());
+
 		if (!id.isNull())
 		{
-			auto id = manager->nodeIdMap().id(source->node()).toString();
-			auto commentedNode = CodeReviewManager::instance().commentedNode(id);
+			auto commentedNode = CodeReviewManager::instance().commentedNode(id.toString());
 			commentedNode->reviewComments()->append(new ReviewComment{});
 
 			// only create highlight if not already existent

--- a/CodeReview/src/items/VCommentedNode.cpp
+++ b/CodeReview/src/items/VCommentedNode.cpp
@@ -53,8 +53,6 @@ void VCommentedNode::initializeForms()
 			return v->node()->reviewComments();});
 	auto grid = (new Visualization::GridLayoutFormElement{})
 			->setHorizontalSpacing(50)
-			->setLeftMargin(10)
-			->setRightMargin(10)
 			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
 			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
 			->setColumnStretchFactor(0, 1)

--- a/CodeReview/src/items/VReviewComment.cpp
+++ b/CodeReview/src/items/VReviewComment.cpp
@@ -44,8 +44,7 @@ VReviewComment::VReviewComment(Visualization::Item* parent, NodeType* node, cons
 void VReviewComment::initializeForms()
 {
 	auto headerContent = (new Visualization::GridLayoutFormElement{})
-		->setHorizontalSpacing(3)
-		->setColumnStretchFactor(3, 1)
+		->setColumnStretchFactor(0, 1)
 		->setVerticalAlignment(Visualization::LayoutStyle::Alignment::Center)
 		->setNoBoundaryCursors([](Item*){return true;})
 		->setNoInnerCursors([](Item*){return true;})
@@ -59,7 +58,7 @@ void VReviewComment::initializeForms()
 			->put(TheTopOf, headerBackground, 2, FromTopOf, headerContent)
 			->put(TheBottomOf, headerBackground, 2, FromBottomOf, headerContent)
 			->put(TheRightOf, headerBackground, 2, FromRightOf, headerContent)}})
-			->setColumnStretchFactor(1, 1);
+			->setColumnStretchFactor(0, 1);
 
 	auto shapeElement = new Visualization::ShapeFormElement{};
 

--- a/CodeReview/src/nodes/CommentedNode.cpp
+++ b/CodeReview/src/nodes/CommentedNode.cpp
@@ -29,6 +29,9 @@
 
 #include "ReviewComment.h"
 
+#include "ModelBase/src/nodes/TypedList.hpp"
+
+template class Model::TypedList<CodeReview::CommentedNode>;
 
 namespace CodeReview
 {

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -58,7 +58,15 @@ void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableH
 
 void CodeReviewCommentOverlay::initializeForms()
 {
-	addForm(item(&I::commentedNodeItem_, [](I* v) {return v->commentedNode_;}));
+	auto grid = (new Visualization::GridLayoutFormElement{})
+							->setColumnStretchFactor(0, 1)
+							->setMargins(5, 5, 5, 5)
+							->setVerticalAlignment(Visualization::LayoutStyle::Alignment::Center)
+							->setNoBoundaryCursors([](Item*){return true;})
+							->setNoInnerCursors([](Item*){return true;})
+							->put(0, 0, item(&I::commentedNodeItem_, [](I* v) {return v->commentedNode_;}));
+
+	addForm(grid);
 
 }
 

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -47,6 +47,7 @@ CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associat
 {
 	setAcceptedMouseButtons(Qt::AllButtons);
 	setFlag(QGraphicsItem::ItemIgnoresTransformations);
+	setItemCategory(Visualization::Scene::MenuItemCategory);
 	offsetItemLocal_ = QPoint{0, associatedItem->heightInLocal()};
 }
 

--- a/VersionControlUI/src/nodes/DiffComparisonPair.cpp
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.cpp
@@ -27,6 +27,10 @@
 
 #include "ModelBase/src/nodes/composite/CompositeNode.h"
 
+#include "ModelBase/src/nodes/TypedList.hpp"
+
+template class Model::TypedList<VersionControlUI::DiffComparisonPair>;
+
 namespace VersionControlUI
 {
 


### PR DESCRIPTION
- Change visualization of review comments to facilitate moving of the overlay
- Add missing TypedList template instantiation
- Disable drawing of CodeReviewCommentOverlays on minimap
- Use findAncestorWithNode to find correct item in CCodeReviewComment
  <a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
  <a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/388?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/388'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
  <a href='#crh-end'></a>
