### PR TITLE
Gm message overlay

### DIFF
--- a/InteractionBase/CMakeLists.txt
+++ b/InteractionBase/CMakeLists.txt
@@ -187,6 +187,8 @@ add_library(InteractionBase SHARED
 	src/handlers/HWebBrowserItem.cpp
 	src/handlers/HMovableItem.h
 	src/handlers/HMovableItem.cpp
+	src/handlers/HMessageOverlay.h
+	src/handlers/HMessageOverlay.cpp
 	src/handlers/HArrowHandler.cpp
 )
 

--- a/InteractionBase/src/InteractionBasePlugin.cpp
+++ b/InteractionBase/src/InteractionBasePlugin.cpp
@@ -38,6 +38,7 @@
 #include "handlers/HViewItem.h"
 #include "handlers/HWebBrowserItem.h"
 #include "handlers/HArrowHandler.h"
+#include "handlers/HMessageOverlay.h"
 
 #include "vis/TextAndDescription.h"
 #include "vis/VViewSwitcherEntry.h"
@@ -106,7 +107,7 @@ bool InteractionBasePlugin::initialize(Core::EnvisionManager& envisionManager)
 	Visualization::VInfoNode::setDefaultClassHandler(HInfoNode::instance());
 	Visualization::ViewItem::setDefaultClassHandler(HViewItem::instance());
 	Visualization::WebBrowserItem::setDefaultClassHandler(HWebBrowserItem::instance());
-	Visualization::MessageOverlay::setDefaultClassHandler(HMovableItem::instance());
+	Visualization::MessageOverlay::setDefaultClassHandler(HMessageOverlay::instance());
 	Visualization::ArrowOverlay::setDefaultClassHandler(HArrowHandler::instance());
 	ActionPrompt::setDefaultClassHandler(HActionPrompt::instance());
 

--- a/InteractionBase/src/handlers/HMessageOverlay.cpp
+++ b/InteractionBase/src/handlers/HMessageOverlay.cpp
@@ -1,0 +1,49 @@
+/***********************************************************************************************************************
+ **
+ ** Copyright (c) 2011, 2016 ETH Zurich
+ ** All rights reserved.
+ **
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ ** following conditions are met:
+ **
+ **    * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ **      following disclaimer.
+ **    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ **      following disclaimer in the documentation and/or other materials provided with the distribution.
+ **    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+ **      derived from this software without specific prior written permission.
+ **
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ ** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ ** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ ** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ ** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **
+ **********************************************************************************************************************/
+
+#include "HMessageOverlay.h"
+
+namespace Interaction {
+
+HMessageOverlay* HMessageOverlay::instance()
+{
+	static HMessageOverlay h;
+	return &h;
+}
+
+void HMessageOverlay::mouseMoveEvent(Visualization::Item *target, QGraphicsSceneMouseEvent *event)
+{
+	HMovableItem::mouseMoveEvent(target, event);
+	if (event->buttons() == Qt::LeftButton && target)
+	{
+		auto overlay = static_cast<Visualization::MessageOverlay*>(target);
+		QPointF diff{(event->scenePos() - event->buttonDownScenePos(Qt::LeftButton))};
+		overlay->updateOffsetItemLocal(itemPosition() + diff);
+	}
+
+}
+
+}

