### PR TITLE
Resolving issue for getting no nodes for loadNodeChildrenData

### DIFF
--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -107,23 +107,24 @@ bool Commit::isValidMatch(const char* content, qint64 size, const char* indexOfI
 								  bool findChildrenByParentId) const
 {
 	start = indexOfId-content;
-	end = start+1;
+	end = start;
+	int precClosedBracketCnt = 0;
 	// start is the first character of the line containing id
 	while (start >= 0 && content[start] != '\n')
 	{
-		// String is of the form {.*} {id}
-		if (!findChildrenByParentId && content[start] == '}') return false;
+		// Remove fake-ids
+		if (content[start] == '}')
+		{
+			if (!findChildrenByParentId)	return false;
+			precClosedBracketCnt++;
+			if (precClosedBracketCnt==2)	return false;
+		}
 		start--;
 	}
 	start++;
-
 	// end is the character after the line containing id
-	while (end < size && content[end] != '\n')
-	{
-		// String is of the form {id} {*.}
-		if (findChildrenByParentId && content[end] == '{') return false;
-		end++;
-	}
+	while (end < size && content[end] != '\n')	end++;
+
 	return true;
 }
 

--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -108,7 +108,7 @@ bool Commit::isValidMatch(const char* content, qint64 size, const char* indexOfI
 {
 	start = indexOfId-content;
 	end = start;
-	int precClosedBracketCnt = 0;
+	int precedingClosingBraceCount = 0;
 	// start is the first character of the line containing id
 	while (start >= 0 && content[start] != '\n')
 	{
@@ -116,8 +116,8 @@ bool Commit::isValidMatch(const char* content, qint64 size, const char* indexOfI
 		if (content[start] == '}')
 		{
 			if (!findChildrenByParentId)	return false;
-			precClosedBracketCnt++;
-			if (precClosedBracketCnt==2)	return false;
+			precedingClosingBraceCount++;
+			if (precedingClosingBraceCount==2)	return false;
 		}
 		start--;
 	}

--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -107,7 +107,7 @@ bool Commit::isValidMatch(const char* content, qint64 size, const char* indexOfI
 								  bool findChildrenByParentId) const
 {
 	start = indexOfId-content;
-	end = start;
+	end = start+1;
 	// start is the first character of the line containing id
 	while (start >= 0 && content[start] != '\n')
 	{

--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -116,8 +116,7 @@ bool Commit::isValidMatch(const char* content, qint64 size, const char* indexOfI
 		if (content[start] == '}')
 		{
 			precedingClosingBraceCount++;
-			if ((findChildrenByParentId && precedingClosingBraceCount > 1) ||
-				(!findChildrenByParentId && precedingClosingBraceCount > 0))
+			if (!findChildrenByParentId || precedingClosingBraceCount >1)
 				return false;
 		}
 		start--;

--- a/FilePersistence/src/version_control/Commit.cpp
+++ b/FilePersistence/src/version_control/Commit.cpp
@@ -115,9 +115,10 @@ bool Commit::isValidMatch(const char* content, qint64 size, const char* indexOfI
 		// Remove fake-ids
 		if (content[start] == '}')
 		{
-			if (!findChildrenByParentId)	return false;
 			precedingClosingBraceCount++;
-			if (precedingClosingBraceCount==2)	return false;
+			if ((findChildrenByParentId && precedingClosingBraceCount > 1) ||
+				(!findChildrenByParentId && precedingClosingBraceCount > 0))
+				return false;
 		}
 		start--;
 	}

--- a/FilePersistence/src/version_control/GitPiecewiseLoader.cpp
+++ b/FilePersistence/src/version_control/GitPiecewiseLoader.cpp
@@ -58,7 +58,6 @@ QList<NodeData> GitPiecewiseLoader::loadNodeChildrenData(Model::NodeIdType id)
 		commit_.reset(repo_->getCommit(revision_));
 
 	auto s = commit_->nodeLinesFromId(id, true);
-	Q_ASSERT(s.size() == 1);
 
 	for (auto line : s)
 		if (!isPersistenceUnit(line))


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/394%23discussion_r66228262%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/394%23discussion_r66284604%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/394%23discussion_r66284812%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/394%23discussion_r66284996%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/394%23discussion_r66286747%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/394%23issuecomment-224643610%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/394%23issuecomment-224643610%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks.%22%2C%20%22created_at%22%3A%20%222016-06-08T16%3A16%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f02932f7ae4b9eeb96339f0b47b28274a2cbc891%20FilePersistence/src/version_control/Commit.cpp%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/394%23discussion_r66286747%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20can%20simplify%20this%20condition%20to%20%60%21findChildrenByParentId%20%7C%7C%20precedingClosingBraceCount%20%3E1%60%22%2C%20%22created_at%22%3A%20%222016-06-08T16%3A11%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL108-132%22%7D%2C%20%22Pull%20da3711f597f5939ae87e3ef36cf2c85d9a6e3303%20FilePersistence/src/version_control/Commit.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/394%23discussion_r66284604%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22please%20do%20not%20abbreviate%20variable%20names.%20Call%20this%20%60precedingClosingBraceCount%60%22%2C%20%22created_at%22%3A%20%222016-06-08T15%3A59%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL108-131%22%7D%2C%20%22Pull%200e4008e0fd906149df94a92c7e6ee62273107c99%20FilePersistence/src/version_control/Commit.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/394%23discussion_r66228262%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20do%20not%20understand%20how%20this%20change%20makes%20a%20difference.%20Could%20you%20explain%20with%20an%20example%3F%22%2C%20%22created_at%22%3A%20%222016-06-08T10%3A07%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL107-114%22%7D%2C%20%22Pull%20da3711f597f5939ae87e3ef36cf2c85d9a6e3303%20FilePersistence/src/version_control/Commit.cpp%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/394%23discussion_r66284996%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20it%27s%20slightly%20nicer%20to%20say%20%3E%201.%20It%20will%20work%20the%20same%20way%2C%20but%20for%20someone%20looking%20at%20the%20text%20it%20will%20be%20a%20clear%20message%20that%20not%20just%202%2C%20but%20anything%20bigger%20than%201%20is%20bad.%22%2C%20%22created_at%22%3A%20%222016-06-08T16%3A01%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL108-131%22%7D%2C%20%22Pull%20da3711f597f5939ae87e3ef36cf2c85d9a6e3303%20FilePersistence/src/version_control/Commit.cpp%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/394%23discussion_r66284812%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20merge%20this%20condition%20into%20the%20next%20one%20%28so%20have%20only%20one%20if%20after%20the%20%2B%2B%29%22%2C%20%22created_at%22%3A%20%222016-06-08T16%3A00%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Commit.cpp%3AL108-131%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 0e4008e0fd906149df94a92c7e6ee62273107c99 FilePersistence/src/version_control/Commit.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/394#discussion_r66228262'>File: FilePersistence/src/version_control/Commit.cpp:L107-114</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I do not understand how this change makes a difference. Could you explain with an example?
- [x] <a href='#crh-comment-Pull da3711f597f5939ae87e3ef36cf2c85d9a6e3303 FilePersistence/src/version_control/Commit.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/394#discussion_r66284604'>File: FilePersistence/src/version_control/Commit.cpp:L108-131</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> please do not abbreviate variable names. Call this `precedingClosingBraceCount`
- [x] <a href='#crh-comment-Pull da3711f597f5939ae87e3ef36cf2c85d9a6e3303 FilePersistence/src/version_control/Commit.cpp 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/394#discussion_r66284812'>File: FilePersistence/src/version_control/Commit.cpp:L108-131</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please merge this condition into the next one (so have only one if after the ++)
- [x] <a href='#crh-comment-Pull da3711f597f5939ae87e3ef36cf2c85d9a6e3303 FilePersistence/src/version_control/Commit.cpp 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/394#discussion_r66284996'>File: FilePersistence/src/version_control/Commit.cpp:L108-131</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I think it's slightly nicer to say > 1. It will work the same way, but for someone looking at the text it will be a clear message that not just 2, but anything bigger than 1 is bad.
- [ ] <a href='#crh-comment-Pull f02932f7ae4b9eeb96339f0b47b28274a2cbc891 FilePersistence/src/version_control/Commit.cpp 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/394#discussion_r66286747'>File: FilePersistence/src/version_control/Commit.cpp:L108-132</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You can simplify this condition to `!findChildrenByParentId || precedingClosingBraceCount >1`
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/394#issuecomment-224643610'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/394?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/394?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/394'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
