### PR TITLE
Gm wfpr

### DIFF
--- a/InteractionBase/src/commands/CommandWithFlags.cpp
+++ b/InteractionBase/src/commands/CommandWithFlags.cpp
@@ -187,7 +187,7 @@ QStringList CommandWithFlags::possibleNames(Visualization::Item*, Visualization:
 QStringList CommandWithFlags::matchingNames(Visualization::Item* source, Visualization::Item* target,
 		const std::unique_ptr<Visualization::Cursor>& cursor, const QString& nameToLookFor)
 {
-	if (nameToLookFor.isNull()) return possibleNames(source, target, cursor);
+	if (nameToLookFor.isEmpty()) return possibleNames(source, target, cursor);
 
 	// Use a pattern like this 'a*b*c*' in order to simplify the search. Note that the first letter must match.
 	QString searchPattern = nameToLookFor;

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -163,7 +163,7 @@ void DiffManager::showNameChangeInformation(Visualization::ViewItem* currentView
 }
 
 // TODO decide what should be highlighted in diff
-bool DiffManager::isNameChange(Model::Node* oldNode, Model::Node* newNode, const DiffSetup& diffSetup)
+bool DiffManager::processNameChange(Model::Node* oldNode, Model::Node* newNode, const DiffSetup& diffSetup)
 {
 	if (!oldNode || !newNode)
 		return false;
@@ -225,7 +225,8 @@ void DiffManager::computeDiff(QString oldVersion, QString newVersion, QList<Chan
 		auto oldNode = const_cast<Model::Node*>(diffSetup.oldVersionManager_->nodeIdMap().node(id));
 		auto newNode = const_cast<Model::Node*>(diffSetup.newVersionManager_->nodeIdMap().node(id));
 
-		if (isNameChange(oldNode, newNode, diffSetup))
+		// don't process this change further if it is a name change, they will be shown seperately
+		if (processNameChange(versionNodes.oldNode_, versionNodes.newNode_, diffSetup))
 			continue;
 
 		if (!targetNodeID_.isNull())

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -60,10 +60,14 @@ const QString DiffManager::OVERVIEW_ICON_OVERLAY_NAME = "changeOverviewIcons";
 
 QHash<Visualization::ViewItem*, int> DiffManager::onZoomHandlerIdPerViewItem_;
 
-struct ChangeWithNodes {
-	Model::NodeIdType id_;
+struct VersionNodes {
 	Model::Node* oldNode_{};
 	Model::Node* newNode_{};
+};
+
+struct ChangeWithNodes {
+	Model::NodeIdType id_;
+	VersionNodes versionNodes_;
 	FilePersistence::ChangeType changeType_{FilePersistence::ChangeType::Unclassified};
 };
 
@@ -168,52 +172,72 @@ bool DiffManager::processNameChange(Model::Node* oldNode, Model::Node* newNode, 
 	if (!oldNode || !newNode)
 		return false;
 
-	if (DCast<Model::NameText>(oldNode) && DCast<Model::NameText>(newNode))
-	{
-		auto oldNameText = DCast<Model::NameText>(oldNode);
-		auto newNameText = DCast<Model::NameText>(newNode);
-		auto id = diffSetup.newVersionManager_->nodeIdMap().idIfExists(newNameText->parent());
-
-		nameChanges_.insert(oldNameText->get(), {newNameText->get(), id});
-
-		return true;
-	}
-
-	if (DCast<Model::Reference>(oldNode) && DCast<Model::Reference>(newNode))
-	{
-		auto oldReference = DCast<Model::Reference>(oldNode);
-		auto newReference = DCast<Model::Reference>(newNode);
-
-		auto result = nameChanges_.find(oldReference->name());
-		if (result != nameChanges_.end() && result->first == newReference->name())
+	if (auto oldReference = DCast<Model::Reference>(oldNode))
+		if (auto newReference = DCast<Model::Reference>(newNode))
 		{
-			if (oldReference->target() && newReference->target())
+			auto result = nameChanges_.find(oldReference->name());
+			if (result != nameChanges_.end() && result->first == newReference->name())
 			{
-				auto oldRefId = diffSetup.oldVersionManager_->nodeIdMap().idIfExists(oldReference->target());
-				auto newRefId = diffSetup.newVersionManager_->nodeIdMap().idIfExists(newReference->target());
+				if (oldReference->target() && newReference->target())
+				{
+					auto oldRefId = diffSetup.oldVersionManager_->nodeIdMap().idIfExists(oldReference->target());
+					auto newRefId = diffSetup.newVersionManager_->nodeIdMap().idIfExists(newReference->target());
 
-				return (oldRefId == newRefId) && (newRefId == result->second);
+					return (oldRefId == newRefId) && (newRefId == result->second);
+				}
+				return true;
 			}
-			return true;
+			return false;
 		}
-		return false;
-	}
 
 	return false;
 
+}
+
+VersionNodes DiffManager::retrieveVersionNodesForId(const Model::NodeIdType& id, const DiffSetup& diffSetup)
+{
+	auto oldNode = const_cast<Model::Node*>(diffSetup.oldVersionManager_->nodeIdMap().node(id));
+	auto newNode = const_cast<Model::Node*>(diffSetup.newVersionManager_->nodeIdMap().node(id));
+
+	return {oldNode, newNode};
+}
+
+void DiffManager::processNameTextChanges(FilePersistence::IdToChangeDescriptionHash& changes,
+													  const DiffSetup& diffSetup)
+{
+	auto iter = changes.begin();
+	while (iter != changes.end())
+	{
+		auto id = iter->get()->nodeId();
+		auto versionNodes = retrieveVersionNodesForId(id, diffSetup);
+
+		if (!versionNodes.oldNode_ || !versionNodes.newNode_) {iter++; continue;}
+
+		if (auto oldNameText = DCast<Model::NameText>(versionNodes.oldNode_))
+			if (auto newNameText = DCast<Model::NameText>(versionNodes.newNode_))
+			{
+				auto id = diffSetup.newVersionManager_->nodeIdMap().idIfExists(newNameText->parent());
+
+				nameChanges_.insert(oldNameText->get(), {newNameText->get(), id});
+
+				iter = changes.erase(iter);
+				continue;
+			}
+		iter++;
+	}
 }
 
 void DiffManager::computeDiff(QString oldVersion, QString newVersion, QList<ChangeWithNodes>& changesWithNodes,
 																		  QSet<Model::NodeIdType>& changedNodesToVisualize,
 																		  DiffSetup& diffSetup)
 {
-
 	diffSetup = initializeDiffPrerequisites(oldVersion, newVersion);
 
 	FilePersistence::Diff diff = diffSetup.repository_->diff(diffSetup.oldVersion_, diffSetup.newVersion_);
 
 	auto changes = diff.changes();
 
+	processNameTextChanges(changes, diffSetup);
 
 	for (auto change : changes.values())
 	{
@@ -222,8 +246,7 @@ void DiffManager::computeDiff(QString oldVersion, QString newVersion, QList<Chan
 
 		auto id = change->nodeId();
 
-		auto oldNode = const_cast<Model::Node*>(diffSetup.oldVersionManager_->nodeIdMap().node(id));
-		auto newNode = const_cast<Model::Node*>(diffSetup.newVersionManager_->nodeIdMap().node(id));
+		auto versionNodes = retrieveVersionNodesForId(id, diffSetup);
 
 		// don't process this change further if it is a name change, they will be shown seperately
 		if (processNameChange(versionNodes.oldNode_, versionNodes.newNode_, diffSetup))
@@ -233,16 +256,16 @@ void DiffManager::computeDiff(QString oldVersion, QString newVersion, QList<Chan
 		{
 			auto targetOldNode = const_cast<Model::Node*>(diffSetup.oldVersionManager_->nodeIdMap().node(targetNodeID_));
 			auto targetNewNode = const_cast<Model::Node*>(diffSetup.newVersionManager_->nodeIdMap().node(targetNodeID_));
-			if ((targetOldNode && targetOldNode->isSameOrAncestorOf(oldNode))
-				 || (targetNewNode && targetNewNode->isSameOrAncestorOf(newNode)))
+			if ((targetOldNode && targetOldNode->isSameOrAncestorOf(versionNodes.oldNode_))
+				 || (targetNewNode && targetNewNode->isSameOrAncestorOf(versionNodes.newNode_)))
 			{
-				changesWithNodes.append({id, oldNode, newNode, change->type()});
+				changesWithNodes.append({id, versionNodes, change->type()});
 			}
 			else
 				continue;
 
 		} else
-			changesWithNodes.append({id, oldNode, newNode, change->type()});
+			changesWithNodes.append({id, versionNodes, change->type()});
 
 		Model::NodeIdType nodeId;
 
@@ -493,10 +516,10 @@ void DiffManager::removeDirectChildrenOfNodesInContainer(QList<ChangeWithNodes>&
 
 	for (auto change : container)
 	{
-		if (change.oldNode_)
-			oldNodes.insert(change.oldNode_, change.changeType_);
-		if (change.newNode_)
-			newNodes.insert(change.newNode_, change.changeType_);
+		if (change.versionNodes_.oldNode_)
+			oldNodes.insert(change.versionNodes_.oldNode_, change.changeType_);
+		if (change.versionNodes_.newNode_)
+			newNodes.insert(change.versionNodes_.newNode_, change.changeType_);
 	}
 
 	QSet<Model::Node*> oldNodesMarkedForRemoval = findAllNodesWithDirectParentPresent(oldNodes);
@@ -505,7 +528,8 @@ void DiffManager::removeDirectChildrenOfNodesInContainer(QList<ChangeWithNodes>&
 	auto it = container.begin();
 	while (it != container.end())
 	{
-		if (oldNodesMarkedForRemoval.contains(it->oldNode_) || newNodesMarkedForRemoval.contains(it->newNode_))
+		if (oldNodesMarkedForRemoval.contains(it->versionNodes_.oldNode_)
+			 || newNodesMarkedForRemoval.contains(it->versionNodes_.newNode_))
 			it = container.erase(it);
 		else
 			it++;
@@ -665,10 +689,10 @@ void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem
 												  arrowIconOverlayStyle, arrowIconOverlayName);
 
 
-		Visualization::Item* oldNodeItem = addOverlaysAndReturnItem(change.oldNode_, diffViewItem,
+		Visualization::Item* oldNodeItem = addOverlaysAndReturnItem(change.versionNodes_.oldNode_, diffViewItem,
 																						highlightOverlayName, highlightOverlayStyle,
 																						arrowIconOverlayName, arrowIconOverlayStyle);
-		Visualization::Item* newNodeItem = addOverlaysAndReturnItem(change.newNode_, diffViewItem,
+		Visualization::Item* newNodeItem = addOverlaysAndReturnItem(change.versionNodes_.newNode_, diffViewItem,
 																						highlightOverlayName, highlightOverlayStyle,
 																						arrowIconOverlayName, arrowIconOverlayStyle);
 		if (oldNodeItem)

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -184,8 +184,6 @@ bool DiffManager::isNameChange(Model::Node* oldNode, Model::Node* newNode, const
 		auto oldReference = DCast<Model::Reference>(oldNode);
 		auto newReference = DCast<Model::Reference>(newNode);
 
-		Model::Reference::resolvePending();
-
 		auto result = nameChanges_.find(oldReference->name());
 		if (result != nameChanges_.end() && result->first == newReference->name())
 		{

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -211,8 +211,6 @@ void DiffManager::processNameTextChanges(FilePersistence::IdToChangeDescriptionH
 		auto id = iter->get()->nodeId();
 		auto versionNodes = retrieveVersionNodesForId(id, diffSetup);
 
-		if (!versionNodes.oldNode_ || !versionNodes.newNode_) {iter++; continue;}
-
 		if (auto oldNameText = DCast<Model::NameText>(versionNodes.oldNode_))
 			if (auto newNameText = DCast<Model::NameText>(versionNodes.newNode_))
 			{

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -215,6 +215,7 @@ void DiffManager::processNameTextChanges(FilePersistence::IdToChangeDescriptionH
 			if (auto newNameText = DCast<Model::NameText>(versionNodes.newNode_))
 			{
 				auto id = diffSetup.newVersionManager_->nodeIdMap().idIfExists(newNameText->parent());
+				Q_ASSERT(!id.isNull());
 
 				nameChanges_.insert(oldNameText->get(), {newNameText->get(), id});
 

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -127,7 +127,7 @@ void DiffManager::clear()
 
 void DiffManager::showNameChangeInformation(Visualization::ViewItem* currentViewItem, const DiffSetup& diffSetup)
 {
-	QString message = "";
+	QString message = "The following objects have been renamed:<br/>";
 
 	for (auto entry : nameChanges_)
 	{

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -134,9 +134,14 @@ class VERSIONCONTROLUI_API DiffManager
 																QString highlightOverlayName, QString highlightOverlayStyle,
 																QString arrowIconOverlayName, QString arrowIconOverlayStyle);
 
+		bool isNameChange(Model::Node* oldNode, Model::Node* newNode, const DiffSetup& diffSetup);
+
+		void showNameChangeInformation(Visualization::ViewItem* currentViewItem, const DiffSetup& diffSetup);
+
 		QString project_;
 		QList<Model::SymbolMatcher> contextUnitMatcherPriorityList_;
 		Model::NodeIdType targetNodeID_;
+		QHash<QString, QPair<QString, Model::NodeIdType>> nameChanges_;
 
 		static void scaleItems(QSet<Visualization::Item*> itemsToScale, Visualization::ViewItem* currentViewItem);
 

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -49,6 +49,7 @@ namespace Visualization
 
 namespace VersionControlUI {
 
+struct VersionNodes;
 struct ChangeWithNodes;
 struct DiffSetup;
 class DiffComparisonPair;
@@ -124,6 +125,10 @@ class VERSIONCONTROLUI_API DiffManager
 		 * Removes all nodes which have an ancestor present in \a container
 		 */
 		void removeNodesWithAncestorPresent(QSet<Model::NodeIdType>& container);
+
+		VersionNodes retrieveVersionNodesForId(const Model::NodeIdType& id, const DiffSetup& diffSetup);
+
+		void processNameTextChanges(FilePersistence::IdToChangeDescriptionHash& changes, const DiffSetup& diffSetup);
 
 		static void setOverlayInformationAccordingToChangeType(FilePersistence::ChangeType changeType,
 																			QString& highlightOverlayStyle, QString& highlightOverlayName,

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -134,7 +134,7 @@ class VERSIONCONTROLUI_API DiffManager
 																QString highlightOverlayName, QString highlightOverlayStyle,
 																QString arrowIconOverlayName, QString arrowIconOverlayStyle);
 
-		bool isNameChange(Model::Node* oldNode, Model::Node* newNode, const DiffSetup& diffSetup);
+		bool processNameChange(Model::Node* oldNode, Model::Node* newNode, const DiffSetup& diffSetup);
 
 		void showNameChangeInformation(Visualization::ViewItem* currentViewItem, const DiffSetup& diffSetup);
 

--- a/VersionControlUI/src/commands/CHistory.cpp
+++ b/VersionControlUI/src/commands/CHistory.cpp
@@ -37,13 +37,13 @@ using namespace FilePersistence;
 
 namespace VersionControlUI {
 
-CHistory::CHistory() : CommandWithFlags{"history", {{"project"}}, true, false}
+CHistory::CHistory() : CommandWithFlags{"history", {{"accumulate"}}, true, false}
 {
 }
 
 Interaction::CommandResult* CHistory::executeNamed(Visualization::Item* /*source*/, Visualization::Item* target,
 												  const std::unique_ptr<Visualization::Cursor>& /*cursor*/,
-												  const QString& name, const QStringList& /*attributes*/)
+												  const QString& name, const QStringList& attributes)
 {
 	Model::TreeManager* headManager = target->node()->manager();
 	QString managerName = headManager->name();
@@ -69,7 +69,12 @@ Interaction::CommandResult* CHistory::executeNamed(Visualization::Item* /*source
 	History history{targetPath, targetID, &graph, repository};
 
 	DiffManager diffManager{managerName, {target->node()->typeName()}};
-	diffManager.showNodeHistory(targetID, history.relevantCommitsByTime(repository, false));
+
+	auto relevantCommitsbyTime = history.relevantCommitsByTime(repository, false);
+	if (attributes.first() == "accumulate")
+		relevantCommitsbyTime = {relevantCommitsbyTime.first(), relevantCommitsbyTime.last()};
+
+	diffManager.showNodeHistory(targetID, relevantCommitsbyTime);
 
 	return new Interaction::CommandResult{};
 }

--- a/VersionControlUI/src/nodes/DiffComparisonPair.cpp
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.cpp
@@ -96,11 +96,12 @@ QString DiffComparisonPair::computeObjectPath(Model::Node* node)
 {
 	if (!node) return "";
 	auto parent = node->parent();
-	QString objectPath = "";
+	QString objectPath = node->definesSymbol() ? node->symbolName() : "";
 	while (parent)
 	{
 		if (parent->definesSymbol())
 			objectPath.prepend(parent->symbolName() + ".");
+
 		parent = parent->parent();
 	}
 

--- a/VersionControlUI/src/nodes/DiffComparisonPair.h
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.h
@@ -71,6 +71,7 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 		QList<ObjectPathCrumbData> objectPathCrumbsDataOldNode();
 		QList<ObjectPathCrumbData> objectPathCrumbsDataNewNode();
 
+		static QString computeObjectPath(Model::Node* node);
 
 	private:
 		bool twoObjectPathsDefined_{};
@@ -83,8 +84,6 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 		QString computeComponentName();
 
 		QList<ObjectPathCrumbData> computeObjectPathCrumbData(Model::Node* node, QString& objectPath);
-
-		QString computeObjectPath(Model::Node* node);
 
 		void computeObjectPathCrumbs(Model::Node* oldNode, QString oldNodeObjectPath,
 											  Model::Node* newNode, QString newNodeObjectPath);


### PR DESCRIPTION
- Check for isEmpty() instead of isNull() to also catch empty strings
- Add option to accumulate changes for CHistory command
- Include node symbol name in object path if available
- Initial version of name change detection
- Remove unnecessary resolvePending() call
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68246879%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68246922%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68247457%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68247717%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68247997%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68248127%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68248438%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68248733%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68249318%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68249603%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68249662%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68249797%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68397874%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68398102%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68398610%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23issuecomment-228348466%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23issuecomment-228350749%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23issuecomment-228353924%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23issuecomment-228348466%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22OK%2C%20that%27s%20all.%20I%20assume%20you%20have%20tested%20the%20latest%20version%3F%22%2C%20%22created_at%22%3A%20%222016-06-24T13%3A41%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20assume%20correctly%21%20Thanks%22%2C%20%22created_at%22%3A%20%222016-06-24T13%3A50%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%22%2C%20%22created_at%22%3A%20%222016-06-24T14%3A03%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f84c3627248b39de08b488e6e89dead078763aa8%20VersionControlUI/src/DiffManager.cpp%2047%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68247457%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Don%27t%20do%20the%20same%20work%20twice%3A%5Cr%5Cn%5Cr%5Cn%20%20%20%20if%28%20auto%20oldNode%20%3D%20DCast%3C...%3E%20...%29%5Cr%5Cn%20%20%20%20%20%20%20%20if%20%28auto%20newNode%20%3D%20DCast%3C...%3E...%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20here%20you%20have%20access%20to%20both%20if%20they%20were%20not%20null%22%2C%20%22created_at%22%3A%20%222016-06-23T14%3A42%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL125-211%22%7D%2C%20%22Pull%20f84c3627248b39de08b488e6e89dead078763aa8%20VersionControlUI/src/DiffManager.cpp%2058%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68247717%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22like%20above%2C%20avoid%20doing%20double%20work.%22%2C%20%22created_at%22%3A%20%222016-06-23T14%3A43%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL125-211%22%7D%2C%20%22Pull%20f84c3627248b39de08b488e6e89dead078763aa8%20VersionControlUI/src/DiffManager.cpp%2042%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68248733%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20like%20this%20method%20name%20since%20it%20does%20additional%20work%20than%20just%20tell%20you%20yes/no.%20Use%20a%20more%20elaborate%20name%2C%20like%20%60processNameChange%60%22%2C%20%22created_at%22%3A%20%222016-06-23T14%3A48%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL125-211%22%7D%2C%20%22Pull%20f84c3627248b39de08b488e6e89dead078763aa8%20VersionControlUI/src/DiffManager.cpp%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68249662%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20would%20be%20nice%20if%20the%20message%20has%20a%20header%20of%20some%20sort%3A%5Cr%5CnThe%20following%20objects%20have%20been%20renamed%3A%22%2C%20%22created_at%22%3A%20%222016-06-23T14%3A53%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL125-211%22%7D%2C%20%22Pull%20f84c3627248b39de08b488e6e89dead078763aa8%20VersionControlUI/src/DiffManager.cpp%2065%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68247997%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmmm%2C%20what%20if%20we%20see%20this%20reference%20change%20%2A%2Abefore%2A%2A%20we%20see%20the%20NameText%20change%2C%20Would%20we%20still%20detect%20this%20renaming%3F%22%2C%20%22created_at%22%3A%20%222016-06-23T14%3A45%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20in%20that%20case%20we%20would%20not%20detect%20it%20the%20way%20it%20is%20now.%20Is%20this%20possible%20to%20happen%3F%20%22%2C%20%22created_at%22%3A%20%222016-06-23T14%3A47%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sure.%20You%27re%20just%20iterating%20over%20a%20QHash%20of%20changes%20and%20the%20order%20of%20these%20is%20totally%20arbitrary.%5Cr%5Cn%5Cr%5CnYou%20need%20to%20look%20in%20two%20stages.%20First%20Specifically%20look%20for%20changing%20NameText%2C%20and%20then%20for%20Reference.%22%2C%20%22created_at%22%3A%20%222016-06-23T14%3A51%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hm%20very%20true%20%3A%29%20%20Will%20do.%20%22%2C%20%22created_at%22%3A%20%222016-06-23T14%3A53%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL125-211%22%7D%2C%20%22Pull%20f84c3627248b39de08b488e6e89dead078763aa8%20VersionControlUI/src/DiffManager.cpp%2091%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68246879%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20do%20we%20skip%20the%20steps%20below%20if%20this%20is%20a%20name%20change%3F%22%2C%20%22created_at%22%3A%20%222016-06-23T14%3A39%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Please%20add%20a%20comment%20here%20explaining%20that.%22%2C%20%22created_at%22%3A%20%222016-06-23T14%3A40%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20avoids%20having%20highlights%20for%20name%20changes%2C%20since%20they%20are%20summarized%20in%20a%20message%20overlay%20at%20the%20moment.%20%22%2C%20%22created_at%22%3A%20%222016-06-23T14%3A45%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Change%20the%20method%20name%20and%20put%20a%20brief%20comment%20here.%22%2C%20%22created_at%22%3A%20%222016-06-23T14%3A54%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL227-236%22%7D%2C%20%22Pull%20c92e91282a8082cbe87ed812b3897e8784abae8b%20VersionControlUI/src/DiffManager.cpp%2075%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68397874%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20can%20drop%20this%20line%2C%20the%20next%20two%20cover%20this%20case%20and%20are%20just%20as%20efficient.%22%2C%20%22created_at%22%3A%20%222016-06-24T13%3A32%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20I%20thought%20the%20cast%20would%20be%20more%20expensive.%20OK%20will%20do%22%2C%20%22created_at%22%3A%20%222016-06-24T13%3A33%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL172-244%22%7D%2C%20%22Pull%20c92e91282a8082cbe87ed812b3897e8784abae8b%20VersionControlUI/src/DiffManager.cpp%2082%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/403%23discussion_r68398610%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20always%20exist%2C%20please%20add%20a%20Q_ASSERT.%22%2C%20%22created_at%22%3A%20%222016-06-24T13%3A37%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL172-244%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull f84c3627248b39de08b488e6e89dead078763aa8 VersionControlUI/src/DiffManager.cpp 91'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/403#discussion_r68246879'>File: VersionControlUI/src/DiffManager.cpp:L227-236</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why do we skip the steps below if this is a name change?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please add a comment here explaining that.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> This avoids having highlights for name changes, since they are summarized in a message overlay at the moment.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Change the method name and put a brief comment here.
- [ ] <a href='#crh-comment-Pull f84c3627248b39de08b488e6e89dead078763aa8 VersionControlUI/src/DiffManager.cpp 47'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/403#discussion_r68247457'>File: VersionControlUI/src/DiffManager.cpp:L125-211</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Don't do the same work twice:
  if( auto oldNode = DCast<...> ...)
  if (auto newNode = DCast<...>...)
  here you have access to both if they were not null
- [ ] <a href='#crh-comment-Pull f84c3627248b39de08b488e6e89dead078763aa8 VersionControlUI/src/DiffManager.cpp 58'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/403#discussion_r68247717'>File: VersionControlUI/src/DiffManager.cpp:L125-211</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> like above, avoid doing double work.
- [ ] <a href='#crh-comment-Pull f84c3627248b39de08b488e6e89dead078763aa8 VersionControlUI/src/DiffManager.cpp 65'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/403#discussion_r68247997'>File: VersionControlUI/src/DiffManager.cpp:L125-211</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmmm, what if we see this reference change **before** we see the NameText change, Would we still detect this renaming?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> No in that case we would not detect it the way it is now. Is this possible to happen?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Sure. You're just iterating over a QHash of changes and the order of these is totally arbitrary.
  You need to look in two stages. First Specifically look for changing NameText, and then for Reference.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Hm very true :)  Will do.
- [ ] <a href='#crh-comment-Pull f84c3627248b39de08b488e6e89dead078763aa8 VersionControlUI/src/DiffManager.cpp 42'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/403#discussion_r68248733'>File: VersionControlUI/src/DiffManager.cpp:L125-211</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I don't like this method name since it does additional work than just tell you yes/no. Use a more elaborate name, like `processNameChange`
- [ ] <a href='#crh-comment-Pull f84c3627248b39de08b488e6e89dead078763aa8 VersionControlUI/src/DiffManager.cpp 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/403#discussion_r68249662'>File: VersionControlUI/src/DiffManager.cpp:L125-211</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> It would be nice if the message has a header of some sort:
  The following objects have been renamed:
- [ ] <a href='#crh-comment-Pull c92e91282a8082cbe87ed812b3897e8784abae8b VersionControlUI/src/DiffManager.cpp 75'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/403#discussion_r68397874'>File: VersionControlUI/src/DiffManager.cpp:L172-244</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You can drop this line, the next two cover this case and are just as efficient.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Ah I thought the cast would be more expensive. OK will do
- [ ] <a href='#crh-comment-Pull c92e91282a8082cbe87ed812b3897e8784abae8b VersionControlUI/src/DiffManager.cpp 82'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/403#discussion_r68398610'>File: VersionControlUI/src/DiffManager.cpp:L172-244</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This should always exist, please add a Q_ASSERT.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/403#issuecomment-228348466'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> OK, that's all. I assume you have tested the latest version?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> You assume correctly! Thanks
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/403?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/403?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/403'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
