### PR TITLE
Relaxing listMerge condition

### DIFF
--- a/FilePersistence/src/version_control/ChangeDescription.cpp
+++ b/FilePersistence/src/version_control/ChangeDescription.cpp
@@ -173,45 +173,46 @@ void ChangeDescription::computeFlags()
 
 void ChangeDescription::print() const
 {
+	QString nodeLine;
 	if (nodeA_ || nodeB_)
-		qDebug() << (nodeA_ ? nodeA_->type() : nodeB_->type()) << "\t";
-	qDebug() << nodeId().toString() << "\t";
+		nodeLine += (nodeA_ ? nodeA_->type() : nodeB_->type()) + " ";
+	nodeLine += nodeId().toString() +" ";
 	switch (type_)
 	{
 		case ChangeType::Insertion:
 		{
-			qDebug() << "Insertion" << endl;
+			nodeLine += "Insertion ";
 			break;
 		}
 		case ChangeType::Deletion:
 		{
-			qDebug() << "Deletion" << endl;
+			nodeLine += "Deletion ";
 			break;
 		}
 		case ChangeType::Move:
 		{
-			qDebug() << "Move" << endl;
+			nodeLine += "Move ";
 			break;
 		}
 		case ChangeType::Stationary:
 		{
-			qDebug() << "Stationary" << endl;
+			nodeLine += "Stationary ";
 			break;
 		}
 		case ChangeType::Unclassified:
 		{
-			qDebug() << "Unclassified" << endl;
+			nodeLine += "Unclassified ";
 			break;
 		}
 		default:
 			Q_ASSERT(false);
 	}
 
-	if (updateFlags_.testFlag(Label)) qDebug() << "\tLabel";
-	if (updateFlags_.testFlag(Type)) qDebug() << "\tType";
-	if (updateFlags_.testFlag(Value)) qDebug() << "\tValue";
-	if (updateFlags_.testFlag(Structure)) qDebug() << "\tStructure";
-	qDebug() << endl;
+	if (updateFlags_.testFlag(Label)) nodeLine += "Label";
+	if (updateFlags_.testFlag(Type)) nodeLine += "Type";
+	if (updateFlags_.testFlag(Value)) nodeLine += "Value";
+	if (updateFlags_.testFlag(Structure)) nodeLine += "Structure";
+	qDebug() << nodeLine;
 }
 
 void ChangeDescription::setStructureChangeFlag(bool value)

--- a/FilePersistence/src/version_control/ListMergeComponent.cpp
+++ b/FilePersistence/src/version_control/ListMergeComponent.cpp
@@ -275,6 +275,12 @@ bool onlyConflictsOnLabel(ConflictPairs& conflictPairs, QSet<Model::NodeIdType>&
 
 		if (changeA && changeB)
 		{
+			if (changeA->onlyLabelChange() && changeB->onlyLabelChange())	continue;
+			else return false;
+			qDebug() << containerId;	//	Used for the code described below
+/*			This part of code contains the original code implemented in Balz thesis
+ *			Now this condition is relaxed
+
 			if (!changeB->onlyLabelChange())
 			{
 				if (!changeA->onlyLabelChange())
@@ -305,6 +311,7 @@ bool onlyConflictsOnLabel(ConflictPairs& conflictPairs, QSet<Model::NodeIdType>&
 					}
 				}
 			}
+*/
 		}
 	}
 	return true;

--- a/FilePersistence/src/version_control/ListMergeComponent.cpp
+++ b/FilePersistence/src/version_control/ListMergeComponent.cpp
@@ -277,10 +277,10 @@ bool onlyConflictsOnLabel(ConflictPairs& conflictPairs, QSet<Model::NodeIdType>&
 		{
 			if (changeA->onlyLabelChange() && changeB->onlyLabelChange())	continue;
 			else return false;
-			qDebug() << containerId;	//	Used for the code described below
-/*			This part of code contains the original code implemented in Balz thesis
- *			Now this condition is relaxed
-
+			(void) containerId;	//	Used for the code described below
+//			This part of code contains the original code implemented in Balz thesis
+//			Now this condition is relaxed
+/*
 			if (!changeB->onlyLabelChange())
 			{
 				if (!changeA->onlyLabelChange())


### PR DESCRIPTION
qDebug() << containerId is kept to use(fake) the variable (Necessary for compiling) otherwise we need to change the function definition
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/396%23discussion_r66970374%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/396%23discussion_r66970565%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/396%23issuecomment-225887786%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/396%23issuecomment-225887786%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks.%22%2C%20%22created_at%22%3A%20%222016-06-14T13%3A53%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%207423a663e7f5f2460315653f57bf7d163041cb90%20FilePersistence/src/version_control/ListMergeComponent.cpp%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/396%23discussion_r66970565%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20comment%20this%20and%20the%20next%20line%20with%20%60//%60%20and%20only%20put%20the%20%60/%2A%60%20after%20the%20text%2C%20once%20the%20code%20starts.%20That%20way%2C%20even%20if%20someone%20removes%20the%20%60/%2A%60%20the%20code%20compiles.%22%2C%20%22created_at%22%3A%20%222016-06-14T13%3A36%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/ListMergeComponent.cpp%3AL275-287%22%7D%2C%20%22Pull%207423a663e7f5f2460315653f57bf7d163041cb90%20FilePersistence/src/version_control/ListMergeComponent.cpp%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/396%23discussion_r66970374%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22the%20proper%20way%20to%20keep%20an%20unused%20variable%20is%20%60%28void%29%20variableName%3B%60.%20Use%20that%20instead%20of%20qDebug.%22%2C%20%22created_at%22%3A%20%222016-06-14T13%3A35%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/ListMergeComponent.cpp%3AL275-287%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 7423a663e7f5f2460315653f57bf7d163041cb90 FilePersistence/src/version_control/ListMergeComponent.cpp 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/396#discussion_r66970374'>File: FilePersistence/src/version_control/ListMergeComponent.cpp:L275-287</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> the proper way to keep an unused variable is `(void) variableName;`. Use that instead of qDebug.
- [ ] <a href='#crh-comment-Pull 7423a663e7f5f2460315653f57bf7d163041cb90 FilePersistence/src/version_control/ListMergeComponent.cpp 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/396#discussion_r66970565'>File: FilePersistence/src/version_control/ListMergeComponent.cpp:L275-287</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please comment this and the next line with `//` and only put the `/*` after the text, once the code starts. That way, even if someone removes the `/*` the code compiles.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/396#issuecomment-225887786'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/396?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/396?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/396'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