--- a/InteractionBase/src/handlers/HMessageOverlay.h
+++ b/InteractionBase/src/handlers/HMessageOverlay.h
@@ -1,0 +1,47 @@
+/***********************************************************************************************************************
+ **
+ ** Copyright (c) 2011, 2016 ETH Zurich
+ ** All rights reserved.
+ **
+ ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ ** following conditions are met:
+ **
+ **    * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ **      following disclaimer.
+ **    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ **      following disclaimer in the documentation and/or other materials provided with the distribution.
+ **    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+ **      derived from this software without specific prior written permission.
+ **
+ **
+ ** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ ** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ ** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ ** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ ** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ **
+ **********************************************************************************************************************/
+
+#pragma once
+
+#include "../interactionbase_api.h"
+
+#include "VisualizationBase/src/overlays/MessageOverlay.h"
+
+#include "HMovableItem.h"
+
+namespace Interaction {
+
+class INTERACTIONBASE_API HMessageOverlay : public HMovableItem {
+
+	public:
+		static HMessageOverlay* instance();
+
+	private:
+		virtual void mouseMoveEvent(Visualization::Item *target, QGraphicsSceneMouseEvent *event) override;
+};
+
+
+}

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -131,7 +131,8 @@ void DiffManager::clear()
 }
 
 void DiffManager::showNameChangeInformation(Visualization::ViewItem* currentViewItem, const DiffSetup& diffSetup,
-														  VersionControlUI::DiffComparisonPair* diffComparisonPair)
+														  VersionControlUI::DiffComparisonPair* diffComparisonPair,
+														  Visualization::MessageOverlay::Position position)
 {
 	if (nameChanges_.isEmpty())
 		return;
@@ -167,34 +168,34 @@ void DiffManager::showNameChangeInformation(Visualization::ViewItem* currentView
 
 	// if there is a message to show add header
 	if (!message.isEmpty())
-		message = message.prepend("The following objects have been renamed:<br/>");
+		message = message.prepend("The following objects <br/> have been renamed:<br/>");
 	else
 		return;
 
 	Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
-								  [currentViewItem, message, diffComparisonPair]() {
-		auto overlay = new Visualization::MessageOverlay{currentViewItem,
-				[currentViewItem, message, diffComparisonPair](Visualization::MessageOverlay* overlay)
+								  [currentViewItem, message, diffComparisonPair, position]() {
+		Visualization::Item* targetItem = nullptr;
+
+		if (diffComparisonPair)
 		{
-			if (diffComparisonPair)
-			{
-				auto vDiffComparisonPair = DCast<VersionControlUI::VDiffComparisonPair>(currentViewItem->
-																										 findVisualizationOf(diffComparisonPair));
-				overlay->setPos(vDiffComparisonPair->scenePos().x(),
-									 vDiffComparisonPair->scenePos().y() + vDiffComparisonPair->heightInScene());
+			auto vDiffComparisonPair = DCast<VersionControlUI::VDiffComparisonPair>(currentViewItem->
+																									 findVisualizationOf(diffComparisonPair));
+			targetItem = vDiffComparisonPair;
+		}
 
-				overlay->setScale(vDiffComparisonPair->scaleFactor());
-			}
-			else
-				overlay->setPos(currentViewItem->scenePos().x(),
-									 currentViewItem->scenePos().y() + currentViewItem->heightInScene());
+		if (!targetItem)
+			targetItem = currentViewItem;
 
-
+		auto overlay = new Visualization::MessageOverlay{targetItem,
+				[message](Visualization::MessageOverlay*)
+		{
 			return message;
-		}, Visualization::MessageOverlay::itemStyles().get("info")};
+		}, Visualization::MessageOverlay::itemStyles().get("info"), true};
 
-		currentViewItem->addOverlay(overlay, "NameChangeInfoOverlay");
+		targetItem->addOverlay(overlay, "NameChangeInfoOverlay");
+		overlay->positionRelativeToAssociatedItem(position);
 	});
+
 
 }
 
@@ -447,22 +448,16 @@ void DiffManager::showDiff(QString oldVersion, QString newVersion)
 		createOverlaysForChanges(diffViewItem, changesWithNodes);
 		auto message = createHTMLCommitInfo(diffSetup.repository_, diffSetup.newVersion_);
 		auto overlay = new Visualization::MessageOverlay{diffViewItem,
-				[diffViewItem, message](Visualization::MessageOverlay* overlay)
+				[diffViewItem, message](Visualization::MessageOverlay*)
 		{
-			auto diffViewItemPos = diffViewItem->scenePos();
-			overlay->setPos(diffViewItemPos.x(),
-								 diffViewItemPos.y() - overlay->heightInScene());
-			auto vDiffComparisonPair = DCast<VersionControlUI::VDiffComparisonPair>(diffViewItem->findVisualizationOf
-																					(diffViewItem->nodeAt(Visualization::MajorMinorIndex{})));
-			overlay->setScale(vDiffComparisonPair->scaleFactor());
 			return message;
-		}, Visualization::MessageOverlay::itemStyles().get("info")};
-
+		}, Visualization::MessageOverlay::itemStyles().get("info"), true};
 
 		diffViewItem->addOverlay(overlay, "DiffInfoMessageOverlay");
+		overlay->positionRelativeToAssociatedItem(Visualization::MessageOverlay::TopLeft);
 	});
 
-	showNameChangeInformation(diffViewItem, diffSetup, diffComparisonPairs.last());
+	showNameChangeInformation(diffViewItem, diffSetup);
 
 	// switch to the newly created view
 	Visualization::VisualizationManager::instance().mainScene()->viewItems()->switchToView(diffViewItem);
