### PR TITLE
Add function to update CG 

### DIFF
--- a/FilePersistence/src/version_control/merge/ChangeGraph.h
+++ b/FilePersistence/src/version_control/merge/ChangeGraph.h
@@ -60,12 +60,12 @@ class FILEPERSISTENCE_API ChangeGraph
 
 		struct LabelData
 		{
-			QString label{};
-			MergeChange::Branches branch{};
+			QString label_{};
+			MergeChange::Branches branch_{};
 		};
 		using IdToLabelMap = QMultiHash<Model::NodeIdType, LabelData>;
 
-		void relabelChildrenUniquely(Model::NodeIdType parentId, IdToLabelMap labelMap, GenericTree* baseTree);
+		void relabelChildrenUniquely(Model::NodeIdType parentId, IdToLabelMap labelMap, GenericTree* tree);
 
 		void applyNonConflictingChanges(GenericTree* currentTree);
 
@@ -105,9 +105,8 @@ class FILEPERSISTENCE_API ChangeGraph
 		void removeLabelDependenciesBetweenChildren(Model::NodeIdType parentId);
 		void removeLabelConflictsBetweenChildren(Model::NodeIdType parentId);
 
-		void updateBaseTreeLabels(Model::NodeIdType parentId, IdToLabelMap labelMap, GenericTree* baseTree);
-		void updateListChanges(Model::NodeIdType parentId, IdToLabelMap labelMap, GenericTree* treeBase);
-
+		void updateBaseTreeLabels(Model::NodeIdType parentId, IdToLabelMap labelMap, GenericTree* tree);
+		void updateLabelsOfChangesTo(Model::NodeIdType parentId, IdToLabelMap labelMap, GenericTree* tree);
 
 		void createRelabelChanges(Model::NodeIdType nodeId, QString oldLabel, QList<LabelData> newLabels,
 										  Model::NodeIdType parentId);

--- a/FilePersistence/src/version_control/merge/ChangeGraph.h
+++ b/FilePersistence/src/version_control/merge/ChangeGraph.h
@@ -106,8 +106,8 @@ class FILEPERSISTENCE_API ChangeGraph
 		void removeLabelConflictsBetweenChildren(Model::NodeIdType parentId);
 
 		void updateBaseTreeLabels(Model::NodeIdType parentId, IdToLabelMap labelMap, GenericTree* baseTree);
