### PR TITLE
Handles assertion in case of deletion of conflicting node in a branch

### DIFF
--- a/FilePersistence/src/version_control/ListMergeComponent.cpp
+++ b/FilePersistence/src/version_control/ListMergeComponent.cpp
@@ -174,7 +174,7 @@ LinkedChangesTransition ListMergeComponent::run(std::shared_ptr<GenericTree>& tr
 					auto oldNode = treeBase->find(elemId);
 					auto newNodeA = treeA->find(elemId);
 					auto newNodeB = treeB->find(elemId);
-					auto adjustChange = [&](GenericNode* oldNode, GenericNode* newNode,
+					auto adjustChange = [&](GenericNode* newNode,
 							ChangeDependencyGraph& cdgA,
 							ChangeDependencyGraph& cdgB)
 					{
@@ -189,13 +189,8 @@ LinkedChangesTransition ListMergeComponent::run(std::shared_ptr<GenericTree>& tr
 
 					Q_ASSERT(oldNode);
 					Q_ASSERT(newNodeA || newNodeB);
-					if (newNodeA)	//Add change in cdgA
-					{
-						adjustChange(oldNode, newNodeA, cdgA, cdgB);
-					}
-					else{		//Add change in cdgB
-						adjustChange(oldNode, newNodeB, cdgB, cdgA);
-					}
+					if (newNodeA)	adjustChange(newNodeA, cdgA, cdgB);
+					else	adjustChange(newNodeB, cdgB, cdgA);
 				}
 			}
 

--- a/FilePersistence/src/version_control/ListMergeComponent.cpp
+++ b/FilePersistence/src/version_control/ListMergeComponent.cpp
@@ -174,26 +174,27 @@ LinkedChangesTransition ListMergeComponent::run(std::shared_ptr<GenericTree>& tr
 					auto oldNode = treeBase->find(elemId);
 					auto newNodeA = treeA->find(elemId);
 					auto newNodeB = treeB->find(elemId);
-					Q_ASSERT(oldNode);
-					Q_ASSERT(newNodeA || newNodeB);
-					if (newNodeA)	//Add change in cdgA
+					auto adjustChange = [&](GenericNode* oldNode, GenericNode* newNode,
+							ChangeDependencyGraph& cdgA,
+							ChangeDependencyGraph& cdgB)
 					{
-						auto newChange = std::make_shared<ChangeDescription>(oldNode, newNodeA);
+						auto newChange = std::make_shared<ChangeDescription>(oldNode, newNode);
 						updateChange(newChange, cdgA, cdgB);
 						auto delChange = cdgA.changes().value(elemId);
 						if (delChange)	cdgA.remove(delChange);		// Remove previous change
 						cdgA.insert(newChange);
 						cdgA.recordDependencies(newChange, true);
 						cdgA.recordDependencies(newChange, false);
+					};
+
+					Q_ASSERT(oldNode);
+					Q_ASSERT(newNodeA || newNodeB);
+					if (newNodeA)	//Add change in cdgA
+					{
+						adjustChange(oldNode, newNodeA, cdgA, cdgB);
 					}
 					else{		//Add change in cdgB
-						auto newChange = std::make_shared<ChangeDescription>(oldNode, newNodeB);
-						updateChange(newChange, cdgB, cdgA);
-						auto delChange = cdgB.changes().value(elemId);
-						if (delChange)	cdgB.remove(delChange);		// Remove previous change
-						cdgB.insert(newChange);
-						cdgB.recordDependencies(newChange, true);
-						cdgB.recordDependencies(newChange, false);
+						adjustChange(oldNode, newNodeB, cdgB, cdgA);
 					}
 				}
 			}

--- a/FilePersistence/src/version_control/ListMergeComponent.cpp
+++ b/FilePersistence/src/version_control/ListMergeComponent.cpp
@@ -172,17 +172,29 @@ LinkedChangesTransition ListMergeComponent::run(std::shared_ptr<GenericTree>& tr
 				for (auto elemId : chunk->spanBase_)
 				{
 					auto oldNode = treeBase->find(elemId);
-					auto newNode = treeA->find(elemId);
+					auto newNodeA = treeA->find(elemId);
+					auto newNodeB = treeB->find(elemId);
 					Q_ASSERT(oldNode);
-					Q_ASSERT(newNode);
-					auto newChange = std::make_shared<ChangeDescription>(oldNode, newNode);
-					updateChange(newChange, cdgA, cdgB);
-					newChange->print();
-					auto delChange = cdgA.changes().value(elemId);
-					cdgA.remove(delChange);		// Remove previous change
-					cdgA.insert(newChange);
-					cdgA.recordDependencies(newChange, true);
-					cdgA.recordDependencies(newChange, false);
+					Q_ASSERT(newNodeA || newNodeB);
+					if (newNodeA)	//Add change in cdgA
+					{
+						auto newChange = std::make_shared<ChangeDescription>(oldNode, newNodeA);
+						updateChange(newChange, cdgA, cdgB);
+						auto delChange = cdgA.changes().value(elemId);
+						if (delChange)	cdgA.remove(delChange);		// Remove previous change
+						cdgA.insert(newChange);
+						cdgA.recordDependencies(newChange, true);
+						cdgA.recordDependencies(newChange, false);
+					}
+					else{		//Add change in cdgB
+						auto newChange = std::make_shared<ChangeDescription>(oldNode, newNodeB);
+						updateChange(newChange, cdgB, cdgA);
+						auto delChange = cdgB.changes().value(elemId);
+						if (delChange)	cdgB.remove(delChange);		// Remove previous change
+						cdgB.insert(newChange);
+						cdgB.recordDependencies(newChange, true);
+						cdgB.recordDependencies(newChange, false);
+					}
 				}
 			}
 

--- a/FilePersistence/src/version_control/ListMergeComponent.cpp
+++ b/FilePersistence/src/version_control/ListMergeComponent.cpp
@@ -174,7 +174,7 @@ LinkedChangesTransition ListMergeComponent::run(std::shared_ptr<GenericTree>& tr
 					auto oldNode = treeBase->find(elemId);
 					auto newNodeA = treeA->find(elemId);
 					auto newNodeB = treeB->find(elemId);
-					auto adjustChange = [&](GenericNode* newNode,
+					auto adjustChange = [&oldNode, &elemId, &updateChange](GenericNode* newNode,
 							ChangeDependencyGraph& cdgA,
 							ChangeDependencyGraph& cdgB)
 					{


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/400%23discussion_r67527091%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/400%23discussion_r67527283%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/400%23discussion_r67531727%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/400%23discussion_r67531737%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/400%23discussion_r67533530%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%208ee59f9fb59b63a1e5a87a82c788d1e9687e2ca9%20FilePersistence/src/version_control/ListMergeComponent.cpp%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/400%23discussion_r67531727%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20use%20%60%5B%26%5D%60%2C%20but%20you%20are%20not%20capturing%20any%20variables.%20Please%20remove%20that.%22%2C%20%22created_at%22%3A%20%222016-06-17T15%3A45%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/ListMergeComponent.cpp%3AL172-202%22%7D%2C%20%22Pull%204cceb4543dffd094c01cc128612e86c547a3262f%20FilePersistence/src/version_control/ListMergeComponent.cpp%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/400%23discussion_r67527283%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Instead%20of%20repeating%20almost%20identical%20code%20twice%2C%20make%20a%20lambda%20and%20call%20with%20with%20appropriate%20arguments.%22%2C%20%22created_at%22%3A%20%222016-06-17T15%3A19%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/ListMergeComponent.cpp%3AL172-201%22%7D%2C%20%22Pull%205e5023d66a29a1e62db884504ec3486fac4eb97b%20FilePersistence/src/version_control/ListMergeComponent.cpp%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/400%23discussion_r67533530%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ok%2C%20if%20you%20want%20to%20leave%20the%20capturing%20in%20there%20that%27s%20fine%2C%20but%20since%20you%20really%20only%20intend%20to%20capture%20one%20variable%20I%27d%20change%20this%20to%20the%20less%20error%20prone%20%60%5B%26oldNode%5D%60%22%2C%20%22created_at%22%3A%20%222016-06-17T15%3A56%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/ListMergeComponent.cpp%3AL172-197%22%7D%2C%20%22Pull%20d8ddabe087d5a9e9aef96dc1f892be405e7d7420%20FilePersistence/src/version_control/Merge.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/400%23discussion_r67527091%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20did%20you%20bring%20in%20this%20commit%20again%3F%20didn%27t%20you%20say%20it%27s%20not%20needed%3F%20Please%2C%20use%20you%20git%20skills%20to%20clean%20your%20branch%20such%20that%20neither%20this%20nor%20the%20next%20commit%20are%20part%20of%20the%20PR.%20You%20can%20use%20an%20interactive%20rebase%20for%20this%20%28google%20it%29.%22%2C%20%22created_at%22%3A%20%222016-06-17T15%3A18%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/Merge.cpp%3AL43-54%22%7D%2C%20%22Pull%208ee59f9fb59b63a1e5a87a82c788d1e9687e2ca9%20FilePersistence/src/version_control/ListMergeComponent.cpp%2031%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/400%23discussion_r67531737%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Improve%20the%20style%20here%3A%5Cr%5Cn-%20no%20need%20for%20the%20comment%2C%20it%20is%20obvious%5Cr%5Cn-%20no%20need%20for%20%7B%20and%20%7D%2C%20it%27s%20just%20a%20single%20short%20statement%5Cr%5Cn-%20same%20for%20the%20else%20part.%5Cr%5Cn-%20make%20this%20just%20on%20two%20lines%20%60%20if...%60%20and%20%60else%20...%60%22%2C%20%22created_at%22%3A%20%222016-06-17T15%3A45%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/ListMergeComponent.cpp%3AL172-202%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull d8ddabe087d5a9e9aef96dc1f892be405e7d7420 FilePersistence/src/version_control/Merge.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/400#discussion_r67527091'>File: FilePersistence/src/version_control/Merge.cpp:L43-54</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why did you bring in this commit again? didn't you say it's not needed? Please, use you git skills to clean your branch such that neither this nor the next commit are part of the PR. You can use an interactive rebase for this (google it).
- [x] <a href='#crh-comment-Pull 4cceb4543dffd094c01cc128612e86c547a3262f FilePersistence/src/version_control/ListMergeComponent.cpp 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/400#discussion_r67527283'>File: FilePersistence/src/version_control/ListMergeComponent.cpp:L172-201</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Instead of repeating almost identical code twice, make a lambda and call with with appropriate arguments.
- [x] <a href='#crh-comment-Pull 8ee59f9fb59b63a1e5a87a82c788d1e9687e2ca9 FilePersistence/src/version_control/ListMergeComponent.cpp 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/400#discussion_r67531727'>File: FilePersistence/src/version_control/ListMergeComponent.cpp:L172-202</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You use `[&]`, but you are not capturing any variables. Please remove that.
- [x] <a href='#crh-comment-Pull 8ee59f9fb59b63a1e5a87a82c788d1e9687e2ca9 FilePersistence/src/version_control/ListMergeComponent.cpp 31'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/400#discussion_r67531737'>File: FilePersistence/src/version_control/ListMergeComponent.cpp:L172-202</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Improve the style here:
- no need for the comment, it is obvious
- no need for { and }, it's just a single short statement
- same for the else part.
- make this just on two lines `if...` and `else ...`
- [x] <a href='#crh-comment-Pull 5e5023d66a29a1e62db884504ec3486fac4eb97b FilePersistence/src/version_control/ListMergeComponent.cpp 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/400#discussion_r67533530'>File: FilePersistence/src/version_control/ListMergeComponent.cpp:L172-197</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Ok, if you want to leave the capturing in there that's fine, but since you really only intend to capture one variable I'd change this to the less error prone `[&oldNode]`

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/400?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/400?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/400'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
