### PR TITLE
Gm wfpr

### DIFF
--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -223,7 +223,7 @@ void DiffManager::showDiff(QString oldVersion, QString newVersion)
 																					(diffViewItem->nodeAt(Visualization::MajorMinorIndex{})));
 			overlay->setScale(vDiffComparisonPair->scaleFactor());
 			return message;
-		}};
+		}, Visualization::MessageOverlay::itemStyles().get("info")};
 
 
 		diffViewItem->addOverlay(overlay, "DiffInfoMessageOverlay");

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -404,6 +404,49 @@ bool DiffManager::findChangedNode(Model::TreeManager* treeManager, Model::NodeId
 	return false;
 }
 
+void DiffManager::setOverlayInformationAccordingToChangeType(FilePersistence::ChangeType changeType,
+																	QString& highlightOverlayStyle, QString& highlightOverlayName,
+																	QString& arrowIconOverlayStyle, QString& arrowIconOverlayName,
+																	bool iconsForMoveAndModify)
+{
+	switch (changeType)
+	{
+		case FilePersistence::ChangeType::Deletion:
+			highlightOverlayName = "delete_highlights";
+			highlightOverlayStyle = "delete_frame";
+			arrowIconOverlayName = "delete_arrow_icons";
+			arrowIconOverlayStyle = "delete_arrow_icon";
+			break;
+		case FilePersistence::ChangeType::Insertion:
+			highlightOverlayName = "insert_highlights";
+			highlightOverlayStyle = "insert_frame";
+			arrowIconOverlayName = "insert_arrow_icons";
+			arrowIconOverlayStyle = "insert_arrow_icon";
+			break;
+		case FilePersistence::ChangeType::Move:
+			highlightOverlayName = "move_highlights";
+			highlightOverlayStyle = "move_frame";
+			if (iconsForMoveAndModify)
+			{
+				arrowIconOverlayName = "move_arrow_icons";
+				arrowIconOverlayStyle = "move_arrow_icon";
+			}
+			break;
+		case FilePersistence::ChangeType::Stationary:
+			highlightOverlayName = "modify_highlights";
+			highlightOverlayStyle = "modify_frame";
+			if (iconsForMoveAndModify)
+			{
+				arrowIconOverlayName = "modify_arrow_icons";
+				arrowIconOverlayStyle = "modify_arrow_icon";
+			}
+			break;
+		case FilePersistence::ChangeType::Unclassified:
+			Q_ASSERT(false);
+			break;
+	}
+}
+
 void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem,
 														 QList<ChangeWithNodes> changesWithNodes)
 {
@@ -421,32 +464,9 @@ void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem
 		QString arrowIconOverlayStyle;
 		QString arrowIconOverlayName;
 
-		switch (change.changeType_)
-		{
-			case FilePersistence::ChangeType::Deletion:
-				highlightOverlayName = "delete_highlights";
-				highlightOverlayStyle = "delete_frame";
-				arrowIconOverlayName = "delete_arrow_icons";
-				arrowIconOverlayStyle = "delete_arrow_icon";
-				break;
-			case FilePersistence::ChangeType::Insertion:
-				highlightOverlayName = "insert_highlights";
-				highlightOverlayStyle = "insert_frame";
-				arrowIconOverlayName = "insert_arrow_icons";
-				arrowIconOverlayStyle = "insert_arrow_icon";
-				break;
-			case FilePersistence::ChangeType::Move:
-				highlightOverlayName = "move_highlights";
-				highlightOverlayStyle = "move_frame";
-				break;
-			case FilePersistence::ChangeType::Stationary:
-				highlightOverlayName = "modify_highlights";
-				highlightOverlayStyle = "modify_frame";
-				break;
-			case FilePersistence::ChangeType::Unclassified:
-				Q_ASSERT(false);
-				break;
-		}
+		setOverlayInformationAccordingToChangeType(change.changeType_, highlightOverlayStyle, highlightOverlayName,
+												  arrowIconOverlayStyle, arrowIconOverlayName);
+
 
 		Visualization::Item* oldNodeItem = addOverlaysAndReturnItem(change.oldNode_, diffViewItem,
 																						highlightOverlayName, highlightOverlayStyle,

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -283,12 +283,14 @@ void DiffManager::showNodeHistory(Model::NodeIdType targetNodeID, QList<QString>
 
 		QString message = createHTMLCommitInfo(diffSetup.repository_->getCommitInformation(diffSetup.newVersion_));
 
+		auto diffComparisonPairs = createDiffComparisonPairs(diffSetup, changedNodesToVisualize);
+
 		int row = 0;
-		for (auto diffComparisonPair : createDiffComparisonPairs(diffSetup, changedNodesToVisualize))
-		{
+		for (auto diffComparisonPair : diffComparisonPairs)
 			historyViewItem->insertNode(diffComparisonPair, {row++, col});
-			diffComparisonPairInfo.append({diffComparisonPair, message});
-		}
+
+		if (!diffComparisonPairs.isEmpty())
+			diffComparisonPairInfo.append({diffComparisonPairs.last(), message});
 
 		// create visualization for changes
 		Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -56,6 +56,7 @@ namespace VersionControlUI
 {
 
 struct ChangeWithNodes {
+	Model::NodeIdType id_;
 	Model::Node* oldNode_{};
 	Model::Node* newNode_{};
 	FilePersistence::ChangeType changeType_{FilePersistence::ChangeType::Unclassified};
@@ -130,13 +131,13 @@ void DiffManager::computeDiff(QString oldVersion, QString newVersion, QList<Chan
 			if ((targetOldNode && targetOldNode->isSameOrAncestorOf(oldNode))
 				 || (targetNewNode && targetNewNode->isSameOrAncestorOf(newNode)))
 			{
-				changesWithNodes.append({oldNode, newNode, change->type()});
+				changesWithNodes.append({id, oldNode, newNode, change->type()});
 			}
 			else
 				continue;
 
 		} else
-			changesWithNodes.append({oldNode, newNode, change->type()});
+			changesWithNodes.append({id, oldNode, newNode, change->type()});
 
 		Model::NodeIdType nodeId;
 

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -174,6 +174,56 @@ void DiffManager::removeNodesWithAncestorPresent(QSet<Model::NodeIdType>& contai
 	container.subtract(nodeIdsToRemove);
 }
 
+void DiffManager::highlightChangedParts(QString oldVersion, QString newVersion, Model::TreeManager* manager)
+{
+	const QString SUMMARY_HIGHLIGHT_OVERLAY_NAME = "changeSummaryHighlights";
+	const QString SUMMARY_ICON_OVERLAY_NAME = "changeSummaryIcons";
+
+	DiffSetup diffSetup;
+
+	// detailed changes
+	QList<ChangeWithNodes> changesWithNodes;
+
+	// contains the nodes which will be drawn
+	QSet<Model::NodeIdType> changedNodesToVisualize;
+
+	// fill up lists
+	computeDiff(oldVersion, newVersion, changesWithNodes, changedNodesToVisualize, diffSetup);
+
+	auto currentViewItem = Visualization::VisualizationManager::instance().
+			mainScene()->currentViewItem();
+
+	// make sure any old overlays are removed first
+	currentViewItem->scene()->removeOverlayGroup(SUMMARY_HIGHLIGHT_OVERLAY_NAME);
+	currentViewItem->scene()->removeOverlayGroup(SUMMARY_ICON_OVERLAY_NAME);
+
+	QString highlightOverlayStyle;
+	QString highlightOverlayName;
+	QString arrowIconOverlayStyle;
+	QString arrowIconOverlayName;
+
+	for (auto changeWithNode : changesWithNodes)
+	{
+		auto node = const_cast<Model::Node*>(manager->nodeIdMap().node(changeWithNode.id_));
+
+		if (node)
+		{
+			setOverlayInformationAccordingToChangeType(changeWithNode.changeType_, highlightOverlayStyle, highlightOverlayName,
+																	 arrowIconOverlayStyle, arrowIconOverlayName, true);
+
+			highlightOverlayName = SUMMARY_HIGHLIGHT_OVERLAY_NAME;
+			arrowIconOverlayName = SUMMARY_ICON_OVERLAY_NAME;
+
+
+			addOverlaysAndReturnItem(node, currentViewItem,
+															 highlightOverlayName, highlightOverlayStyle,
+															 arrowIconOverlayName, arrowIconOverlayStyle);
+		}
+	}
+
+}
+
+
 void DiffManager::showDiff(QString oldVersion, QString newVersion)
 {
 	DiffSetup diffSetup;

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -461,6 +461,11 @@ void DiffManager::setOverlayInformationAccordingToChangeType(FilePersistence::Ch
 																	QString& arrowIconOverlayStyle, QString& arrowIconOverlayName,
 																	bool iconsForMoveAndModify)
 {
+	highlightOverlayStyle = QString{};
+	highlightOverlayName = QString{};
+	arrowIconOverlayStyle = QString{};
+	arrowIconOverlayName = QString{};
+
 	switch (changeType)
 	{
 		case FilePersistence::ChangeType::Deletion:

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -64,6 +64,8 @@ class VERSIONCONTROLUI_API DiffManager
 
 		void showNodeHistory(Model::NodeIdType targetNodeID, QList<QString> versions);
 
+		void highlightChangedParts(QString oldVersion, QString newVersion, Model::TreeManager* manager);
+
 		static QString createHTMLCommitInfo(FilePersistence::CommitMetaData commitMetaData);
 
 	private:

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -121,6 +121,11 @@ class VERSIONCONTROLUI_API DiffManager
 		 */
 		void removeNodesWithAncestorPresent(QSet<Model::NodeIdType>& container);
 
+		static void setOverlayInformationAccordingToChangeType(FilePersistence::ChangeType changeType,
+																			QString& highlightOverlayStyle, QString& highlightOverlayName,
+																			QString& arrowIconOverlayStyle, QString& arrowIconOverlayName,
+																			bool iconsForMoveAndModify = false);
+
 		static Visualization::Item* addOverlaysAndReturnItem(Model::Node* node, Visualization::ViewItem* viewItem,
 																QString highlightOverlayName, QString highlightOverlayStyle,
 																QString arrowIconOverlayName, QString arrowIconOverlayStyle);

--- a/VersionControlUI/src/commands/CDiff.cpp
+++ b/VersionControlUI/src/commands/CDiff.cpp
@@ -84,7 +84,7 @@ bool CDiff::canInterpret(Visualization::Item*, Visualization::Item* target,
 		if (!commandTokensCopy.isEmpty())
 		{
 			auto token = commandTokensCopy.takeFirst();
-			if (token != "summary")
+			if (token != SUMMARY_COMMAND)
 				return false;
 		}
 		return true;

--- a/VersionControlUI/src/commands/CDiff.cpp
+++ b/VersionControlUI/src/commands/CDiff.cpp
@@ -125,7 +125,7 @@ Interaction::CommandResult* CDiff::execute(Visualization::Item*, Visualization::
 	return new Interaction::CommandResult{};
 }
 
-QString CDiff::descriptionForCommits(QString token, QList<QPair<QString, QString>> commits)
+QString CDiff::descriptionForCommits(QString token, const QList<QPair<QString, QString>>& commits)
 {
 	QString suggestDescription;
 

--- a/VersionControlUI/src/commands/CDiff.cpp
+++ b/VersionControlUI/src/commands/CDiff.cpp
@@ -149,7 +149,6 @@ QList<Interaction::CommandSuggestion*> CDiff::suggest(Visualization::Item*, Visu
 	QStringList tokensSoFar = textSoFar.split(" ");
 
 	QList<Interaction::CommandSuggestion*> suggestions;
-	QString commandName = name();
 
 	// no suggestions for that many tokens
 	if (tokensSoFar.size() > 4)

--- a/VersionControlUI/src/commands/CDiff.h
+++ b/VersionControlUI/src/commands/CDiff.h
@@ -59,7 +59,7 @@ class VERSIONCONTROLUI_API CDiff : public Interaction::Command
 		QStringList computeUnambiguousShortestPrefixesPerString(const QStringList& strings, const int minPrefixLength);
 
 		QHash<QString, QString> unambigousPrefixPerRevision_;
-		QString descriptionForCommits(QString token, QList<QPair<QString, QString>> commits);
+		QString descriptionForCommits(QString token, const QList<QPair<QString, QString>>& commits);
 };
 
 }

--- a/VersionControlUI/src/commands/CDiff.h
+++ b/VersionControlUI/src/commands/CDiff.h
@@ -45,6 +45,8 @@ class VERSIONCONTROLUI_API CDiff : public Interaction::Command
 				const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>& cursor) override;
 
 	private:
+
+		static const QString SUMMARY_COMMAND;
 		/**
 		 * Returns the unambigous prefixes of commits and their description that start with \a partialCommitId.
 		 */

--- a/VersionControlUI/src/commands/CDiff.h
+++ b/VersionControlUI/src/commands/CDiff.h
@@ -57,6 +57,7 @@ class VERSIONCONTROLUI_API CDiff : public Interaction::Command
 		QStringList computeUnambiguousShortestPrefixesPerString(const QStringList& strings, const int minPrefixLength);
 
 		QHash<QString, QString> unambigousPrefixPerRevision_;
+		QString descriptionForCommits(QString token, QList<QPair<QString, QString>> commits);
 };
 
 }

--- a/VisualizationBase/src/items/ViewItem.cpp
+++ b/VisualizationBase/src/items/ViewItem.cpp
@@ -132,7 +132,7 @@ MajorMinorIndex ViewItem::positionOfNode(Model::Node *node) const
 	for (int major = 0; major < nodes_.size(); major++)
 		for (int minor = 0; minor < nodes_[major].size(); minor++)
 			if (nodes_[major][minor] == node ||
-					DCast<ViewItemNode>(nodes_[major][minor])->reference() == node)
+					(nodes_[major][minor] && DCast<ViewItemNode>(nodes_[major][minor])->reference() == node))
 				return {major, minor};
 
 	return {-1, -1};


### PR DESCRIPTION
- Add id to ChangeWithNodes struct
- Extract switch on change type to new Method
- Extract method to construct description message for commits
- Add initial version of summary command for Diff
- Use SUMMARY_COMMAND instead of string literal

Fixes:
- Use "info" style for MessageOverlay in showDiff
- Only show info for last diffComparisonPair per column
- Add nullptr check in positionOfNode
- Remove unused variable
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/401%23discussion_r67682252%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/401%23discussion_r67682504%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/401%23issuecomment-227134798%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/401%23issuecomment-227136861%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%200d316d5451bec3c8eea41f4c0e5fdc7cd96fb6a7%20VersionControlUI/src/DiffManager.cpp%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/401%23discussion_r67682252%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Now%20that%20this%20is%20a%20separate%20method%2C%20I%20would%20explicitly%20%5C%22nullify%5C%22%20strings%20which%20should%20be%20null%3A%20%60str%20%3D%20%7B%7D%60%22%2C%20%22created_at%22%3A%20%222016-06-20T12%3A39%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL404-453%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/401%23issuecomment-227134798%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22That%27s%20all%20my%20comments.%20I%20really%20like%20the%20way%20you%20introduced%20this%20change.%20First%20abstracting%20a%20few%20things%20into%20methods%20and%20then%20just%20reusing%20those%20in%20a%20bit%20of%20new%20code.%20Very%20nice%2C%20very%20proper.%22%2C%20%22created_at%22%3A%20%222016-06-20T12%3A59%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%21%20%3A%29%20Updated%22%2C%20%22created_at%22%3A%20%222016-06-20T13%3A08%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20bc5da35ac7b5742270fbe50d761345113ff5f399%20VersionControlUI/src/commands/CDiff.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/401%23discussion_r67682504%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22pass%20this%20list%20as%20a%20%60const%20%26%60.%20In%20general%2C%20pass%20QT%20classes%20%28QList%2C%20QString%2C%20etc%29%20by%20a%20const%20reference%20if%20you%20don%27t%20need%20to%20modify%20them.%22%2C%20%22created_at%22%3A%20%222016-06-20T12%3A42%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/commands/CDiff.cpp%3AL111-135%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 0d316d5451bec3c8eea41f4c0e5fdc7cd96fb6a7 VersionControlUI/src/DiffManager.cpp 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/401#discussion_r67682252'>File: VersionControlUI/src/DiffManager.cpp:L404-453</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Now that this is a separate method, I would explicitly "nullify" strings which should be null: `str = {}`
- [ ] <a href='#crh-comment-Pull bc5da35ac7b5742270fbe50d761345113ff5f399 VersionControlUI/src/commands/CDiff.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/401#discussion_r67682504'>File: VersionControlUI/src/commands/CDiff.cpp:L111-135</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> pass this list as a `const &`. In general, pass QT classes (QList, QString, etc) by a const reference if you don't need to modify them.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/401#issuecomment-227134798'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> That's all my comments. I really like the way you introduced this change. First abstracting a few things into methods and then just reusing those in a bit of new code. Very nice, very proper.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Thanks! :) Updated

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/401?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/401?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/401'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