@@ -543,7 +538,8 @@ void DiffManager::showNodeHistory(Model::NodeIdType targetNodeID, QList<QString>
 			diffComparisonPairInfo.append({diffComparisonPairs.first(), message});
 
 		if (nameChangeVisualization_.testFlag(Summary) && !nameChangesIdsIsNameText_.isEmpty())
-			showNameChangeInformation(historyViewItem, diffSetup, diffComparisonPairs.last());
+			showNameChangeInformation(historyViewItem, diffSetup, diffComparisonPairs.last(),
+											  Visualization::MessageOverlay::BottomLeft);
 
 		// create visualization for changes
 		Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
@@ -557,17 +553,16 @@ void DiffManager::showNodeHistory(Model::NodeIdType targetNodeID, QList<QString>
 								  [historyViewItem, diffComparisonPairInfo]() {
 		for (auto info : diffComparisonPairInfo)
 		{
-			auto overlay = new Visualization::MessageOverlay{historyViewItem, [historyViewItem, info]
-					(Visualization::MessageOverlay* overlay)
+			auto vDiffComparisonPair =
+					DCast<VersionControlUI::VDiffComparisonPair>(historyViewItem->findVisualizationOf(info.first));
+
+			auto overlay = new Visualization::MessageOverlay{vDiffComparisonPair, [historyViewItem, info]
+					(Visualization::MessageOverlay*)
 			{
-				auto vDiffComparisonPair =
-						DCast<VersionControlUI::VDiffComparisonPair>(historyViewItem->findVisualizationOf(info.first));
-				overlay->setPos(vDiffComparisonPair->scenePos().x(),
-									 vDiffComparisonPair->scenePos().y()-overlay->heightInScene());
-				overlay->setScale(vDiffComparisonPair->scaleFactor());
 				return info.second;
-			}, Visualization::MessageOverlay::itemStyles().get("info") };
-			historyViewItem->addOverlay(overlay, "DiffInfoMessageOverlay");
+			}, Visualization::MessageOverlay::itemStyles().get("info"), true};
+			vDiffComparisonPair->addOverlay(overlay, "DiffInfoMessageOverlay");
+			overlay->positionRelativeToAssociatedItem(Visualization::MessageOverlay::TopLeft);
 		}
 	});
 

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -479,7 +479,7 @@ QString DiffManager::createHTMLCommitInfo(const FilePersistence::GitRepository* 
 	return commitMetaData.message_.replace("\n", "<br/>") + (messageEndsInNewline ? "<br/>" : "<br/><br/>")
 			+ "<font color='gray'>" + commitMetaData.author_.name_ + "</font><br/>"
 			+ "<font color='gray'>" + commitMetaData.dateTime_.toString("dd.MM.yyyy hh:mm") + "</font><br/>"
-			+ "<font color='gray'>" + commitMetaData.sha1_ + "</font>";
+			+ "<font color='gray'>" + commitMetaData.sha1_.left(15) + "</font>";
 }
 
 void DiffManager::showNodeHistory(Model::NodeIdType targetNodeID, QList<QString> versions)

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -34,6 +34,8 @@
 #include "FilePersistence/src/version_control/ChangeDescription.h"
 #include "FilePersistence/src/version_control/Diff.h"
 
+#include "VisualizationBase/src/overlays/MessageOverlay.h"
+
 
 namespace FilePersistence
 {
@@ -150,7 +152,9 @@ class VERSIONCONTROLUI_API DiffManager
 		bool processNameChange(Model::Node* oldNode, Model::Node* newNode, const DiffSetup& diffSetup);
 
 		void showNameChangeInformation(Visualization::ViewItem* currentViewItem, const DiffSetup& diffSetup,
-												 VersionControlUI::DiffComparisonPair* diffComparisonPair);
+												 VersionControlUI::DiffComparisonPair* diffComparisonPair = nullptr,
+												 Visualization::MessageOverlay::Position position =
+																			Visualization::MessageOverlay::TopRight);
 
 		bool areInTargetNodeSubtree(Model::Node* oldNode, Model::Node* newNode,
 																					const DiffSetup& diffSetup);

--- a/VisualizationBase/src/overlays/MessageOverlay.h
+++ b/VisualizationBase/src/overlays/MessageOverlay.h
@@ -41,13 +41,20 @@ class VISUALIZATIONBASE_API MessageOverlay : public Super<Overlay<DeclarativeIte
 	ITEM_COMMON(MessageOverlay)
 
 	public:
+		enum Position {TopLeft, TopRight, BottomLeft, BottomRight};
+
 		using SyncFunction = std::function<QString (MessageOverlay* self)>;
-		MessageOverlay(Item* associatedItem, const StyleType* style = itemStyles().get());
-		MessageOverlay(Item* associatedItem, SyncFunction syncFunction, const StyleType* style = itemStyles().get());
+		MessageOverlay(Item* associatedItem, const StyleType* style = itemStyles().get(), bool ignoresScaling = false);
+		MessageOverlay(Item* associatedItem, SyncFunction syncFunction, const StyleType* style = itemStyles().get(),
+							bool ignoresScaling = false);
 
 		static void initializeForms();
 
 		Item*& content();
+
+		void updateOffsetItemLocal(QPointF scenePos);
+
+		void positionRelativeToAssociatedItem(Position position);
 
 	protected:
 		virtual void determineChildren() override;
