### PR TITLE
Add functions to handle labels for unstable chunk

### DIFF
--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
@@ -69,10 +69,10 @@ void ListMergeComponentV2::run(MergeData& mergeData)
 	}
 }
 
-ListMergeComponentV2::IdtoIndexMap ListMergeComponentV2::computeAdjustedIndices(Model::NodeIdType listId,
+ListMergeComponentV2::IdToIndexMap ListMergeComponentV2::computeAdjustedIndices(Model::NodeIdType listId,
 																										  MergeData& mergeData)
 {
-	IdtoIndexMap map;
+	IdToIndexMap map;
 	auto chunks = listToChunks(listId, mergeData);
 	int finalIndexInList = 0;	// Final index of elements in the merged tree such that all labels are unique
 	for (auto chunk : chunks)
@@ -80,7 +80,7 @@ ListMergeComponentV2::IdtoIndexMap ListMergeComponentV2::computeAdjustedIndices(
 		if (chunk->stable_)
 			for (auto id : chunk->spanBase_)
 			{
-				map.insert(id, LabelData{QString::number(finalIndexInList), MergeChange::None});
+				map.insert(id, {QString::number(finalIndexInList), MergeChange::None});
 				finalIndexInList++;
 			}
 		else
@@ -94,7 +94,7 @@ ListMergeComponentV2::IdtoIndexMap ListMergeComponentV2::computeAdjustedIndices(
 	return map;
 }
 
-void ListMergeComponentV2::adjustCG(Model::NodeIdType /*listId*/, IdtoIndexMap /*map*/, MergeData& /*mergeData*/)
+void ListMergeComponentV2::adjustCG(Model::NodeIdType /*listId*/, IdToIndexMap /*map*/, MergeData& /*mergeData*/)
 {}
 
 QList<Chunk*> ListMergeComponentV2::listToChunks(Model::NodeIdType listId, MergeData& mergeData)
@@ -140,11 +140,11 @@ void ListMergeComponentV2::computeOffsetsInBranch(const QList<Model::NodeIdType>
 		if (lcs.contains(id))
 		{
 			baseIndex = treeBase->find(id)->label().toInt();
-			list.append(IdPosition{id, baseIndex, offset, branch});	//Labelling it same as base
+			list.append({id, baseIndex, offset, branch});	//Labelling it same as base
 			offset = 1;
 		}
 		else
-			list.append(IdPosition{id, baseIndex, offset, branch});
+			list.append({id, baseIndex, offset++, branch});
 	}
 }
 

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
@@ -80,14 +80,14 @@ ListMergeComponentV2::IdToIndexMap ListMergeComponentV2::computeAdjustedIndices(
 		if (chunk->stable_)
 			for (auto id : chunk->spanBase_)
 			{
-				map.insert(id, qMakePair(QString::number(index), 0));
+				map.insert(id, qMakePair(QString::number(index), MergeChange::None));
 				index++;
 			}
 		else
 		{
 			IdPositionMap temp;	// temp will store the relative positions of elements of unstable chunk
-			fillIndices(chunk->spanBase_, chunk->spanA_, temp, mergeData.treeBase_);
-			fillIndices(chunk->spanBase_, chunk->spanB_, temp, mergeData.treeBase_);
+			fillIndices(chunk->spanBase_, chunk->spanA_, temp, mergeData.treeBase_, MergeChange::BranchA);
+			fillIndices(chunk->spanBase_, chunk->spanB_, temp, mergeData.treeBase_, MergeChange::BranchB);
 			// Sort temp and insert ids to the map
 		}
 	}
@@ -130,7 +130,7 @@ QList<Model::NodeIdType> ListMergeComponentV2::nodeListToSortedIdList(const QLis
 }
 
 void ListMergeComponentV2::fillIndices(const QList<Model::NodeIdType> base, const QList<Model::NodeIdType> version,
-													IdPositionMap& vector, std::shared_ptr<GenericTree> treeBase)
+													IdPositionMap& vector, std::shared_ptr<GenericTree> treeBase, MergeChange::Branches branch)
 {
 	int tempIndex = -1;
 	int pair = 1;
@@ -140,11 +140,11 @@ void ListMergeComponentV2::fillIndices(const QList<Model::NodeIdType> base, cons
 		if (lcs.contains(id))
 		{
 			tempIndex = treeBase->find(id)->label().toInt();
-			vector.append(qMakePair(qMakePair(tempIndex, 0), id));	//Give it index same as base
+			vector.append(qMakePair(qMakePair(tempIndex, 0), qMakePair(id, branch)));	//Give it index same as base
 			pair = 1;
 		}
 		else
-			vector.append(qMakePair(qMakePair(tempIndex, pair++), id));
+			vector.append(qMakePair(qMakePair(tempIndex, pair++), qMakePair(id, branch)));
 	}
 }
 

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
@@ -49,8 +49,17 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 
 	private:
 
-		using IdToIndexMap = QMultiHash<Model::NodeIdType, QPair<QString, MergeChange::Branches>>;
-		using IdPositionMap = QVector<QPair<QPair<int, int>, QPair<Model::NodeIdType, MergeChange::Branches>>>;
+		struct LabelData{
+				QString label;
+				MergeChange::Branches branch;
+		};
+		struct IdPosition{
+				Model::NodeIdType id;
+				int baseIndex;
+				int offset;
+				MergeChange::Branches branch;
+		};
+		using IdtoIndexMap = QMultiHash<Model::NodeIdType, LabelData>;
 		/**
 		 * Finds all the lists that we will process in the merge.
 		 *
@@ -63,12 +72,12 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 		 * Returns the map of new labels(Integral) of list.
 		 * so that all labels are unique.
 		 */
-		IdToIndexMap computeAdjustedIndices(Model::NodeIdType listId, MergeData& mergeData);
+		IdtoIndexMap computeAdjustedIndices(Model::NodeIdType listId, MergeData& mergeData);
 
 		/**
 		 * Adjusts CG according to the new indices returned by computeAdjustedIndices.
 		 */
-		void adjustCG(Model::NodeIdType listId, IdToIndexMap map, MergeData& mergeData);
+		void adjustCG(Model::NodeIdType listId, IdtoIndexMap map, MergeData& mergeData);
 
 		/**
 		*	Returns chunks for the given list.
@@ -81,10 +90,10 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 		QList<Model::NodeIdType> nodeListToSortedIdList(const QList<GenericNode*>& list);
 
 		/**
-		 * Fills the vector with the indices with proper
+		 * Fills the list with the indices mapped to proper positions relative to Base.
 		 */
-		void fillIndices(const QList<Model::NodeIdType> base, const QList<Model::NodeIdType> version,
-								IdPositionMap& vector, std::shared_ptr<GenericTree> treeBase,  MergeChange::Branches branch);
+		void computeOffsetsInBranch(const QList<Model::NodeIdType> base, const QList<Model::NodeIdType> version,
+										QList<IdPosition>& list, std::shared_ptr<GenericTree> treeBase,  MergeChange::Branches branch);
 };
 
 }

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
@@ -50,6 +50,7 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 	private:
 
 		using IdToIndexMap = QMultiHash<Model::NodeIdType, QPair<QString, MergeChange::Branches>>;
