### PR TITLE
Gm wfpr

### DIFF
--- a/CodeReview/src/items/VCommentedNode.cpp
+++ b/CodeReview/src/items/VCommentedNode.cpp
@@ -47,6 +47,11 @@ VCommentedNode::VCommentedNode(Visualization::Item* parent, NodeType* node, cons
 {
 }
 
+Visualization::Item::UpdateType VCommentedNode::needsUpdate()
+{
+	return Visualization::Item::StandardUpdate;
+}
+
 void VCommentedNode::initializeForms()
 {
 	auto comments = item<Visualization::VList>(&I::comments_, [](I* v) {

--- a/CodeReview/src/items/VCommentedNode.h
+++ b/CodeReview/src/items/VCommentedNode.h
@@ -53,6 +53,7 @@ class CODEREVIEW_API VCommentedNode : public Super<Visualization::ItemWithNode<V
 	public:
 		VCommentedNode(Visualization::Item* parent, NodeType* node, const StyleType* style = itemStyles().get());
 		static void initializeForms();
+		virtual Visualization::Item::UpdateType needsUpdate() override;
 
 	private:
 		Visualization::VList* comments_{};

--- a/CodeReview/src/items/VReviewComment.cpp
+++ b/CodeReview/src/items/VReviewComment.cpp
@@ -36,11 +36,11 @@ namespace CodeReview
 
 DEFINE_ITEM_COMMON(VReviewComment, "item")
 
-VReviewComment::VReviewComment(Visualization::Item* parent, NodeType* nodeType, const StyleType* style)
-	: Super{parent, nodeType, style}
+VReviewComment::VReviewComment(Visualization::Item* parent, NodeType* node, const StyleType* style)
+	: Super{parent, node, style}
 {
 	date_ = new Visualization::Text{this,  ""};
-	username_ = new Visualization::Text{this, node()->username()};
+	username_ = new Visualization::Text{this, node->username()};
 }
 
 void VReviewComment::initializeForms()

--- a/CodeReview/src/items/VReviewComment.cpp
+++ b/CodeReview/src/items/VReviewComment.cpp
@@ -80,8 +80,6 @@ Visualization::Item::UpdateType VReviewComment::needsUpdate()
 void VReviewComment::determineChildren()
 {
 	Super::determineChildren();
-
-	// TODO implement mechanism for time-based updates to avoid exploiting determineChildren and needsUpdate
 	updateDateText();
 }
 

--- a/CodeReview/src/items/VReviewComment.cpp
+++ b/CodeReview/src/items/VReviewComment.cpp
@@ -72,6 +72,19 @@ void VReviewComment::initializeForms()
 	addForm(container);
 }
 
+Visualization::Item::UpdateType VReviewComment::needsUpdate()
+{
+	return Visualization::Item::StandardUpdate;
+}
+
+void VReviewComment::determineChildren()
+{
+	Super::determineChildren();
+
+	// TODO implement mechanism for time-based updates to avoid exploiting determineChildren and needsUpdate
+	updateDateText();
+}
+
 void VReviewComment::updateDateText()
 {
 	auto commentDate = QDateTime::fromMSecsSinceEpoch(node()->date());

--- a/CodeReview/src/items/VReviewComment.cpp
+++ b/CodeReview/src/items/VReviewComment.cpp
@@ -40,7 +40,6 @@ VReviewComment::VReviewComment(Visualization::Item* parent, NodeType* node, cons
 	: Super{parent, node, style}
 {
 	date_ = new Visualization::Text{this,  ""};
-	username_ = new Visualization::Text{this, node->username()};
 }
 
 void VReviewComment::initializeForms()
@@ -53,7 +52,8 @@ void VReviewComment::initializeForms()
 			->setNoInnerCursors([](Item*){return true;})
 			->setHorizontalSpacing(10)
 			->setColumnHorizontalAlignment(3, Visualization::LayoutStyle::Alignment::Right)
-			->put(0, 0, item<Visualization::Text>(&I::username_, &StyleType::username))
+			->put(0, 0, item<Visualization::VText>(&I::username_, [](I* v)
+					{return v->node()->usernameNode();}, &StyleType::username))
 			->put(3, 0, item<Visualization::Text>(&I::date_, &StyleType::date));
 
 

--- a/CodeReview/src/items/VReviewComment.h
+++ b/CodeReview/src/items/VReviewComment.h
@@ -55,6 +55,8 @@ class CODEREVIEW_API VReviewComment : public Super<Visualization::ItemWithNode<V
 	public:
 		VReviewComment(Visualization::Item* parent, NodeType* nodeType, const StyleType* style = itemStyles().get());
 		static void initializeForms();
+		virtual void determineChildren() override;
+		virtual Visualization::Item::UpdateType needsUpdate() override;
 
 	private:
 		void updateDateText();

--- a/CodeReview/src/items/VReviewComment.h
+++ b/CodeReview/src/items/VReviewComment.h
@@ -53,7 +53,7 @@ class CODEREVIEW_API VReviewComment : public Super<Visualization::ItemWithNode<V
 	ITEM_COMMON(VReviewComment)
 
 	public:
-		VReviewComment(Visualization::Item* parent, NodeType* nodeType, const StyleType* style = itemStyles().get());
+		VReviewComment(Visualization::Item* parent, NodeType* node, const StyleType* style = itemStyles().get());
 		static void initializeForms();
 		virtual void determineChildren() override;
 		virtual Visualization::Item::UpdateType needsUpdate() override;

--- a/CodeReview/src/items/VReviewComment.h
+++ b/CodeReview/src/items/VReviewComment.h
@@ -38,7 +38,7 @@
 #include "Comments/src/items/VComment.h"
 
 #include "VisualizationBase/src/items/Item.h"
-#include "VisualizationBase/src/items/VText.h"
+#include "VisualizationBase/src/items/Text.h"
 #include "VisualizationBase/src/items/EmptyItem.h"
 
 
@@ -53,11 +53,13 @@ class CODEREVIEW_API VReviewComment : public Super<Visualization::ItemWithNode<V
 	ITEM_COMMON(VReviewComment)
 
 	public:
-		VReviewComment(Visualization::Item* parent, NodeType* node, const StyleType* style = itemStyles().get());
+		VReviewComment(Visualization::Item* parent, NodeType* nodeType, const StyleType* style = itemStyles().get());
 		static void initializeForms();
 
 	private:
-		Visualization::VText* date_{};
+		void updateDateText();
+		Visualization::Text* date_{};
+		Visualization::Text* username_{};
 		Comments::VComment* comment_{};
 };
 

--- a/CodeReview/src/items/VReviewComment.h
+++ b/CodeReview/src/items/VReviewComment.h
@@ -39,6 +39,7 @@
 
 #include "VisualizationBase/src/items/Item.h"
 #include "VisualizationBase/src/items/Text.h"
+#include "VisualizationBase/src/items/VText.h"
 #include "VisualizationBase/src/items/EmptyItem.h"
 
 
@@ -61,7 +62,7 @@ class CODEREVIEW_API VReviewComment : public Super<Visualization::ItemWithNode<V
 	private:
 		void updateDateText();
 		Visualization::Text* date_{};
-		Visualization::Text* username_{};
+		Visualization::VText* username_{};
 		Comments::VComment* comment_{};
 };
 

--- a/CodeReview/src/items/VReviewCommentStyle.h
+++ b/CodeReview/src/items/VReviewCommentStyle.h
@@ -41,6 +41,7 @@ class CODEREVIEW_API VReviewCommentStyle : public Super<Visualization::Declarati
 		virtual ~VReviewCommentStyle() override;
 		Property<Comments::VCommentStyle> comment{this, "comment"};
 		Property<Visualization::TextStyle> date{this, "date"};
+		Property<Visualization::TextStyle> username{this, "username"};
 
 };
 

--- a/CodeReview/src/nodes/ReviewComment.cpp
+++ b/CodeReview/src/nodes/ReviewComment.cpp
@@ -37,12 +37,14 @@ namespace CodeReview
 DEFINE_COMPOSITE_TYPE_REGISTRATION_METHODS(ReviewComment)
 
 DEFINE_ATTRIBUTE(ReviewComment, commentNode, CommentNode, false, false, true)
+DEFINE_ATTRIBUTE(ReviewComment, username, Text, false, false, true)
+DEFINE_ATTRIBUTE(ReviewComment, dateString, Text, false, false, true)
 
 ReviewComment::ReviewComment(Comments::CommentNode* commentNode, qint64 date, Model::Node* parent) :
 	Super{parent, ReviewComment::getMetaData()}
 {
-	date_ = date;
-	username_ = systemUsername();
+	setUsername(systemUsername());
+	setDate(date);
 	setComment(commentNode);
 }
 

--- a/CodeReview/src/nodes/ReviewComment.cpp
+++ b/CodeReview/src/nodes/ReviewComment.cpp
@@ -42,11 +42,11 @@ ReviewComment::ReviewComment(Comments::CommentNode* commentNode, qint64 date, Mo
 	Super{parent, ReviewComment::getMetaData()}
 {
 	date_ = date;
-	username_ = getSystemUsername();
+	username_ = systemUsername();
 	setComment(commentNode);
 }
 
-QString ReviewComment::getSystemUsername()
+QString ReviewComment::systemUsername()
 {
 	QString username = qgetenv("USER");
 	if (username.isEmpty())

--- a/CodeReview/src/nodes/ReviewComment.cpp
+++ b/CodeReview/src/nodes/ReviewComment.cpp
@@ -46,6 +46,15 @@ ReviewComment::ReviewComment(Comments::CommentNode* commentNode, Model::Text* da
 	setComment(commentNode);
 }
 
+QString ReviewComment::getSystemUsername()
+{
+	QString username = qgetenv("USER");
+	if (username.isEmpty())
+		username = qgetenv("USERNAME");
+	return username;
+}
+
+
 ReviewComment::ReviewComment(Model::Node* parent) :
 	ReviewComment{new Comments::CommentNode{"comment here"},
 							  new Model::Text{QDateTime::currentDateTime().toString()}, parent}

--- a/CodeReview/src/nodes/ReviewComment.cpp
+++ b/CodeReview/src/nodes/ReviewComment.cpp
@@ -36,13 +36,13 @@ namespace CodeReview
 
 DEFINE_COMPOSITE_TYPE_REGISTRATION_METHODS(ReviewComment)
 
-DEFINE_ATTRIBUTE(ReviewComment, date, Text, false, false, true)
 DEFINE_ATTRIBUTE(ReviewComment, commentNode, CommentNode, false, false, true)
 
-ReviewComment::ReviewComment(Comments::CommentNode* commentNode, Model::Text* date, Model::Node* parent) :
+ReviewComment::ReviewComment(Comments::CommentNode* commentNode, qint64 date, Model::Node* parent) :
 	Super{parent, ReviewComment::getMetaData()}
 {
-	setDate(date);
+	date_ = date;
+	username_ = getSystemUsername();
 	setComment(commentNode);
 }
 
@@ -57,7 +57,7 @@ QString ReviewComment::getSystemUsername()
 
 ReviewComment::ReviewComment(Model::Node* parent) :
 	ReviewComment{new Comments::CommentNode{"comment here"},
-							  new Model::Text{QDateTime::currentDateTime().toString()}, parent}
+							  QDateTime::currentMSecsSinceEpoch(), parent}
 {}
 
 ReviewComment::ReviewComment(Model::Node *, Model::PersistentStore &, bool)

--- a/CodeReview/src/nodes/ReviewComment.h
+++ b/CodeReview/src/nodes/ReviewComment.h
@@ -54,7 +54,7 @@ class CODEREVIEW_API ReviewComment : public Super<Model::CompositeNode>
 		QString username();
 
 		// TODO move to more fitting place
-		static QString getSystemUsername();
+		static QString systemUsername();
 
 	private:
 		qint64 date_{};

--- a/CodeReview/src/nodes/ReviewComment.h
+++ b/CodeReview/src/nodes/ReviewComment.h
@@ -33,6 +33,8 @@
 
 #include "Comments/src/nodes/CommentNode.h"
 
+#include "ModelBase/src/nodes/Text.h"
+
 namespace CodeReview
 {
 class ReviewComment;
@@ -47,22 +49,19 @@ class CODEREVIEW_API ReviewComment : public Super<Model::CompositeNode>
 	COMPOSITENODE_DECLARE_STANDARD_METHODS(ReviewComment)
 
 	ATTRIBUTE(Comments::CommentNode, commentNode, setComment)
+	ATTRIBUTE_VALUE(Model::Text, username, setUsername, QString)
+	PRIVATE_ATTRIBUTE_VALUE(Model::Text, dateString, setDateString, QString)
 
 	public:
 		ReviewComment(Comments::CommentNode* commentNode, qint64 date, Model::Node* parent=nullptr);
 		qint64 date();
-		QString username();
+		void setDate(qint64 date);
 
 		// TODO move to more fitting place
 		static QString systemUsername();
-
-	private:
-		qint64 date_{};
-		QString username_;
-
 };
 
-inline qint64 ReviewComment::date() {return date_;}
-inline QString ReviewComment::username() {return username_;}
+inline qint64 ReviewComment::date() { return dateString().toLongLong(); }
+inline void ReviewComment::setDate(qint64 date) { setDateString(QString::number(date)); }
 
 }

--- a/CodeReview/src/nodes/ReviewComment.h
+++ b/CodeReview/src/nodes/ReviewComment.h
@@ -51,6 +51,8 @@ class CODEREVIEW_API ReviewComment : public Super<Model::CompositeNode>
 
 	public:
 		ReviewComment(Comments::CommentNode* commentNode, Model::Text* date, Model::Node* parent=nullptr);
+		// TODO move to more fitting place
+		static QString getSystemUsername();
 
 };
 

--- a/CodeReview/src/nodes/ReviewComment.h
+++ b/CodeReview/src/nodes/ReviewComment.h
@@ -46,14 +46,23 @@ class CODEREVIEW_API ReviewComment : public Super<Model::CompositeNode>
 {
 	COMPOSITENODE_DECLARE_STANDARD_METHODS(ReviewComment)
 
-	ATTRIBUTE(Model::Text, date, setDate)
 	ATTRIBUTE(Comments::CommentNode, commentNode, setComment)
 
 	public:
-		ReviewComment(Comments::CommentNode* commentNode, Model::Text* date, Model::Node* parent=nullptr);
+		ReviewComment(Comments::CommentNode* commentNode, qint64 date, Model::Node* parent=nullptr);
+		qint64 date();
+		QString username();
+
 		// TODO move to more fitting place
 		static QString getSystemUsername();
 
+	private:
+		qint64 date_{};
+		QString username_;
+
 };
+
+inline qint64 ReviewComment::date() {return date_;}
+inline QString ReviewComment::username() {return username_;}
 
 }

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -66,8 +66,7 @@ void CodeReviewCommentOverlay::initializeForms()
 				->setColumnStretchFactor(3, 1)
 				->setVerticalAlignment(Visualization::LayoutStyle::Alignment::Center)
 				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->put(1, 0, item<Visualization::Static>(&I::icon_, &StyleType::icon))