@@ -59,7 +66,11 @@ class VISUALIZATIONBASE_API MessageOverlay : public Super<Overlay<DeclarativeIte
 		Text* message_{};
 		Item* content_{};
 		SyncFunction syncFunction_{};
-		bool positionSet_{};
+		QPointF offsetItemLocal_;
+		QRectF associatedItemSceneBoundingRect_;
+		bool ignoresScaling_{};
+		bool needsPositioning_{};
+		Position position_{TopLeft};
 };
 
 inline Item*& MessageOverlay::content() { return content_; }


### PR DESCRIPTION
- Limit sha1 for HTML commit info to 15 characters
- Extend MessageOverlay to be movable in relation to associated item
- Use new MessageOverlay capabilities for Information Overlays in DiffManager
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/409%23discussion_r69808841%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/409%23discussion_r69809335%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/409%23discussion_r69809456%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/409%23issuecomment-230903248%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/409%23discussion_r69874205%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%205431e8f5b64ecc440d08fdbe53a3bd6c3dadb40b%20VersionControlUI/src/DiffManager.cpp%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/409%23discussion_r69809456%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20was%20this%20necessary%3F%22%2C%20%22created_at%22%3A%20%222016-07-06T20%3A53%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL168-203%22%7D%2C%20%22Pull%205431e8f5b64ecc440d08fdbe53a3bd6c3dadb40b%20VisualizationBase/src/overlays/MessageOverlay.cpp%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/409%23discussion_r69809335%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20be%20called%20%60setPosition...%60%22%2C%20%22created_at%22%3A%20%222016-07-06T20%3A52%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VisualizationBase/src/overlays/MessageOverlay.cpp%3AL53-77%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/409%23issuecomment-230903248%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22wow%2C%20did%20not%20expect%20the%20move%20change%20to%20be%20so%20big.%22%2C%20%22created_at%22%3A%20%222016-07-06T20%3A54%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%205431e8f5b64ecc440d08fdbe53a3bd6c3dadb40b%20VisualizationBase/src/overlays/MessageOverlay.cpp%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/409%23discussion_r69874205%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20initialize%20all%20things%20in%20the%20memeber%20initializer%20list.%22%2C%20%22created_at%22%3A%20%222016-07-07T09%3A11%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VisualizationBase/src/overlays/MessageOverlay.cpp%3AL53-77%22%7D%2C%20%22Pull%205431e8f5b64ecc440d08fdbe53a3bd6c3dadb40b%20VisualizationBase/src/overlays/MessageOverlay.cpp%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/409%23discussion_r69808841%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22When%20I%20see%20an%20Item%20constructor%20that%20has%20an%20argument%20called%20%60ignoresScaling%60%2C%20I%20expect%20to%20find%20the%20%60ItemsIgnoresTransformations%60%20flag%2C%20but%20it%27s%20not%20there.%20How%20exactly%20does%20this%20overlay%20ignore%20scaling%3F%20Can%27t/shouldn%27t%20we%20make%20use%20of%20the%20flag%3F%22%2C%20%22created_at%22%3A%20%222016-07-06T20%3A49%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VisualizationBase/src/overlays/MessageOverlay.cpp%3AL32-46%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 5431e8f5b64ecc440d08fdbe53a3bd6c3dadb40b VisualizationBase/src/overlays/MessageOverlay.cpp 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/409#discussion_r69808841'>File: VisualizationBase/src/overlays/MessageOverlay.cpp:L32-46</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> When I see an Item constructor that has an argument called `ignoresScaling`, I expect to find the `ItemsIgnoresTransformations` flag, but it's not there. How exactly does this overlay ignore scaling? Can't/shouldn't we make use of the flag?
- [ ] <a href='#crh-comment-Pull 5431e8f5b64ecc440d08fdbe53a3bd6c3dadb40b VisualizationBase/src/overlays/MessageOverlay.cpp 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/409#discussion_r69809335'>File: VisualizationBase/src/overlays/MessageOverlay.cpp:L53-77</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This should be called `setPosition...`
- [ ] <a href='#crh-comment-Pull 5431e8f5b64ecc440d08fdbe53a3bd6c3dadb40b VersionControlUI/src/DiffManager.cpp 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/409#discussion_r69809456'>File: VersionControlUI/src/DiffManager.cpp:L168-203</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> why was this necessary?
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/409#issuecomment-230903248'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> wow, did not expect the move change to be so big.
- [ ] <a href='#crh-comment-Pull 5431e8f5b64ecc440d08fdbe53a3bd6c3dadb40b VisualizationBase/src/overlays/MessageOverlay.cpp 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/409#discussion_r69874205'>File: VisualizationBase/src/overlays/MessageOverlay.cpp:L53-77</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please initialize all things in the memeber initializer list.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/409?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/409?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/409'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