+		using IdPositionMap = QVector<QPair<QPair<int, int>, Model::NodeIdType>>;
 		/**
 		 * Finds all the lists that we will process in the merge.
 		 *
@@ -79,6 +80,11 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 		 */
 		QList<Model::NodeIdType> nodeListToSortedIdList(const QList<GenericNode*>& list);
 
+		/**
+		 * Fills the vector with the indices with proper
+		 */
+		void fillIndices(const QList<Model::NodeIdType> base, const QList<Model::NodeIdType> version,
+															IdPositionMap& vector, std::shared_ptr<GenericTree> treeBase);
 };
 
 }

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
@@ -50,16 +50,16 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 	private:
 
 		struct LabelData{
-				QString label;
-				MergeChange::Branches branch;
+				QString label{};
+				MergeChange::Branches branch{};
 		};
 		struct IdPosition{
-				Model::NodeIdType id;
-				int baseIndex;
-				int offset;
-				MergeChange::Branches branch;
+				Model::NodeIdType id{};
+				int baseIndex{};
+				int offset{};
+				MergeChange::Branches branch{};
 		};
-		using IdtoIndexMap = QMultiHash<Model::NodeIdType, LabelData>;
+		using IdToIndexMap = QMultiHash<Model::NodeIdType, LabelData>;
 		/**
 		 * Finds all the lists that we will process in the merge.
 		 *
@@ -72,12 +72,12 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 		 * Returns the map of new labels(Integral) of list.
 		 * so that all labels are unique.
 		 */
-		IdtoIndexMap computeAdjustedIndices(Model::NodeIdType listId, MergeData& mergeData);
+		IdToIndexMap computeAdjustedIndices(Model::NodeIdType listId, MergeData& mergeData);
 
 		/**
 		 * Adjusts CG according to the new indices returned by computeAdjustedIndices.
 		 */