-		void updateIncomingLabels(Model::NodeIdType parentId, IdToLabelMap labelMap);
-		void updateOutgoingLabels(Model::NodeIdType parentId, IdToLabelMap labelMap);
+		void updateListChanges(Model::NodeIdType parentId, IdToLabelMap labelMap, GenericTree* treeBase);
+
 
 		void createRelabelChanges(Model::NodeIdType nodeId, QString oldLabel, QList<LabelData> newLabels,
 										  Model::NodeIdType parentId);


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70429442%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70429611%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70429632%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70430168%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70430743%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70431741%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432025%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432299%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432409%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432755%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432865%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432895%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432910%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70433154%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70433288%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70433603%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70434093%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70434485%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70461725%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70461800%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70461956%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70462230%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70462487%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70463399%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70463548%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70464801%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70465247%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70465549%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23issuecomment-232089831%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/commit/172ec88e919d588f4ceae715634fdb313f115808%23commitcomment-18215395%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%20123%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70433288%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22also%20do%20noFlags%2C%20if%20it%20is%20insertion.%22%2C%20%22created_at%22%3A%20%222016-07-12T13%3A05%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-551%22%7D%2C%20%22Commit%20172ec88e919d588f4ceae715634fdb313f115808%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2052%20516%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/commit/172ec88e919d588f4ceae715634fdb313f115808%23commitcomment-18215395%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22remove%20the%20white%20space%20above%22%2C%20%22created_at%22%3A%20%222016-07-12T16%3A06%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL516%20%28172ec88%29%22%7D%2C%20%22Pull%20c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70461725%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22do%20not%20use%20%60NULL%60%2C%20use%20the%20new%20%60nullptr%60%22%2C%20%22created_at%22%3A%20%222016-07-12T15%3A26%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Or%20in%20this%20case%2C%20simply%20%60Q_ASSERT%28parentNode%29%60%22%2C%20%22created_at%22%3A%20%222016-07-12T15%3A26%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20actually%2C%20it%20seems%20like%20we%20only%20need%20the%20tree%20here%2C%20so%20that%20we%20can%20perform%20this%20check.%20I%20would%20rather%20remove%20the%20tree%20argument%20and%20not%20do%20this%20check%2C%20and%20let%20this%20function%20work%20purely%20on%20the%20merge%20changes.%22%2C%20%22created_at%22%3A%20%222016-07-12T15%3A40%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-559%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432409%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20I%27m%20not%20sure%20there%20is%20a%20need%20to%20look%20for%20the%20child%20node%20at%20all.%20It%20seems%20like%20we%20only%20do%20this%20for%20checking%2C%20but%20we%20can%20do%20this%20while%20iterating%20over%20all%20changes%20for%20nodeId.%20We%20should%20discuss%20this.%22%2C%20%22created_at%22%3A%20%222016-07-12T13%3A00%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-551%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%20129%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70434093%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60label.isNull%60%22%2C%20%22created_at%22%3A%20%222016-07-12T13%3A10%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-551%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2075%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70431741%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22add%20%27%7C%7C%20changeIt.type%28%29%20%3D%3D%20ChangeType%3A%3ADeletion%60%22%2C%20%22created_at%22%3A%20%222016-07-12T12%3A55%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Won%27t%20it%20be%20already%20set%20as%20NoFlags%20for%20deletion%3F%22%2C%20%22created_at%22%3A%20%222016-07-12T12%3A59%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11445667%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Vaishal-shah%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20will%20be%2C%20but%20we%20want%20to%20keep%20it%20that%20way.%20Your%20code%20will%20potentially%20set%20it%20to%20Label.%22%2C%20%22created_at%22%3A%20%222016-07-12T13%3A07%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-551%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2073%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70433154%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20we%20clear%20the%20label%20%3F%20e.g.%20%60labelNode.clear%28%29%60%20%3F%22%2C%20%22created_at%22%3A%20%222016-07-12T13%3A04%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20not%2C%20put%20a%20comment%20here%20explaining%20why%20we%20shouldn%27t%20clear%20it.%22%2C%20%22created_at%22%3A%20%222016-07-12T13%3A13%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-551%22%7D%2C%20%22Pull%20c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2072%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70465549%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20comment%20why%20we%20shouldn%27t%20clear%20%60labelNone%60%22%2C%20%22created_at%22%3A%20%222016-07-12T15%3A44%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-559%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23issuecomment-232089831%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22OK%2C%20those%20are%20all%20my%20comments.%20It%27s%20looking%20almost%20ready.%22%2C%20%22created_at%22%3A%20%222016-07-12T15%3A44%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%20111%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70465247%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22change%20this%20to%20the%20more%20general%20%60default%3A%60%20in%20case%20someone%20introduces%20new%20kinds%20of%20changes%20in%20the%20future.%22%2C%20%22created_at%22%3A%20%222016-07-12T15%3A42%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-559%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%20100%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432865%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22here%20you%20need%20to%20use%20%60%26%26%60%2C%20instead%20of%20%60%7C%7C%60%20right%3F%22%2C%20%22created_at%22%3A%20%222016-07-12T13%3A02%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-551%22%7D%2C%20%22Pull%20c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2055%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70462230%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20need%20to%20insert%20break%20statements%20at%20the%20end%20of%20each%20case.%22%2C%20%22created_at%22%3A%20%222016-07-12T15%3A28%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-559%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%20106%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432755%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20%60label.clear%28%29%60%20here%20and%20below.%22%2C%20%22created_at%22%3A%20%222016-07-12T13%3A01%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-551%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70430743%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20can%20bring%20this%20and%20the%20qassert%20below%20outside%20of%20the%20main%20loop.%20It%20won%27t%20change.%22%2C%20%22created_at%22%3A%20%222016-07-12T12%3A49%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-551%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70430168%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20like%20the%20word%20%60list%60%20in%20the%20name%20of%20this%20method.%20While%20we%20use%20it%20for%20lists%2C%20it%20could%20technically%20be%20used%20for%20anything%20else%20that%20has%20unique%20labels.%5Cr%5Cn%5Cr%5CnLet%27s%20call%20this%20%60updateLabelsOfChangesTo%60%22%2C%20%22created_at%22%3A%20%222016-07-12T12%3A45%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-551%22%7D%2C%20%22Pull%20c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2089%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70463399%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Instead%20of%20this%20%60continue%60%2C%20I%20would%20prefer%20an%20%60else%20if%60%20on%20the%20next%20statement.%22%2C%20%22created_at%22%3A%20%222016-07-12T15%3A33%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-559%22%7D%2C%20%22Pull%20c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%20104%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70463548%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20put%20a%20comment%20here%2C%20why%20we%20shuoldn%27t%20clear%20%60labelNone%60%22%2C%20%22created_at%22%3A%20%222016-07-12T15%3A34%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-559%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70429442%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22actually%2C%20you%20should%20not%20use%20%60.treeBase_%60%20but%20%60mergedTree_%60.%20no%20just%20on%20this%20line%2C%20but%20in%20all%20cases.%22%2C%20%22created_at%22%3A%20%222016-07-12T12%3A40%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Also%20you%20should%20not%20call%20this%20function%20here%2C%20it%20should%20be%20a%20private%20function%20called%20from%20within%2C%20%60relabelChildrenUniquely%60%22%2C%20%22created_at%22%3A%20%222016-07-12T12%3A41%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL63-72%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.h%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70429632%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20be%20private.%22%2C%20%22created_at%22%3A%20%222016-07-12T12%3A42%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.h%3AL60-77%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%20119%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432910%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60.clear%60%22%2C%20%22created_at%22%3A%20%222016-07-12T13%3A03%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-551%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2083%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432025%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20is%20not%20a%20good%20way%20of%20checking%20as%20it%20involves%20creating%20an%20extra%20empty%20object%20and%20is%20less%20readable.%20use%20%60.isNull%28%29%60%20instead.%5Cr%5Cn%5Cr%5CnThis%20applies%20for%20the%20two%20instances%20below%2C%20too.%22%2C%20%22created_at%22%3A%20%222016-07-12T12%3A57%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-551%22%7D%2C%20%22Pull%20c3711942d045962aa9a3eb1e3a5aebcc0add3b45%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%20114%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70432895%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60.clear%60%22%2C%20%22created_at%22%3A%20%222016-07-12T13%3A02%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-551%22%7D%2C%20%22Pull%20c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2057%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70462487%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20addition%2C%20also%20assert%20that%20it%20is%20not%20a%20Label%20change.%22%2C%20%22created_at%22%3A%20%222016-07-12T15%3A29%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-559%22%7D%2C%20%22Pull%20c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%2042%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/418%23discussion_r70461956%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Could%20you%20please%20Q_ASSERT%20that%20only%20one%20flag%20is%20set.%22%2C%20%22created_at%22%3A%20%222016-07-12T15%3A27%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.cpp%3AL446-559%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70429442'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L63-72</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> actually, you should not use `.treeBase_` but `mergedTree_`. no just on this line, but in all cases.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Also you should not call this function here, it should be a private function called from within, `relabelChildrenUniquely`
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.h 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70429632'>File: FilePersistence/src/version_control/merge/ChangeGraph.h:L60-77</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Should be private.
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.cpp 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70430168'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-551</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I don't like the word `list` in the name of this method. While we use it for lists, it could technically be used for anything else that has unique labels.
  Let's call this `updateLabelsOfChangesTo`
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.cpp 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70430743'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-551</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You can bring this and the qassert below outside of the main loop. It won't change.
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.cpp 75'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70431741'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-551</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> add '|| changeIt.type() == ChangeType::Deletion`
- <a href='https://github.com/Vaishal-shah'><img border=0 src='https://avatars.githubusercontent.com/u/11445667?v=3' height=16 width=16'></a> Won't it be already set as NoFlags for deletion?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> It will be, but we want to keep it that way. Your code will potentially set it to Label.
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.cpp 83'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70432025'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-551</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> this is not a good way of checking as it involves creating an extra empty object and is less readable. use `.isNull()` instead.
  This applies for the two instances below, too.
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.cpp 52'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70432409'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-551</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, I'm not sure there is a need to look for the child node at all. It seems like we only do this for checking, but we can do this while iterating over all changes for nodeId. We should discuss this.
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.cpp 106'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70432755'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-551</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Use `label.clear()` here and below.
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.cpp 100'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70432865'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-551</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> here you need to use `&&`, instead of `||` right?
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.cpp 114'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70432895'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-551</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `.clear`
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.cpp 119'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70432910'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-551</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `.clear`
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.cpp 73'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70433154'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-551</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Shouldn't we clear the label ? e.g. `labelNode.clear()` ?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> If not, put a comment here explaining why we shouldn't clear it.
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.cpp 123'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70433288'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-551</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> also do noFlags, if it is insertion.
- [x] <a href='#crh-comment-Pull c3711942d045962aa9a3eb1e3a5aebcc0add3b45 FilePersistence/src/version_control/merge/ChangeGraph.cpp 129'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70434093'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-551</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `label.isNull`
- [x] <a href='#crh-comment-Pull c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c FilePersistence/src/version_control/merge/ChangeGraph.cpp 33'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70461725'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-559</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> do not use `NULL`, use the new `nullptr`
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Or in this case, simply `Q_ASSERT(parentNode)`
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, actually, it seems like we only need the tree here, so that we can perform this check. I would rather remove the tree argument and not do this check, and let this function work purely on the merge changes.
- [x] <a href='#crh-comment-Pull c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c FilePersistence/src/version_control/merge/ChangeGraph.cpp 42'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70461956'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-559</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Could you please Q_ASSERT that only one flag is set.
- [x] <a href='#crh-comment-Pull c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c FilePersistence/src/version_control/merge/ChangeGraph.cpp 55'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70462230'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-559</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You need to insert break statements at the end of each case.
- [x] <a href='#crh-comment-Pull c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c FilePersistence/src/version_control/merge/ChangeGraph.cpp 57'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70462487'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-559</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> In addition, also assert that it is not a Label change.
- [x] <a href='#crh-comment-Pull c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c FilePersistence/src/version_control/merge/ChangeGraph.cpp 89'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70463399'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-559</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Instead of this `continue`, I would prefer an `else if` on the next statement.
- [x] <a href='#crh-comment-Pull c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c FilePersistence/src/version_control/merge/ChangeGraph.cpp 104'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70463548'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-559</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Could you put a comment here, why we shuoldn't clear `labelNone`
- [x] <a href='#crh-comment-Pull c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c FilePersistence/src/version_control/merge/ChangeGraph.cpp 111'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70465247'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-559</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> change this to the more general `default:` in case someone introduces new kinds of changes in the future.
- [x] <a href='#crh-comment-Pull c3ef56ba399e6bb413dabbf4eb06a28d722f2b6c FilePersistence/src/version_control/merge/ChangeGraph.cpp 72'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#discussion_r70465549'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L446-559</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please comment why we shouldn't clear `labelNone`
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/418#issuecomment-232089831'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> OK, those are all my comments. It's looking almost ready.
- [x] <a href='#crh-comment-Commit 172ec88e919d588f4ceae715634fdb313f115808 FilePersistence/src/version_control/merge/ChangeGraph.cpp 52 516'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/commit/172ec88e919d588f4ceae715634fdb313f115808#commitcomment-18215395'>File: FilePersistence/src/version_control/merge/ChangeGraph.cpp:L516 (172ec88)</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> remove the white space above

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/418?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/418?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/418'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
