### PR TITLE
Gm wfpr

### DIFF
--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -146,7 +146,7 @@ void DiffManager::showNameChangeInformation(Visualization::ViewItem* currentView
 		auto newNode = const_cast<Model::Node*>(diffSetup.newVersionManager_->nodeIdMap().node(id));
 
 		// if targetNode is defined, we only want to know about name changes related to it
-		if (!satisfiesTargetNodeIdConstraint(oldNode, newNode, diffSetup))
+		if (!areInTargetNodeSubtree(oldNode, newNode, diffSetup))
 			 continue;
 
 		message += DiffComparisonPair::computeObjectPath(oldNode) +
@@ -244,7 +244,7 @@ void DiffManager::processNameTextChanges(FilePersistence::IdToChangeDescriptionH
 	}
 }
 
-bool DiffManager::satisfiesTargetNodeIdConstraint(Model::Node* oldNode, Model::Node* newNode,
+bool DiffManager::areInTargetNodeSubtree(Model::Node* oldNode, Model::Node* newNode,
 																  const DiffSetup& diffSetup)
 {
 	if (targetNodeId_.isNull())
@@ -302,7 +302,7 @@ void DiffManager::computeDiff(QString oldVersion, QString newVersion, QList<Chan
 		if (processNameChange(versionNodes.oldNode_, versionNodes.newNode_, diffSetup))
 			nameChangesIdsIsNameText_.insert(id, false);
 
-		if (satisfiesTargetNodeIdConstraint(versionNodes.oldNode_, versionNodes.newNode_, diffSetup))
+		if (areInTargetNodeSubtree(versionNodes.oldNode_, versionNodes.newNode_, diffSetup))
 			changesWithNodes.append({id, versionNodes, change->type()});
 		else
 			continue;

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -145,6 +145,7 @@ void DiffManager::showNameChangeInformation(Visualization::ViewItem* currentView
 		auto oldNode = const_cast<Model::Node*>(diffSetup.oldVersionManager_->nodeIdMap().node(id));
 		auto newNode = const_cast<Model::Node*>(diffSetup.newVersionManager_->nodeIdMap().node(id));
 
+		// if targetNode is defined, we only want to know about name changes related to it
 		if (!satisfiesTargetNodeIdConstraint(oldNode, newNode, diffSetup))
 			 continue;
 
@@ -260,7 +261,6 @@ bool DiffManager::satisfiesTargetNodeIdConstraint(Model::Node* oldNode, Model::N
 }
 
 bool DiffManager::satisfiesNameChangeVisualizationConstraints(Model::NodeIdType id)
-__attribute__((optnone))
 {
 	auto iter = nameChangesIdsIsNameText_.find(id);
 

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -260,16 +260,19 @@ bool DiffManager::areInTargetNodeSubtree(Model::Node* oldNode, Model::Node* newN
 	return false;
 }
 
-bool DiffManager::satisfiesNameChangeVisualizationConstraints(Model::NodeIdType id)
+bool DiffManager::shouldShowChange(Model::NodeIdType id)
 {
 	auto iter = nameChangesIdsIsNameText_.find(id);
 
+	// id is not involved in name change
 	if (iter == nameChangesIdsIsNameText_.end())
 		return true;
 
+	// node for id is NameText, if NameText flag is not set don't show it
 	if (iter.value() && !nameChangeVisualization_.testFlag(NameText))
 		return false;
 
+	// node for id is Reference, if References flag is not set don't show it
 	if (!iter.value() && !nameChangeVisualization_.testFlag(References))
 		return false;
 
@@ -309,7 +312,7 @@ void DiffManager::computeDiff(QString oldVersion, QString newVersion, QList<Chan
 
 		Model::NodeIdType nodeId;
 
-		if (satisfiesNameChangeVisualizationConstraints(id))
+		if (shouldShowChange(id))
 		{
 			if (change->type() != FilePersistence::ChangeType::Deletion)
 				if (findChangedNode(diffSetup.newVersionManager_, id, nodeId))

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -155,7 +155,7 @@ class VERSIONCONTROLUI_API DiffManager
 		bool areInTargetNodeSubtree(Model::Node* oldNode, Model::Node* newNode,
 																					const DiffSetup& diffSetup);
 
-		bool satisfiesNameChangeVisualizationConstraints(Model::NodeIdType id);
+		bool shouldShowChange(Model::NodeIdType id);
 
 		QString project_;
 		QList<Model::SymbolMatcher> contextUnitMatcherPriorityList_;

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -152,7 +152,7 @@ class VERSIONCONTROLUI_API DiffManager
 		void showNameChangeInformation(Visualization::ViewItem* currentViewItem, const DiffSetup& diffSetup,
 												 VersionControlUI::DiffComparisonPair* diffComparisonPair);
 
-		bool satisfiesTargetNodeIdConstraint(Model::Node* oldNode, Model::Node* newNode,
+		bool areInTargetNodeSubtree(Model::Node* oldNode, Model::Node* newNode,
 																					const DiffSetup& diffSetup);
 
 		bool satisfiesNameChangeVisualizationConstraints(Model::NodeIdType id);

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -159,7 +159,10 @@ class VERSIONCONTROLUI_API DiffManager
 
 		QString project_;
 		QList<Model::SymbolMatcher> contextUnitMatcherPriorityList_;
+
+		// if set specifies which node we are interested in, used for history
 		Model::NodeIdType targetNodeId_;
+
 		QHash<QString, QPair<QString, Model::NodeIdType>> nameChanges_;
 		QHash<Model::NodeIdType, bool> nameChangesIdsIsNameText_;
 		NameChangeVisualizations nameChangeVisualization_{Summary};

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -57,9 +57,17 @@ class DiffComparisonPair;
 class VERSIONCONTROLUI_API DiffManager
 {
 	public:
+		enum NameChangeVisualization {
+				Summary = 0x1,
+				NameText = 0x2,
+				References = 0x4
+		};
+		using NameChangeVisualizations = QFlags<NameChangeVisualization>;
+
 		DiffManager(QString project,
 						QList<Model::SymbolMatcher> contextUnitMatcherPriorityList,
-						Model::NodeIdType targetNodeID=Model::NodeIdType{});
+						Model::NodeIdType targetNodeID=Model::NodeIdType{},
+						NameChangeVisualizations nameChangeVisualization = NameChangeVisualizations(Summary));
 
 		void showDiff(QString oldVersion, QString newVersion);
 
@@ -141,12 +149,20 @@ class VERSIONCONTROLUI_API DiffManager
 
 		bool processNameChange(Model::Node* oldNode, Model::Node* newNode, const DiffSetup& diffSetup);
 
-		void showNameChangeInformation(Visualization::ViewItem* currentViewItem, const DiffSetup& diffSetup);
+		void showNameChangeInformation(Visualization::ViewItem* currentViewItem, const DiffSetup& diffSetup,
+												 VersionControlUI::DiffComparisonPair* diffComparisonPair);
+
+		bool satisfiesTargetNodeIdConstraint(Model::Node* oldNode, Model::Node* newNode,
+																					const DiffSetup& diffSetup);
+
+		bool satisfiesNameChangeVisualizationConstraints(Model::NodeIdType id);
 
 		QString project_;
 		QList<Model::SymbolMatcher> contextUnitMatcherPriorityList_;
-		Model::NodeIdType targetNodeID_;
+		Model::NodeIdType targetNodeId_;
 		QHash<QString, QPair<QString, Model::NodeIdType>> nameChanges_;
+		QHash<Model::NodeIdType, bool> nameChangesIdsIsNameText_;
+		NameChangeVisualizations nameChangeVisualization_{Summary};
 
 		static void scaleItems(QSet<Visualization::Item*> itemsToScale, Visualization::ViewItem* currentViewItem);
 
@@ -155,5 +171,7 @@ class VERSIONCONTROLUI_API DiffManager
 
 		static QHash<Visualization::ViewItem*, int> onZoomHandlerIdPerViewItem_;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(DiffManager::NameChangeVisualizations)
 
 }

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -66,8 +66,8 @@ class VERSIONCONTROLUI_API DiffManager
 
 		DiffManager(QString project,
 						QList<Model::SymbolMatcher> contextUnitMatcherPriorityList,
-						Model::NodeIdType targetNodeID=Model::NodeIdType{},
-						NameChangeVisualizations nameChangeVisualization = NameChangeVisualizations(Summary));
+						Model::NodeIdType targetNodeID={},
+						NameChangeVisualizations nameChangeVisualization = Summary);
 
 		void showDiff(QString oldVersion, QString newVersion);
 

--- a/VersionControlUI/src/commands/CHistory.cpp
+++ b/VersionControlUI/src/commands/CHistory.cpp
@@ -81,6 +81,12 @@ Interaction::CommandResult* CHistory::executeNamed(Visualization::Item* /*source
 	DiffManager diffManager{managerName, {target->node()->typeName()}};
 
 	auto relevantCommitsbyTime = history.relevantCommitsByTime(repository, false);
+
+	auto firstCommitIndex = repository->revisions().indexOf(relevantCommitsbyTime.first());
+
+	if (firstCommitIndex < repository->revisions().size() - 1)
+			relevantCommitsbyTime.prepend(repository->revisions().at(firstCommitIndex+1));
+
 	if (attributes.first() == "accumulate")
 		relevantCommitsbyTime = {relevantCommitsbyTime.first(), relevantCommitsbyTime.last()};
 

--- a/VersionControlUI/src/items/VDiffComparisonPair.cpp
+++ b/VersionControlUI/src/items/VDiffComparisonPair.cpp
@@ -80,6 +80,8 @@ void VDiffComparisonPair::initializeForms()
 
 	auto noNodeFound = item<Visualization::Static>(&I::nodeNotFoundIcon_, &StyleType::nodeNotFoundIcon);
 
+	auto dummy = item<Visualization::Static>(&I::dummyIcon_, &StyleType::dummyIcon);
+
 	// form with both nodes and only one object path
 
 	auto infoGrid = (new Visualization::GridLayoutFormElement{})
@@ -256,6 +258,32 @@ void VDiffComparisonPair::initializeForms()
 
 	addForm(container);
 
+	diffGrid = (new Visualization::GridLayoutFormElement{})
+			->setHorizontalSpacing(50)
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setColumnStretchFactor(0, 1)
+			->setRowStretchFactor(0, 1)
+			->setRowVerticalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->put(0, 0, dummy);
+
+	container = (new Visualization::GridLayoutFormElement{})
+			->setHorizontalSpacing(30)
+			->setVerticalSpacing(15)
+			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
+			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+			->setLeftMargin(10)
+			->setRightMargin(10)
+			->setColumnStretchFactor(0, 1)
+			->setRowStretchFactor(0, 1)
+			->setColumnHorizontalAlignment(0, Visualization::LayoutStyle::Alignment::Center)
+			->put(0, 0, diffGrid);
+
+	addForm(container);
+
 }
 
 bool VDiffComparisonPair::isSensitiveToScale() const
@@ -285,6 +313,9 @@ void VDiffComparisonPair::scaleVisualizations()
 	if (nodeNotFoundIcon_)
 		nodeNotFoundIcon_->setScale(scale);
 
+	if (dummyIcon_)
+		dummyIcon_->setScale(scale);
+
 	for (auto crumb : objectPathCrumbsNewNode_)
 		crumb->setScale(scale);
 
@@ -304,6 +335,10 @@ int VDiffComparisonPair::determineForm()
 	static const int FORM_CONTAINING_ONLY_NEW_NODE = 1;
 	static const int FORM_CONTAINING_ONLY_OLD_NODE = 2;
 	static const int FORM_WITH_TWO_OBJECT_PATHS = 3;
+	static const int FORM_FOR_DUMMY_PAIR = 4;
+
+	if (node()->isDummyDiffComparisonPair())
+		return FORM_FOR_DUMMY_PAIR;
 
 	if (node()->twoObjectPathsDefined())
 		return FORM_WITH_TWO_OBJECT_PATHS;

--- a/VersionControlUI/src/items/VDiffComparisonPair.h
+++ b/VersionControlUI/src/items/VDiffComparisonPair.h
@@ -69,6 +69,7 @@ class VERSIONCONTROLUI_API VDiffComparisonPair : public Super<Visualization::Ite
 		Visualization::Item* newVersionNode_{};
 
 		Visualization::Static* nodeNotFoundIcon_{};
+		Visualization::Static* dummyIcon_{};
 
 		QList<Visualization::Item*> objectPathCrumbsOldNode_{};
 		QList<Visualization::Item*> objectPathCrumbsNewNode_{};

--- a/VersionControlUI/src/items/VDiffComparisonPairStyle.h
+++ b/VersionControlUI/src/items/VDiffComparisonPairStyle.h
@@ -45,5 +45,6 @@ class VERSIONCONTROLUI_API VDiffComparisonPairStyle : public Super<Visualization
 		Property<Visualization::TextStyle> singleObjectPath{this, "singleObjectPath"};
 		Property<Visualization::TextStyle> componentType{this, "componentType"};
 		Property<Visualization::StaticStyle> nodeNotFoundIcon{this, "nodeNotFoundIcon"};
+		Property<Visualization::StaticStyle> dummyIcon{this, "dummyIcon"};
 };
 }

--- a/VersionControlUI/src/nodes/DiffComparisonPair.cpp
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.cpp
@@ -36,6 +36,10 @@ namespace VersionControlUI
 
 DEFINE_NODE_TYPE_REGISTRATION_METHODS(DiffComparisonPair)
 
+DiffComparisonPair::DiffComparisonPair(Model::Node *)
+	:Super{}, isDummyDiffComparisonPair_{true}
+{}
+
 DiffComparisonPair::DiffComparisonPair(Model::Node* oldVersionNode, Model::Node* newVersionNode) : Super{}
 {
 	oldVersionNode_ = oldVersionNode;
@@ -170,12 +174,6 @@ QString DiffComparisonPair::computeComponentName()
 		}
 	}
 	return componentName;
-}
-
-DiffComparisonPair::DiffComparisonPair(Model::Node *)
-	:Super{}
-{
-	Q_ASSERT(false);
 }
 
 DiffComparisonPair::DiffComparisonPair(Model::Node *, Model::PersistentStore &, bool)

--- a/VersionControlUI/src/nodes/DiffComparisonPair.h
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.h
@@ -53,6 +53,7 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 	NODE_DECLARE_STANDARD_METHODS(DiffComparisonPair)
 
 	public:
+		DiffComparisonPair(QString);
 		DiffComparisonPair(Model::Node* oldVersionNode, Model::Node* newVersionNode);
 
 		virtual QJsonValue toJson() const override;
@@ -66,6 +67,7 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 		Model::Text* singleObjectPath();
 
 		bool twoObjectPathsDefined();
+		bool isDummyDiffComparisonPair();
 		QString comparisonName();
 
 		QList<ObjectPathCrumbData> objectPathCrumbsDataOldNode();
@@ -74,6 +76,7 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 		static QString computeObjectPath(Model::Node* node);
 
 	private:
+		bool isDummyDiffComparisonPair_{false};
 		bool twoObjectPathsDefined_{};
 
 		Model::Node* oldVersionNode_{};
@@ -101,6 +104,7 @@ inline Model::Node* DiffComparisonPair::newVersionNode() {return newVersionNode_
 inline Model::Node* DiffComparisonPair::oldVersionNode() {return oldVersionNode_;}
 
 inline bool DiffComparisonPair::twoObjectPathsDefined() {return twoObjectPathsDefined_;}
+inline bool DiffComparisonPair::isDummyDiffComparisonPair() {return isDummyDiffComparisonPair_;}
 
 inline QString DiffComparisonPair::comparisonName() { return comparisonName_; }
 

--- a/VersionControlUI/src/nodes/DiffComparisonPair.h
+++ b/VersionControlUI/src/nodes/DiffComparisonPair.h
@@ -53,7 +53,6 @@ class VERSIONCONTROLUI_API DiffComparisonPair : public Super<Visualization::UINo
 	NODE_DECLARE_STANDARD_METHODS(DiffComparisonPair)
 
 	public:
-		DiffComparisonPair(QString);
 		DiffComparisonPair(Model::Node* oldVersionNode, Model::Node* newVersionNode);
 
 		virtual QJsonValue toJson() const override;

--- a/VersionControlUI/styles/item/VDiffComparisonPair/default
+++ b/VersionControlUI/styles/item/VDiffComparisonPair/default
@@ -19,4 +19,7 @@
 	<nodeNotFoundIcon prototypes="item/Symbol/keyword">
 		<symbol>no node</symbol>
 	</nodeNotFoundIcon>
+	<dummyIcon prototypes="item/Symbol/keyword">
+		<symbol>no changes to show</symbol>
+	</dummyIcon>
 </style>


### PR DESCRIPTION
- Add one commit from before first relevant commit if possible
- Introduce dummy DiffComparisonPair
- Improve control mechanism for name change visualizations
- Add comment in showNameChangeInformation
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69156700%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69157361%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69157463%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69157484%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69157760%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69157904%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69158658%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69159274%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23issuecomment-229704300%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69269054%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69269067%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69270536%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69272722%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69272861%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69273085%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23issuecomment-229905864%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23issuecomment-229704300%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Alright%2C%20those%20are%20my%20comments%20for%20now.%22%2C%20%22created_at%22%3A%20%222016-06-30T15%3A58%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%22%2C%20%22created_at%22%3A%20%222016-07-01T09%3A47%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20164b159b9755935af497c020948124e5d3bcaefd%20VersionControlUI/src/nodes/DiffComparisonPair.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69156700%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20add%20an%20argument%20name%20here%2C%20it%27s%20useful%20for%20auto-completion.%22%2C%20%22created_at%22%3A%20%222016-06-30T15%3A39%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20%20I%20think%20this%20constructor%20shouldn%27t%20be%20there%20anyway.%20%22%2C%20%22created_at%22%3A%20%222016-06-30T15%3A43%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/nodes/DiffComparisonPair.h%3AL53-60%22%7D%2C%20%22Pull%20415721c18e92b593b886bdcf07a4a7a7e949cbc1%20VersionControlUI/src/DiffManager.h%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69157760%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20understand%20the%20names%20of%20this%20method%20and%20the%20next%20one.%20What%20do%20they%20do%3F%20Can%20we%20come%20up%20with%20better%20names%3F%22%2C%20%22created_at%22%3A%20%222016-06-30T15%3A44%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22satisfiesTargetNodeIdConstraint%20checks%20whether%20the%20nodes%20are%20the%20ones%20we%20are%20interested%20in%20%28same%20id%20as%20targetNodeId_%29%20or%20targetNodeId_%20is%20an%20ancestor%20of%20them.%5Cr%5Cn%5Cr%5CnThe%20other%20method%20I%20explained%20in%20the%20other%20comment.%22%2C%20%22created_at%22%3A%20%222016-07-01T09%3A06%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.h%3AL149-169%22%7D%2C%20%22Pull%20415721c18e92b593b886bdcf07a4a7a7e949cbc1%20VersionControlUI/src/DiffManager.h%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69157904%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20this%20used%20for%20history%3F%20If%20so%20please%20put%20a%20small%20comment%20on%20the%20right.%22%2C%20%22created_at%22%3A%20%222016-06-30T15%3A45%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20used%20to%20specify%20which%20node%20id%20we%20are%20interested%20in.%20At%20the%20moment%20it%20is%20only%20used%20for%20history.%20OK%2C%20will%20do.%22%2C%20%22created_at%22%3A%20%222016-07-01T08%3A54%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.h%3AL149-169%22%7D%2C%20%22Pull%20a9ef8f1c3d225675fe63692b46cf1dc78dada634%20VersionControlUI/src/DiffManager.cpp%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69158658%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%2C%20be%20more%20careful%20when%20committing%20and%20avoid%20committing%20things%20like%20this.%20In%20the%20ideal%20case%20the%20commit%20history%20should%20contain%20small%2C%20but%20still%20meaningful%20commits.%20Even%20if%20you%20accidentally%20commit%20some%20debug%20code%2C%20you%20should%20still%20see%20if%20there%20is%20a%20good%20way%20to%20fix%20it%20before%20pushing.%20In%20this%20particular%20case%20you%20could%20have%20avoided%20the%20extra%20commit%2C%20by%20simply%20amending%20the%20previous%20one.%22%2C%20%22created_at%22%3A%20%222016-06-30T15%3A49%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL261-267%22%7D%2C%20%22Pull%20415721c18e92b593b886bdcf07a4a7a7e949cbc1%20VersionControlUI/src/DiffManager.h%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69157361%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22you%20can%20use%20simply%20%60%7B%7D%60%20here%2C%20without%20the%20%60Model%3A%3ANodeIdType%60%20after%20the%20%60%3D%60.%20It%27s%20a%20bit%20clearer.%22%2C%20%22created_at%22%3A%20%222016-06-30T15%3A42%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.h%3AL57-74%22%7D%2C%20%22Pull%20415721c18e92b593b886bdcf07a4a7a7e949cbc1%20VersionControlUI/src/DiffManager.h%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69157484%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20%60%3D%20Summary%60%22%2C%20%22created_at%22%3A%20%222016-06-30T15%3A43%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.h%3AL57-74%22%7D%2C%20%22Pull%20415721c18e92b593b886bdcf07a4a7a7e949cbc1%20VersionControlUI/src/DiffManager.cpp%20142%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69159274%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20this%20method%20really%20ask%20for%20both%20references%20and%20nametext%3F%20In%20what%20situations%20to%20you%20use%20it%3F%22%2C%20%22created_at%22%3A%20%222016-06-30T15%3A52%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20checks%20if%20the%20id%20is%20involved%20in%20a%20name%20change%20and%20iter.value%28%29%20is%20used%20to%20distinguish%20wheter%20it%20is%20a%20NameText%20or%20a%20Reference.%20If%20it%20is%20e.g.%20a%20NameText%20and%20the%20NameText%20flag%20is%20not%20set%2C%20then%20the%20method%20will%20return%20false.%20At%20the%20moment%2C%20it%20is%20used%20to%20find%20out%20whether%20the%20node%20with%20the%20specified%20id%20should%20be%20visualized%20or%20not.%22%2C%20%22created_at%22%3A%20%222016-07-01T08%3A54%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Let%27s%20call%20this%20%60shouldShowChange%60%2C%20and%20please%20put%20short%20comments%20in%20front%20of%20the%20different%20conditions%20to%20indicate%20what%20they%20mean.%22%2C%20%22created_at%22%3A%20%222016-07-01T09%3A28%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL233-283%22%7D%2C%20%22Pull%20415721c18e92b593b886bdcf07a4a7a7e949cbc1%20VersionControlUI/src/DiffManager.cpp%20115%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/406%23discussion_r69272722%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Let%27s%20call%20this%3A%20%60areInTargetNodeSubtree%60%22%2C%20%22created_at%22%3A%20%222016-07-01T09%3A25%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sounds%20good.%22%2C%20%22created_at%22%3A%20%222016-07-01T09%3A26%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL233-283%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 164b159b9755935af497c020948124e5d3bcaefd VersionControlUI/src/nodes/DiffComparisonPair.h 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/406#discussion_r69156700'>File: VersionControlUI/src/nodes/DiffComparisonPair.h:L53-60</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please add an argument name here, it's useful for auto-completion.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Oh,  I think this constructor shouldn't be there anyway.
- [ ] <a href='#crh-comment-Pull 415721c18e92b593b886bdcf07a4a7a7e949cbc1 VersionControlUI/src/DiffManager.h 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/406#discussion_r69157361'>File: VersionControlUI/src/DiffManager.h:L57-74</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> you can use simply `{}` here, without the `Model::NodeIdType` after the `=`. It's a bit clearer.
- [ ] <a href='#crh-comment-Pull 415721c18e92b593b886bdcf07a4a7a7e949cbc1 VersionControlUI/src/DiffManager.h 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/406#discussion_r69157484'>File: VersionControlUI/src/DiffManager.h:L57-74</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Use `= Summary`
- [ ] <a href='#crh-comment-Pull 415721c18e92b593b886bdcf07a4a7a7e949cbc1 VersionControlUI/src/DiffManager.h 27'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/406#discussion_r69157760'>File: VersionControlUI/src/DiffManager.h:L149-169</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I don't understand the names of this method and the next one. What do they do? Can we come up with better names?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> satisfiesTargetNodeIdConstraint checks whether the nodes are the ones we are interested in (same id as targetNodeId_) or targetNodeId_ is an ancestor of them.
  The other method I explained in the other comment.
- [ ] <a href='#crh-comment-Pull 415721c18e92b593b886bdcf07a4a7a7e949cbc1 VersionControlUI/src/DiffManager.h 35'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/406#discussion_r69157904'>File: VersionControlUI/src/DiffManager.h:L149-169</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Is this used for history? If so please put a small comment on the right.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> It is used to specify which node id we are interested in. At the moment it is only used for history. OK, will do.
- [ ] <a href='#crh-comment-Pull a9ef8f1c3d225675fe63692b46cf1dc78dada634 VersionControlUI/src/DiffManager.cpp 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/406#discussion_r69158658'>File: VersionControlUI/src/DiffManager.cpp:L261-267</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please, be more careful when committing and avoid committing things like this. In the ideal case the commit history should contain small, but still meaningful commits. Even if you accidentally commit some debug code, you should still see if there is a good way to fix it before pushing. In this particular case you could have avoided the extra commit, by simply amending the previous one.
- [ ] <a href='#crh-comment-Pull 415721c18e92b593b886bdcf07a4a7a7e949cbc1 VersionControlUI/src/DiffManager.cpp 142'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/406#discussion_r69159274'>File: VersionControlUI/src/DiffManager.cpp:L233-283</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Should this method really ask for both references and nametext? In what situations to you use it?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> It checks if the id is involved in a name change and iter.value() is used to distinguish wheter it is a NameText or a Reference. If it is e.g. a NameText and the NameText flag is not set, then the method will return false. At the moment, it is used to find out whether the node with the specified id should be visualized or not.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Let's call this `shouldShowChange`, and please put short comments in front of the different conditions to indicate what they mean.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/406#issuecomment-229704300'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Alright, those are my comments for now.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks.
- [ ] <a href='#crh-comment-Pull 415721c18e92b593b886bdcf07a4a7a7e949cbc1 VersionControlUI/src/DiffManager.cpp 115'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/406#discussion_r69272722'>File: VersionControlUI/src/DiffManager.cpp:L233-283</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Let's call this: `areInTargetNodeSubtree`
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Sounds good.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/406?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/406?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/406'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
