### PR TITLE
Add function to update labels of baseTree

### DIFF
--- a/FilePersistence/src/version_control/merge/ChangeGraph.cpp
+++ b/FilePersistence/src/version_control/merge/ChangeGraph.cpp
@@ -458,9 +458,11 @@ void ChangeGraph::updateBaseTreeLabels(Model::NodeIdType parentId, IdToLabelMap 
 		auto labelIt = labelMap.find(node->id());
 		while (labelIt != labelMap.end() && labelIt.key() == node->id()) {
 			if (labelIt.value().branch.testFlag(MergeChange::None))	// Base element
+			{
+				node->setLabel(labelIt.value().label);
 				break;
+			}
 		}
-		node->setLabel(labelIt.value().label);
 	}
 }
 

--- a/FilePersistence/src/version_control/merge/ChangeGraph.cpp
+++ b/FilePersistence/src/version_control/merge/ChangeGraph.cpp
@@ -448,10 +448,20 @@ void ChangeGraph::updateOutgoingLabels(Model::NodeIdType /*parentId*/, IdToLabel
 	Q_ASSERT(false);
 }
 
-void ChangeGraph::updateBaseTreeLabels(Model::NodeIdType /*parentId*/, IdToLabelMap /*labelMap*/,
-													GenericTree* /*baseTree*/)
+void ChangeGraph::updateBaseTreeLabels(Model::NodeIdType parentId, IdToLabelMap labelMap,	GenericTree* baseTree)
 {
-	Q_ASSERT(false);
+	auto parentNode = baseTree->find(parentId);
+
+	// Update baseTree labels according to base Labels in labelMap
+	for (auto node : parentNode->children())
+	{
+		auto labelIt = labelMap.find(node->id());
+		while (labelIt != labelMap.end() && labelIt.key() == node->id()) {
+			if (labelIt.value().branch.testFlag(MergeChange::None))	// Base element
+				break;
+		}
+		node->setLabel(labelIt.value().label);
+	}
 }
 
 }


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/417%23discussion_r70256693%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20687d515154d3bed3456e273f13b3b61325592a39%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/417%23discussion_r70256693%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20you%20are%20implicitly%20assuming%20here%20that%20we%20always%20hit%20the%20%60//%20Base%20element%60%20and%20break%20out%20of%20the%20loop%20and%20then%20update%20the%20node%20with%20the%20new%20label.%20However%2C%20to%20be%20on%20the%20safe%20side%2C%20we%20should%20make%20sure%20to%20only%20update%20the%20label%20if%20we%20indeed%20hit%20%60//%20Base%20element%60.%20In%20particular%2C%20right%20now%20we%27ll%20update%20the%20node%2C%20every%20time%20we%20call%20%60lablMap.find%60%20and%20it%20returns%20%60end%28%29%60.%5Cr%5Cn%5Cr%5CnJust%20move%20this%20update%20in%20the%20%60if%60%20above%2C%20right%20before%20the%20break.%22%2C%20%22created_at%22%3A%20%222016-07-11T13%3A29%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL448-468%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 687d515154d3bed3456e273f13b3b61325592a39 FilePersistence/src/version_control/merge/ChangeGraph.cpp 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/417#discussion_r70256693'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L448-468</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I think you are implicitly assuming here that we always hit the `// Base element` and break out of the loop and then update the node with the new label. However, to be on the safe side, we should make sure to only update the label if we indeed hit `// Base element`. In particular, right now we'll update the node, every time we call `lablMap.find` and it returns `end()`.
  Just move this update in the `if` above, right before the break.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/417?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/417?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/417'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