-		void adjustCG(Model::NodeIdType listId, IdtoIndexMap map, MergeData& mergeData);
+		void adjustCG(Model::NodeIdType listId, IdToIndexMap map, MergeData& mergeData);
 
 		/**
 		*	Returns chunks for the given list.

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
@@ -50,7 +50,7 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 	private:
 
 		using IdToIndexMap = QMultiHash<Model::NodeIdType, QPair<QString, MergeChange::Branches>>;
-		using IdPositionMap = QVector<QPair<QPair<int, int>, Model::NodeIdType>>;
+		using IdPositionMap = QVector<QPair<QPair<int, int>, QPair<Model::NodeIdType, MergeChange::Branches>>>;
 		/**
 		 * Finds all the lists that we will process in the merge.
 		 *
@@ -84,7 +84,7 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 		 * Fills the vector with the indices with proper
 		 */
 		void fillIndices(const QList<Model::NodeIdType> base, const QList<Model::NodeIdType> version,
-															IdPositionMap& vector, std::shared_ptr<GenericTree> treeBase);
+								IdPositionMap& vector, std::shared_ptr<GenericTree> treeBase,  MergeChange::Branches branch);
 };
 
 }


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70062393%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70062519%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70062594%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70062846%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70063044%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70063088%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70063346%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70063577%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70063591%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70063630%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70064038%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70068008%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70068192%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70068323%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70068367%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70068627%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23issuecomment-231354919%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2049bbf8bb3dd5dc990133317d53af2251a8eb4eff%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70062393%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20sentence%20feels%20unfinished.%20Proper%20what%3F%22%2C%20%22created_at%22%3A%20%222016-07-08T11%3A49%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%3AL80-91%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23issuecomment-231354919%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks.%22%2C%20%22created_at%22%3A%20%222016-07-08T13%3A09%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2049bbf8bb3dd5dc990133317d53af2251a8eb4eff%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70062519%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20this%20a%20map%20of%20a%20vector%3F%20What%20does%20the%20QPair%20stand%20for%3F%22%2C%20%22created_at%22%3A%20%222016-07-08T11%3A51%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%3AL50-57%22%7D%2C%20%22Pull%20797e33e72a6e3513e7441384a7a6f4a6485dd7cd%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70062846%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22let%27s%20call%20this%20%60finalIndexInList%60%22%2C%20%22created_at%22%3A%20%222016-07-08T11%3A55%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL74-97%22%7D%2C%20%22Pull%208bcd2ea37e9572e413c46457848a5b8808f01cff%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70068192%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20shouldn%27t%20need%20to%20write%20%60LabelData%60%20here%22%2C%20%22created_at%22%3A%20%222016-07-08T12%3A47%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL69-101%22%7D%2C%20%22Pull%20797e33e72a6e3513e7441384a7a6f4a6485dd7cd%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70063044%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60QList%60%22%2C%20%22created_at%22%3A%20%222016-07-08T11%3A56%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Make%20structures%20for%20these%20things%20instead%20of%20QPairs.%20It%27s%20too%20confusing.%22%2C%20%22created_at%22%3A%20%222016-07-08T11%3A57%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60IdPositions%60%22%2C%20%22created_at%22%3A%20%222016-07-08T12%3A00%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22for%20the%20qpair%20use%20%60baseIndex%60%20and%20%60offset%60%22%2C%20%22created_at%22%3A%20%222016-07-08T12%3A03%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%3AL50-57%22%7D%2C%20%22Pull%208bcd2ea37e9572e413c46457848a5b8808f01cff%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70068008%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20name%20was%20fine%20before%20with%20capital%20%60To%60%22%2C%20%22created_at%22%3A%20%222016-07-08T12%3A45%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%3AL72-84%22%7D%2C%20%22Pull%20797e33e72a6e3513e7441384a7a6f4a6485dd7cd%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70063630%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60offset%60%22%2C%20%22created_at%22%3A%20%222016-07-08T12%3A03%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL129-152%22%7D%2C%20%22Pull%20797e33e72a6e3513e7441384a7a6f4a6485dd7cd%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2032%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70063591%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60baseIndex%60%22%2C%20%22created_at%22%3A%20%222016-07-08T12%3A03%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL129-152%22%7D%2C%20%22Pull%208bcd2ea37e9572e413c46457848a5b8808f01cff%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2054%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70068323%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20shouldn%27t%20need%20%60IdPosition%60%20here%20and%20a%20few%20lines%20down.%22%2C%20%22created_at%22%3A%20%222016-07-08T12%3A48%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL128-152%22%7D%2C%20%22Pull%2049bbf8bb3dd5dc990133317d53af2251a8eb4eff%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70062594%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22don%27t%20call%20things%20%60temp%60%20That%20names%20is%20useless%20since%20it%20doesn%27t%20give%20you%20any%20information.%20Provide%20a%20better%20name.%22%2C%20%22created_at%22%3A%20%222016-07-08T11%3A51%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL74-97%22%7D%2C%20%22Pull%208bcd2ea37e9572e413c46457848a5b8808f01cff%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2058%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70068367%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60offset%2B%2B%60%22%2C%20%22created_at%22%3A%20%222016-07-08T12%3A49%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL128-152%22%7D%2C%20%22Pull%208bcd2ea37e9572e413c46457848a5b8808f01cff%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70068627%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22just%20to%20make%20sure%20this%20structure%20is%20alwasy%20properly%20initialized%2C%20please%20use%20default%20initialization%20here%20and%20the%20for%20the%20next%20two%20lines.%20In%20general%2C%20always%20default%20initialize%20primitive%20types%20and%20enums.%5Cr%5Cn%5Cr%5CnDefault%20initialization%20means%20to%20add%20the%20%60%7B%7D%60%2C%20as%20in%20%60type%20name%7B%7D%3B%60%22%2C%20%22created_at%22%3A%20%222016-07-08T12%3A51%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%3AL49-66%22%7D%2C%20%22Pull%20797e33e72a6e3513e7441384a7a6f4a6485dd7cd%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/412%23discussion_r70064038%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60computeOffsetsInBranch%60%22%2C%20%22created_at%22%3A%20%222016-07-08T12%3A08%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL74-97%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 49bbf8bb3dd5dc990133317d53af2251a8eb4eff FilePersistence/src/version_control/merge/ListMergeComponentV2.h 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70062393'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.h:L80-91</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> this sentence feels unfinished. Proper what?
- [x] <a href='#crh-comment-Pull 49bbf8bb3dd5dc990133317d53af2251a8eb4eff FilePersistence/src/version_control/merge/ListMergeComponentV2.h 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70062519'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.h:L50-57</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Is this a map of a vector? What does the QPair stand for?
- [x] <a href='#crh-comment-Pull 49bbf8bb3dd5dc990133317d53af2251a8eb4eff FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70062594'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L74-97</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> don't call things `temp` That names is useless since it doesn't give you any information. Provide a better name.
- [x] <a href='#crh-comment-Pull 797e33e72a6e3513e7441384a7a6f4a6485dd7cd FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70062846'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L74-97</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> let's call this `finalIndexInList`
- [x] <a href='#crh-comment-Pull 797e33e72a6e3513e7441384a7a6f4a6485dd7cd FilePersistence/src/version_control/merge/ListMergeComponentV2.h 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70063044'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.h:L50-57</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `QList`
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Make structures for these things instead of QPairs. It's too confusing.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `IdPositions`
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> for the qpair use `baseIndex` and `offset`
- [x] <a href='#crh-comment-Pull 797e33e72a6e3513e7441384a7a6f4a6485dd7cd FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 32'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70063591'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L129-152</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `baseIndex`
- [x] <a href='#crh-comment-Pull 797e33e72a6e3513e7441384a7a6f4a6485dd7cd FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 33'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70063630'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L129-152</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `offset`
- [x] <a href='#crh-comment-Pull 797e33e72a6e3513e7441384a7a6f4a6485dd7cd FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70064038'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L74-97</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `computeOffsetsInBranch`
- [x] <a href='#crh-comment-Pull 8bcd2ea37e9572e413c46457848a5b8808f01cff FilePersistence/src/version_control/merge/ListMergeComponentV2.h 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70068008'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.h:L72-84</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> The name was fine before with capital `To`
- [x] <a href='#crh-comment-Pull 8bcd2ea37e9572e413c46457848a5b8808f01cff FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70068192'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L69-101</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You shouldn't need to write `LabelData` here
- [x] <a href='#crh-comment-Pull 8bcd2ea37e9572e413c46457848a5b8808f01cff FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 54'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70068323'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L128-152</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You shouldn't need `IdPosition` here and a few lines down.
- [x] <a href='#crh-comment-Pull 8bcd2ea37e9572e413c46457848a5b8808f01cff FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 58'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70068367'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L128-152</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `offset++`
- [x] <a href='#crh-comment-Pull 8bcd2ea37e9572e413c46457848a5b8808f01cff FilePersistence/src/version_control/merge/ListMergeComponentV2.h 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#discussion_r70068627'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.h:L49-66</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> just to make sure this structure is alwasy properly initialized, please use default initialization here and the for the next two lines. In general, always default initialize primitive types and enums.
  Default initialization means to add the `{}`, as in `type name{};`
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/412#issuecomment-231354919'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/412?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/412?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/412'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