-				->put(2, 0, item<Visualization::Static>(&I::title_, &StyleType::title));
+				->put(1, 0, item<Visualization::Static>(&I::icon_, &StyleType::icon));
 
 	auto grid = (new Visualization::GridLayoutFormElement{})
 							->setColumnStretchFactor(0, 1)

--- a/CodeReview/styles/item/Text/codeReviewHeaderText
+++ b/CodeReview/styles/item/Text/codeReviewHeaderText
@@ -1,0 +1,9 @@
+<!DOCTYPE EnvisionVisualizationStyle>
+<style prototypes="item/Text/default">
+	<pen>
+		<color>#757575</color>
+	</pen>
+	<font>
+		<size>13</size>
+	</font>
+</style>

--- a/CodeReview/styles/item/VCommentedNode/default
+++ b/CodeReview/styles/item/VCommentedNode/default
@@ -5,8 +5,7 @@
 		<shape prototypes="shape/Box/default">
 			Box
 			<outline>
-				<width>1</width>
-				<color>#a0a0a0</color>
+				<style>0</style>
 			</outline>
 			<cornerRadius>5</cornerRadius>
 			<cornerType>0</cornerType>

--- a/CodeReview/styles/item/VReviewComment/default
+++ b/CodeReview/styles/item/VReviewComment/default
@@ -1,5 +1,15 @@
 <!DOCTYPE EnvisionVisualizationStyle>
 <style prototypes="item/DeclarativeItemBase/default">
