### PR TITLE
Adding Skeleton code for listMergeComponentV2

### DIFF
--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
@@ -60,15 +60,13 @@ bool ListMergeComponentV2::isOrderedList(const QString& type)
 void ListMergeComponentV2::run(MergeData& mergeData)
 {
 	//	applyNonConflictingChanges(mergeData);
-	// Temporarily remove update changes(Conflicts)
 	auto listsToMerge = computeListsToMerge(mergeData);
 	for (auto listContainerId : listsToMerge)
 	{
 		auto map = getAdjustedIndices(listContainerId, mergeData);
 		adjustCG(map, mergeData);
 		//	applyChanges(mergeData);
-		// removeHoles();
-		// Restore Update Changes(Conflicts)
+		// removeHoles(mergeData);
 		// Report Conflicts
 	}
 

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
@@ -25,6 +25,13 @@
 ***********************************************************************************************************************/
 
 #include "ListMergeComponentV2.h"
+#include "../../filepersistence_api.h"
+#include "MergeChange.h"
+
+#include "ModelBase/src/persistence/PersistentStore.h"
+#include "../Diff3Parse.h"
+#include "../../simple/GenericNode.h"
+#include "../../simple/GenericTree.h"
 
 namespace FilePersistence {
 
@@ -50,7 +57,22 @@ bool ListMergeComponentV2::isOrderedList(const QString& type)
 	return !isUnorderedList(type) && isList(type);
 }
 
-void ListMergeComponentV2::run(MergeData& /*mergeData*/)
-{}
+void ListMergeComponentV2::run(MergeData& mergeData)
+{
+	//	applyNonConflictingChanges(mergeData);
+	// Temporarily remove update changes(Conflicts)
+	auto listsToMerge = computeListsToMerge(mergeData);
+	for (auto listContainerId : listsToMerge)
+	{
+		auto map = getAdjustedIndices(listContainerId, mergeData);
+		adjustCG(map, mergeData);
+		//	applyChanges(mergeData);
+		// removeHoles();
+		// Restore Update Changes(Conflicts)
+		// Report Conflicts
+	}
+
+}
+
 
 }

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
@@ -56,13 +56,13 @@ bool ListMergeComponentV2::isOrderedList(const QString& type)
 
 void ListMergeComponentV2::run(MergeData& mergeData)
 {
-	//	applyNonConflictingChanges(mergeData);
+	// applyNonConflictingChanges(mergeData);
 	auto listsToMerge = computeListsToMerge(mergeData);
 	for (auto listContainerId : listsToMerge)
 	{
-		auto map = getAdjustedIndices(listContainerId, mergeData);
+		auto map = computeAdjustedIndices(listContainerId, mergeData);
 		adjustCG(listContainerId, map, mergeData);
-		//	applyChanges(mergeData);
+		// applyChanges(mergeData);
 		// removeHoles(mergeData);
 		// Report Conflicts
 	}

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
@@ -25,10 +25,7 @@
 ***********************************************************************************************************************/
 
 #include "ListMergeComponentV2.h"
-#include "../../filepersistence_api.h"
-#include "MergeChange.h"
 
-#include "ModelBase/src/persistence/PersistentStore.h"
 #include "../Diff3Parse.h"
 #include "../../simple/GenericNode.h"
 #include "../../simple/GenericTree.h"
@@ -64,7 +61,7 @@ void ListMergeComponentV2::run(MergeData& mergeData)
 	for (auto listContainerId : listsToMerge)
 	{
 		auto map = getAdjustedIndices(listContainerId, mergeData);
-		adjustCG(map, mergeData);
+		adjustCG(listContainerId, map, mergeData);
 		//	applyChanges(mergeData);
 		// removeHoles(mergeData);
 		// Report Conflicts

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
@@ -47,7 +47,7 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 
 	private:
 
-		using IdToIndexMap = QMultiHash<Model::NodeIdType, QPair<QString, MergeChange::Branch>>;
+		using IdToIndexMap = QMultiHash<Model::NodeIdType, QPair<QString, MergeChange::Branches>>;
 		/**
 		 * Finds all the lists that we will process in the merge.
 		 *

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
@@ -27,10 +27,11 @@
 #pragma once
 
 #include "../../filepersistence_api.h"
-
+#include "ModelBase/src/persistence/PersistentStore.h"
 #include "MergePipelineComponent.h"
 
 namespace FilePersistence {
+class GenericNode;
 
 class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 {
@@ -40,6 +41,13 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 		static bool isList(const QString& type);
 		static bool isUnorderedList(const QString& type);
 		static bool isOrderedList(const QString& type);
+
+		QList<Model::NodeIdType> computeListsToMerge(MergeData& mergeData);
+		QMultiHash<Model::NodeIdType, QPair<QString, QString>>
+			getAdjustedIndices(Model::NodeIdType list, MergeData& mergeData);
+		void adjustCG(QMultiHash<Model::NodeIdType, QPair<QString, QString>> map, MergeData& mergeData);
+		QList<Model::NodeIdType> nodeListToSortedIdList(const QList<GenericNode*>& list);
+
 };
 
 }

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
@@ -27,8 +27,11 @@
 #pragma once
 
 #include "../../filepersistence_api.h"
-#include "ModelBase/src/persistence/PersistentStore.h"
+
 #include "MergePipelineComponent.h"
+#include "MergeChange.h"
+
+#include "ModelBase/src/persistence/PersistentStore.h"
 
 namespace FilePersistence {
 class GenericNode;
@@ -42,11 +45,25 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 		static bool isUnorderedList(const QString& type);
 		static bool isOrderedList(const QString& type);
 
+	private:
+
+		using IdToIndexMap = QMultiHash<Model::NodeIdType, QPair<QString, MergeChange::Branch>>;
+		/**
+		 * computeListsToMerge finds the lists having structure changes &
+		 * assumes Insertion/Deletion of whole list does not happen
+		 */
 		QList<Model::NodeIdType> computeListsToMerge(MergeData& mergeData);
-		QMultiHash<Model::NodeIdType, QPair<QString, QString>>
-			getAdjustedIndices(Model::NodeIdType list, MergeData& mergeData);
-		void adjustCG(QMultiHash<Model::NodeIdType, QPair<QString, QString>> map, MergeData& mergeData);
-		QList<Model::NodeIdType> nodeListToSortedIdList(const QList<GenericNode*>& list);
+
+		/**
+		 * getAdjustedIndices returns the map of new labels(Integral) of list
+		 * so that labels do not collide with each other
+		 */
+		IdToIndexMap getAdjustedIndices(Model::NodeIdType list, MergeData& mergeData);
+
+		/**
+		 * adjustCG adjusts CG according to the new indices returned by getAdjustedIndices
+		 */
+		void adjustCG(Model::NodeIdType list, IdToIndexMap map, MergeData& mergeData);
 
 };
 

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
@@ -49,21 +49,28 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 
 		using IdToIndexMap = QMultiHash<Model::NodeIdType, QPair<QString, MergeChange::Branch>>;
 		/**
-		 * computeListsToMerge finds the lists having structure changes &
-		 * assumes Insertion/Deletion of whole list does not happen
+		 * Finds all the lists that we will process in the merge.
+		 *
+		 * Finds the lists having structure changes
+		 * Assumes Insertion/Deletion of whole list does not happen.
 		 */
 		QList<Model::NodeIdType> computeListsToMerge(MergeData& mergeData);
 
 		/**
-		 * getAdjustedIndices returns the map of new labels(Integral) of list
-		 * so that labels do not collide with each other
+		 * Returns the map of new labels(Integral) of list
+		 * so that all labels are unique
 		 */
-		IdToIndexMap getAdjustedIndices(Model::NodeIdType list, MergeData& mergeData);
+		IdToIndexMap computeAdjustedIndices(Model::NodeIdType list, MergeData& mergeData);
 
 		/**
-		 * adjustCG adjusts CG according to the new indices returned by getAdjustedIndices
+		 * Adjusts CG according to the new indices returned by computeAdjustedIndices.
 		 */
 		void adjustCG(Model::NodeIdType list, IdToIndexMap map, MergeData& mergeData);
+
+		/**
+		 * Returns list of nodeIds sorted by labels that is used for computing chunks
+		 */
+		QList<Model::NodeIdType> nodeListToSortedIdList(const QList<GenericNode*>& list);
 
 };
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23discussion_r69809713%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23discussion_r69813197%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23discussion_r69813566%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23discussion_r69813612%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23discussion_r69814016%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23discussion_r69814400%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23issuecomment-230912381%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23discussion_r69878708%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%209ba5099cbbe6d777ad65e48483711d812fa0990f%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23discussion_r69813612%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Make%20all%20of%20these%20methods%20private.%22%2C%20%22created_at%22%3A%20%222016-07-06T21%3A20%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%3AL41-54%22%7D%2C%20%22Pull%209ba5099cbbe6d777ad65e48483711d812fa0990f%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23discussion_r69813197%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20just%20added%20the%20%60MergeChange%3A%3ABranches%60%20type%2C%20use%20it%20in%20the%20%60QPair%60%20instead%20of%20string%20to%20indicate%20which%20branch%20makes%20a%20change.%22%2C%20%22created_at%22%3A%20%222016-07-06T21%3A17%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Also%20Please%20define%20a%20new%20type%20%60using%20IdToIndexMap%20%3D%20QMultiHash%3C%20.......%3E%60%20and%20use%20it%20instead%20of%20repeating%20the%20entire%20complex%20type%20again%20and%20again.%20%22%2C%20%22created_at%22%3A%20%222016-07-06T21%3A19%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%3AL41-54%22%7D%2C%20%22Pull%209ba5099cbbe6d777ad65e48483711d812fa0990f%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23discussion_r69814400%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Which%20one%20is%20this%20function%20exactly%3F%20I%20find%20the%20fact%20that%20it%20takes%20generic%20nodes%20as%20inputs%20but%20returns%20IDs%20a%20bit%20confusing.%20Where%20do%20we%20call%20this%3F%22%2C%20%22created_at%22%3A%20%222016-07-06T21%3A25%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%2C%20it%20will%20be%20used%20later%20in%20other%20function%20for%20Computing%20chunks%22%2C%20%22created_at%22%3A%20%222016-07-07T09%3A41%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11445667%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Vaishal-shah%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%3AL41-54%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23issuecomment-230912381%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%2C%20at%20least%20for%20the%20top-level%20functions%2C%20put%20brief%20comments%20in%20the%20%60.h%60%20file%20that%20explain%20what%20these%20functions%20do%20%28one-two%20line%20description%2C%20not%20the%20full%20detail%20of%20the%20algorithm%29.%20See%20%60Item.h%60%20for%20many%20examples%20of%20how%20to%20write%20doxygen%20comments.%22%2C%20%22created_at%22%3A%20%222016-07-06T21%3A27%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%209ba5099cbbe6d777ad65e48483711d812fa0990f%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23discussion_r69814016%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20function%20should%20also%20take%20a%20list%20Id%20or%20a%20list%20node%20as%20an%20input%20argument%22%2C%20%22created_at%22%3A%20%222016-07-06T21%3A22%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%3AL41-54%22%7D%2C%20%22Pull%209ba5099cbbe6d777ad65e48483711d812fa0990f%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/408%23discussion_r69809713%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%2C%20always%20put%20includes%20from%20other%20plug-ins%20after%20includes%20of%20the%20current%20plug-in.%20Also%20group%20gether%20includes%20from%20the%20same%20plug-in.%22%2C%20%22created_at%22%3A%20%222016-07-06T20%3A55%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL25-38%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 9ba5099cbbe6d777ad65e48483711d812fa0990f FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/408#discussion_r69809713'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L25-38</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please, always put includes from other plug-ins after includes of the current plug-in. Also group gether includes from the same plug-in.
- [x] <a href='#crh-comment-Pull 9ba5099cbbe6d777ad65e48483711d812fa0990f FilePersistence/src/version_control/merge/ListMergeComponentV2.h 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/408#discussion_r69813197'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.h:L41-54</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I just added the `MergeChange::Branches` type, use it in the `QPair` instead of string to indicate which branch makes a change.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Also Please define a new type `using IdToIndexMap = QMultiHash< .......>` and use it instead of repeating the entire complex type again and again.
- [x] <a href='#crh-comment-Pull 9ba5099cbbe6d777ad65e48483711d812fa0990f FilePersistence/src/version_control/merge/ListMergeComponentV2.h 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/408#discussion_r69813612'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.h:L41-54</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Make all of these methods private.
- [x] <a href='#crh-comment-Pull 9ba5099cbbe6d777ad65e48483711d812fa0990f FilePersistence/src/version_control/merge/ListMergeComponentV2.h 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/408#discussion_r69814016'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.h:L41-54</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This function should also take a list Id or a list node as an input argument
- [x] <a href='#crh-comment-Pull 9ba5099cbbe6d777ad65e48483711d812fa0990f FilePersistence/src/version_control/merge/ListMergeComponentV2.h 22'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/408#discussion_r69814400'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.h:L41-54</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Which one is this function exactly? I find the fact that it takes generic nodes as inputs but returns IDs a bit confusing. Where do we call this?
- <a href='https://github.com/Vaishal-shah'><img border=0 src='https://avatars.githubusercontent.com/u/11445667?v=3' height=16 width=16'></a> Sorry, it will be used later in other function for Computing chunks
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/408#issuecomment-230912381'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please, at least for the top-level functions, put brief comments in the `.h` file that explain what these functions do (one-two line description, not the full detail of the algorithm). See `Item.h` for many examples of how to write doxygen comments.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/408?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/408?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/408'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
