### PR TITLE
Add function to compute Lists to be merged

### DIFF
--- a/FilePersistence/src/version_control/merge/ChangeGraph.h
+++ b/FilePersistence/src/version_control/merge/ChangeGraph.h
@@ -73,6 +73,7 @@ class FILEPERSISTENCE_API ChangeGraph
 		QList<MergeChange*> changesForNode(Model::NodeIdType nodeId) const;
 
 	private:
+		friend class ListMergeComponentV2;
 		// The nodes of the graph
 		QList<MergeChange*> changes_;
 

--- a/FilePersistence/src/version_control/merge/ChangeGraph.h
+++ b/FilePersistence/src/version_control/merge/ChangeGraph.h
@@ -73,7 +73,6 @@ class FILEPERSISTENCE_API ChangeGraph
 		QList<MergeChange*> changesForNode(Model::NodeIdType nodeId) const;
 
 	private:
-		friend class ListMergeComponentV2;
 		// The nodes of the graph
 		QList<MergeChange*> changes_;
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/419%23discussion_r70592306%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/419%23discussion_r70592811%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/419%23discussion_r70593122%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/419%23discussion_r70593970%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/419%23discussion_r70594016%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2003e7acb2625b7513c1c8d91f23689ec2849c83f5%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/419%23discussion_r70593122%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22remove%20Lists.%20You%27re%20not%20ignoring%20the%20lists%2C%20but%20changes%20to%20items%20of%20the%20list%2C%20if%20those%20changes%20are%20stationary.%22%2C%20%22created_at%22%3A%20%222016-07-13T09%3A33%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL70-112%22%7D%2C%20%22Pull%2003e7acb2625b7513c1c8d91f23689ec2849c83f5%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/419%23discussion_r70594016%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20the%20newly%20pushed%20accessor%20method%20in%20CG.%22%2C%20%22created_at%22%3A%20%222016-07-13T09%3A39%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL70-112%22%7D%2C%20%22Pull%2003e7acb2625b7513c1c8d91f23689ec2849c83f5%20FilePersistence/src/version_control/merge/ChangeGraph.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/419%23discussion_r70592306%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20ChangeGraph%20should%20not%20know%20about%20the%20%60ListMergeComponent%60%20and%20it%20cannot%20be%20its%20friend.%22%2C%20%22created_at%22%3A%20%222016-07-13T09%3A27%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20just%20added%20a%20%60changes%28%29%60%20method.%20Use%20that%20one.%22%2C%20%22created_at%22%3A%20%222016-07-13T09%3A31%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ChangeGraph.h%3AL70-77%22%7D%2C%20%22Pull%2003e7acb2625b7513c1c8d91f23689ec2849c83f5%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/419%23discussion_r70593970%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20do%20not%20use%20Java-style%20iterators.%20Use%20a%20normal%20iterator%20and%20%20either%20to%20%60%2B%2Bit%60%20or%20%60it%20%3D%20listsToMerge.erase%28it%29%60.%22%2C%20%22created_at%22%3A%20%222016-07-13T09%3A38%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL70-112%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 03e7acb2625b7513c1c8d91f23689ec2849c83f5 FilePersistence/src/version_control/merge/ChangeGraph.h 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/419#discussion_r70592306'>File: FilePersistence/src/version_control/merge/ChangeGraph.h:L70-77</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> The ChangeGraph should not know about the `ListMergeComponent` and it cannot be its friend.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I just added a `changes()` method. Use that one.
- [x] <a href='#crh-comment-Pull 03e7acb2625b7513c1c8d91f23689ec2849c83f5 FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/419#discussion_r70593122'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L70-112</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> remove Lists. You're not ignoring the lists, but changes to items of the list, if those changes are stationary.
- [x] <a href='#crh-comment-Pull 03e7acb2625b7513c1c8d91f23689ec2849c83f5 FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/419#discussion_r70593970'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L70-112</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please do not use Java-style iterators. Use a normal iterator and  either to `++it` or `it = listsToMerge.erase(it)`.
- [x] <a href='#crh-comment-Pull 03e7acb2625b7513c1c8d91f23689ec2849c83f5 FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 27'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/419#discussion_r70594016'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L70-112</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Use the newly pushed accessor method in CG.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/419?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/419?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/419'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