+	<shape prototypes="shape/Frame/default">
+		Frame
+
+		<topWidth>1</topWidth>
+		<topBrush><color>#858585</color></topBrush>
+
+		<contentBrush>
+			<color>#ffffff</color>
+		</contentBrush>
+	</shape>
 	<shape prototypes="shape/Box/default">
 		Box
 		<cornerType>0</cornerType>
@@ -12,8 +22,13 @@
 			<style>0</style>
 		</outline>
 	</shape>
-	<date prototypes="item/Text/default" />
+
+	<date prototypes="item/Text/codeReviewHeaderText" />
+
+	<username prototypes="item/Text/codeReviewHeaderText" />
+
 	<comment prototypes="item/VComment/default">
+		<commentText prototypes="item/Text/default"/>
 		<shape>
 			Box
 			<outline>
@@ -26,7 +41,6 @@
 			<cornerType>0</cornerType>
 			<cornerRadius>2</cornerRadius>
 		</shape>
-
 		<editList>
 			<shape>
 				Box

--- a/Comments/src/items/VComment.cpp
+++ b/Comments/src/items/VComment.cpp
@@ -357,7 +357,7 @@ Item* VComment::createTextualCommentElement(QStringList& contents, bool asHtml)
 		}
 		else
 		{
-			auto text = new Text{this, Text::itemStyles().get("comment"), replaceMarkdown(joined)};
+			auto text = new Text{this, &style()->commentText(), replaceMarkdown(joined)};
 			text->setTextFormat(Qt::RichText);
 			commentElements_.append(text);
 			item = text;

--- a/Comments/src/items/VCommentStyle.h
+++ b/Comments/src/items/VCommentStyle.h
@@ -30,6 +30,7 @@
 
 #include "VisualizationBase/src/declarative/DeclarativeItemBaseStyle.h"
 #include "VisualizationBase/src/items/VListStyle.h"
+#include "VisualizationBase/src/items/TextStyle.h"
 
 namespace Comments {
 
@@ -38,6 +39,7 @@ class COMMENTS_API VCommentStyle : public Super<Visualization::DeclarativeItemBa
 		virtual ~VCommentStyle() override;
 
 		Property<Visualization::VListStyle> editList{this, "editList"};
+		Property<Visualization::TextStyle> commentText{this, "commentText"};
 };
 
 }

