### PR TITLE
Resolves application crash in case of not 'true merge'

### DIFF
--- a/FilePersistence/src/version_control/Merge.cpp
+++ b/FilePersistence/src/version_control/Merge.cpp
@@ -43,6 +43,11 @@ namespace FilePersistence {
 
 bool Merge::commit(const Signature& author, const Signature& committer, const QString& message)
 {
+	if (stage_ == Stage::Committed)
+	{
+		// AlreadyUpToDate:: Not a True Merge
+		return true;
+	}
 	Q_ASSERT(stage_ == Stage::WroteToIndex);
 
 	QString treeSHA1 = repository_->writeIndexToTree();

--- a/FilePersistence/src/version_control/Merge.cpp
+++ b/FilePersistence/src/version_control/Merge.cpp
@@ -43,11 +43,6 @@ namespace FilePersistence {
 
 bool Merge::commit(const Signature& author, const Signature& committer, const QString& message)
 {
-	if (stage_ == Stage::Committed)
-	{
-		// AlreadyUpToDate:: Not a True Merge
-		return true;
-	}
 	Q_ASSERT(stage_ == Stage::WroteToIndex);
 
 	QString treeSHA1 = repository_->writeIndexToTree();

--- a/FilePersistence/src/version_control/Merge.h
+++ b/FilePersistence/src/version_control/Merge.h
@@ -53,6 +53,7 @@ class FILEPERSISTENCE_API Merge
 		enum class Stage {NotInitialized, FoundMergeBase, Classified, AutoMerged,
 								ManualMerged, BuiltMergedTree, WroteToWorkDir, WroteToIndex, Committed};
 
+		bool isAlreadyMerged() const;
 		bool hasConflicts() const;
 		const QSet<std::shared_ptr<ChangeDescription>> getConflicts() const;
 		std::shared_ptr<GenericTree> mergedTree();
@@ -141,6 +142,7 @@ class FILEPERSISTENCE_API Merge
 };
 
 inline bool Merge::hasConflicts() const { return !conflictingChanges_.isEmpty(); }
+inline bool Merge::isAlreadyMerged() const { return stage_ == Stage::Committed; }
 
 inline const QSet<std::shared_ptr<ChangeDescription>> Merge::getConflicts() const { return conflictingChanges_; }
 

--- a/FilePersistence/test/VersionControlMergetests.cpp
+++ b/FilePersistence/test/VersionControlMergetests.cpp
@@ -174,7 +174,7 @@ class FILEPERSISTENCE_API RunMerge
 	}
 	GitRepository repo{"/tmp/EnvisionVC/TestMerge"};
 	auto merge = repo.merge("dev");
-	if (!merge->hasConflicts())
+	if (!merge->isAlreadyMerged() && !merge->hasConflicts())
 	{
 		Signature sig;
 		sig.name_ = "Chuck TESTa";


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/397%23discussion_r67005592%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/397%23issuecomment-225950942%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/397%23issuecomment-225950942%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks.%22%2C%20%22created_at%22%3A%20%222016-06-14T17%3A14%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20fdd9312dea701d31735a06a464bb27ada2e647bb%20FilePersistence/src/version_control/Merge.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/397%23discussion_r67005592%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20this%20is%20not%20the%20right%20place%20for%20this%20check.%20You%20need%20to%20do%20this%20in%20the%20place%20where%20%60commit%28%29%60%20is%20called%20and%20not%20call%20it%20in%20case%20%60AlreadyUpToDate%60%20is%20the%20case.%20Please%20reset%20this%20commit%20and%20make%20a%20new%20one%20%28instead%20of%20just%20fixing%20this%20code%20here%2C%20by%20removing%20it%29.%20So%20the%20PR%20should%20still%20have%20one%20commit%20afterwards.%22%2C%20%22created_at%22%3A%20%222016-06-14T16%3A27%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Merge.cpp%3AL43-54%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull fdd9312dea701d31735a06a464bb27ada2e647bb FilePersistence/src/version_control/Merge.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/397#discussion_r67005592'>File: FilePersistence/src/version_control/Merge.cpp:L43-54</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, this is not the right place for this check. You need to do this in the place where `commit()` is called and not call it in case `AlreadyUpToDate` is the case. Please reset this commit and make a new one (instead of just fixing this code here, by removing it). So the PR should still have one commit afterwards.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/397#issuecomment-225950942'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/397?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/397?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/397'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