--- a/Comments/styles/item/Text/comment
+++ b/Comments/styles/item/Text/comment
@@ -1,6 +1,0 @@
-<!DOCTYPE EnvisionVisualizationStyle>
-<style prototypes="default">
-	<pen>
-		<color>#646464</color>
-	</pen>
-</style>

--- a/Comments/styles/item/VComment/default
+++ b/Comments/styles/item/VComment/default
@@ -14,6 +14,12 @@
 		</outline>
 	</shape>
 
+	<commentText prototypes="item/Text/default">
+		<pen>
+			<color>#646464</color>
+		</pen>
+	</commentText>
+
 	<editList prototypes="item/VList/default">
 		<shape prototypes="shape/Box/default">
 			Box

--- a/InteractionBase/src/handlers/HMovableItem.cpp
+++ b/InteractionBase/src/handlers/HMovableItem.cpp
@@ -55,8 +55,6 @@ void HMovableItem::mouseMoveEvent(Visualization::Item* target, QGraphicsSceneMou
 void HMovableItem::move(Visualization::Item* item, const QPointF& to)
 {
 	QPointF dest{itemPosition_ + to};
-	if (dest.x() < 0) dest.setX(0);
-	if (dest.y() < 0) dest.setY(0);
 
 	item->setPos(dest);
 }

--- a/VersionControlUI/src/nodes/DiffComparisonPair.h
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.h
@@ -43,44 +43,45 @@ namespace VersionControlUI {
 
 class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINode>
 {
-		NODE_DECLARE_STANDARD_METHODS(DiffComparisonPair)
+	NODE_DECLARE_STANDARD_METHODS(DiffComparisonPair)
 
-		public:
-			DiffComparisonPair(Model::Node* oldVersionNode, Model::Node* newVersionNode);
+	public:
+		DiffComparisonPair(Model::Node* oldVersionNode, Model::Node* newVersionNode);
 
-			virtual QJsonValue toJson() const override;
+		virtual QJsonValue toJson() const override;
 
-			Model::Node* oldVersionNode();
-			Model::Node* newVersionNode();
+		Model::Node* oldVersionNode();
+		Model::Node* newVersionNode();
 
-			Model::Text* newVersionObjectPath();
-			Model::Text* oldVersionObjectPath();
+		Model::Text* newVersionObjectPath();
+		Model::Text* oldVersionObjectPath();
 
-			Model::Text* singleObjectPath();
+		Model::Text* singleObjectPath();
 
-			bool twoObjectPathsDefined();
-			QString comparisonName();
+		bool twoObjectPathsDefined();
+		QString comparisonName();
 
 
-		private:
-			bool twoObjectPathsDefined_{};
+	private:
+		bool twoObjectPathsDefined_{};
 
-			Model::Node* oldVersionNode_{};
-			Model::Node* newVersionNode_{};
+		Model::Node* oldVersionNode_{};
+		Model::Node* newVersionNode_{};
 
-			Model::Text* newVersionObjectPath_{};
-			Model::Text* oldVersionObjectPath_{};
+		Model::Text* newVersionObjectPath_{};
+		Model::Text* oldVersionObjectPath_{};
 
-			Model::Text* singleObjectPath_{};
+		Model::Text* singleObjectPath_{};
 
-			QString comparisonName_;
+		QString comparisonName_;
 
-			QString computeObjectPath(Model::Node* node);
-			QString computeComponentName();
+		QString computeObjectPath(Model::Node* node);
+		QString computeComponentName();
 
-			void computeObjectPath();
+		void computeObjectPath();
 
-			void setComparisonName(Model::Node* node, QString nodeObjectPath, QString componentName);
+		void setComparisonName(Model::Node* node, QString nodeObjectPath, QString componentName);
+
 };
 
 inline Model::Node* DiffComparisonPair::newVersionNode() {return newVersionNode_;}


### PR DESCRIPTION
- Add new style property commentText to VCommentStyle
- Fix indentation in DiffComparisonPair.h
- Add method getSystemUsername to ReviewComment
- Improve visualization for ReviewComments
- Change date from Text to qint64 in ReviewComment
- Add username to ReviewComment visualization
- Use determineChildren to update dateText in VReviewComment
- Remove positive coordinates enforcement in HMovableItem
- Rename getSystemUsername() to systemUsername()
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65562843%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65563643%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65564145%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65564538%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23issuecomment-223332403%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65565277%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65565596%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65565663%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65565915%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65566333%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23issuecomment-223535231%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65682001%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23issuecomment-223537147%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23issuecomment-223539084%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23issuecomment-223332403%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Alright%2C%20that%27s%20all%20for%20now%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-06-02T15%3A42%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%20Updated%22%2C%20%22created_at%22%3A%20%222016-06-03T09%3A37%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%27s%20my%20only%20new%20comment%20%28should%20have%20seen%20this%20before%29.%22%2C%20%22created_at%22%3A%20%222016-06-03T09%3A45%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Updated%22%2C%20%22created_at%22%3A%20%222016-06-03T09%3A55%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%200dcdf2a1320c167aa4bcf8780fa2526bb12dc8dd%20CodeReview/src/items/VReviewComment.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65682001%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22So%2C%20unlike%20%60date_%60%20which%20needs%20some%20transformation%20from%20the%20thing%20stored%20in%20the%20node%2C%20to%20the%20thing%20that%27s%20displayed%2C%20%60username_%60%20is%20directly%20from%20the%20node.%20Instead%20of%20usint%20%60Text%60%2C%20use%20a%20%60VText%60%20and%20directly%20render%20the%20node.%22%2C%20%22created_at%22%3A%20%222016-06-03T09%3A44%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/items/VReviewComment.cpp%3AL39-107%22%7D%2C%20%22Pull%20058e7d2c53a7cb847b99ad9e3dff1ede5185df59%20CodeReview/src/items/VReviewComment.cpp%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65563643%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20did%20you%20rename%20this%3F%20%60node%60%20is%20correct.%20What%27s%20passed%20in%20is%20not%20a%20type%20but%20a%20node%20whose%20type%20is%20%60NodeType%60.%22%2C%20%22created_at%22%3A%20%222016-06-02T15%3A36%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22To%20avoid%20the%20hiding%20of%20function%20%60node%28%29%60%2C%20%20but%20I%20can%20just%20use%20%60VReviewComment%3A%3A%60.%20%22%2C%20%22created_at%22%3A%20%222016-06-02T15%3A44%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20shouldn%27t%20care%20about%20hiding%20that%20function%2C%20since%20it%20returns%20%60node%60%20anyway.%20So%20just%20use%20%60node%60%20in%20the%20second%20line%20and%20you%27re%20done.%22%2C%20%22created_at%22%3A%20%222016-06-02T15%3A46%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20will%20do%22%2C%20%22created_at%22%3A%20%222016-06-02T15%3A48%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/items/VReviewComment.cpp%3AL36-96%22%7D%2C%20%22Pull%20058e7d2c53a7cb847b99ad9e3dff1ede5185df59%20CodeReview/src/nodes/ReviewComment.h%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65564145%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Wait%2C%20that%27s%20not%20right%2C%20both%20the%20date%20and%20the%20username%20should%20be%20attributes.%20You%20want%20those%20to%20be%20persisted.%22%2C%20%22created_at%22%3A%20%222016-06-02T15%3A39%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Can%20I%20have%20a%20%60qint64%60%20attribute%3F%20I%20assumed%20it%20has%20to%20be%20a%20subtype%20of%20%60Node%2A%60.%20%22%2C%20%22created_at%22%3A%20%222016-06-02T15%3A46%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22hmm%2C%20you%20can%20have%20an%20%60Integer%60%20attribute%20which%20holds%20an%20%60int%60%20You%20have%20two%20choices%2C%20either%20store%20the%20number%20as%20a%20string%2C%20or%20store%20it%20as%20two%20integers.%20Either%20way%20make%20these%20private%20attributes%20%28look%20at%20how%20enumerations%20are%20defined%20for%20info%20on%20private%20attributes%2C%20e.g.%20method%20kind%20in%20method%29%2C%20since%20you%20don%27t%20want%20them%20to%20be%20accessed%20directly%2C%20then%20make%20yourself%20a%20nice%20getter/setter%20that%20transparently%20converts%20to%20and%20from%20%60qint64%60.%5Cr%5Cn%5Cr%5CnWhatever%20the%20case%2C%20we%20need%20to%20store%20the%20date%2C%20so%20it%20needs%20to%20be%20represented%20as%20attributes.%22%2C%20%22created_at%22%3A%20%222016-06-02T15%3A50%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/nodes/ReviewComment.h%3AL46-69%22%7D%2C%20%22Pull%2097e39e59d3934fd00e6a44e4738ca4827abeaadd%20Comments/src/items/VComment.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65562843%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Since%20the%20old%20file%20%27comment%27%20is%20no%20longer%20needed%2C%20could%20you%20please%20remove%20it.%22%2C%20%22created_at%22%3A%20%222016-06-02T15%3A32%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Comments/src/items/VComment.cpp%3AL357-364%22%7D%2C%20%22Pull%2053d97c2825c96f6d585525b842e555f89ed72f70%20CodeReview/src/items/VReviewComment.cpp%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/392%23discussion_r65564538%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Well%2C%20actually%20I%20think%20it%27s%20rather%20ok%20to%20do%20it%20this%20way%2C%20at%20least%20until%20we%20see%20a%20performance%20issue.%20So%20please%20remove%20this%20TODO.%22%2C%20%22created_at%22%3A%20%222016-06-02T15%3A40%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/items/VReviewComment.cpp%3AL72-91%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 97e39e59d3934fd00e6a44e4738ca4827abeaadd Comments/src/items/VComment.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/392#discussion_r65562843'>File: Comments/src/items/VComment.cpp:L357-364</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Since the old file 'comment' is no longer needed, could you please remove it.
- [x] <a href='#crh-comment-Pull 058e7d2c53a7cb847b99ad9e3dff1ede5185df59 CodeReview/src/items/VReviewComment.cpp 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/392#discussion_r65563643'>File: CodeReview/src/items/VReviewComment.cpp:L36-96</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why did you rename this? `node` is correct. What's passed in is not a type but a node whose type is `NodeType`.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> To avoid the hiding of function `node()`,  but I can just use `VReviewComment::`.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You shouldn't care about hiding that function, since it returns `node` anyway. So just use `node` in the second line and you're done.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> OK, will do
- [x] <a href='#crh-comment-Pull 058e7d2c53a7cb847b99ad9e3dff1ede5185df59 CodeReview/src/nodes/ReviewComment.h 10'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/392#discussion_r65564145'>File: CodeReview/src/nodes/ReviewComment.h:L46-69</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Wait, that's not right, both the date and the username should be attributes. You want those to be persisted.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Can I have a `qint64` attribute? I assumed it has to be a subtype of `Node*`.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> hmm, you can have an `Integer` attribute which holds an `int` You have two choices, either store the number as a string, or store it as two integers. Either way make these private attributes (look at how enumerations are defined for info on private attributes, e.g. method kind in method), since you don't want them to be accessed directly, then make yourself a nice getter/setter that transparently converts to and from `qint64`.
  Whatever the case, we need to store the date, so it needs to be represented as attributes.
- [x] <a href='#crh-comment-Pull 53d97c2825c96f6d585525b842e555f89ed72f70 CodeReview/src/items/VReviewComment.cpp 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/392#discussion_r65564538'>File: CodeReview/src/items/VReviewComment.cpp:L72-91</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Well, actually I think it's rather ok to do it this way, at least until we see a performance issue. So please remove this TODO.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/392#issuecomment-223332403'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Alright, that's all for now :)
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Thanks. Updated
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> That's my only new comment (should have seen this before).
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Updated
- [x] <a href='#crh-comment-Pull 0dcdf2a1320c167aa4bcf8780fa2526bb12dc8dd CodeReview/src/items/VReviewComment.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/392#discussion_r65682001'>File: CodeReview/src/items/VReviewComment.cpp:L39-107</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> So, unlike `date_` which needs some transformation from the thing stored in the node, to the thing that's displayed, `username_` is directly from the node. Instead of usint `Text`, use a `VText` and directly render the node.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/392?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/392?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/392'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
