### PR TITLE
Initial version of code review comments persistence

### DIFF
--- a/CodeReview/CMakeLists.txt
+++ b/CodeReview/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(CodeReview SHARED
 	src/handlers/HReviewableItem.h
 	src/handlers/HCodeReviewOverlay.h
 	src/nodes/CommentedNode.h
+	src/nodes/CommentedNodeList.h
 	src/nodes/ReviewComment.h
 	src/items/VCommentedNode.h
 	src/items/VCommentedNodeStyle.h
@@ -33,6 +34,7 @@ add_library(CodeReview SHARED
 	src/handlers/HReviewableItem.cpp
 	src/handlers/HCodeReviewOverlay.cpp
 	src/nodes/CommentedNode.cpp
+	src/nodes/CommentedNodeList.cpp
 	src/nodes/ReviewComment.cpp
 	src/items/VCommentedNode.cpp
 	src/items/VCommentedNodeStyle.cpp

--- a/CodeReview/src/CodeReviewManager.cpp
+++ b/CodeReview/src/CodeReviewManager.cpp
@@ -81,7 +81,7 @@ void CodeReviewManager::saveReview(QString newVersion)
 
 }
 
-QList<CommentedNode*> CodeReviewManager::loadReview(QString newVersion)
+CommentedNodeList* CodeReviewManager::loadReview(QString newVersion)
 {
 	// no comments to load
 	if (!QDir{CODE_REVIEW_COMMENTS_PREFIX+newVersion}.exists()) return {};
@@ -91,14 +91,8 @@ QList<CommentedNode*> CodeReviewManager::loadReview(QString newVersion)
 	manager->load(store, CODE_REVIEW_COMMENTS_PREFIX+newVersion, false);
 	commentedNodes_ = DCast<CommentedNodeList>(manager->root());
 	Q_ASSERT(commentedNodes_);
-	QList<CommentedNode*> result;
-	for (auto node : *commentedNodes_)
-	{
-		auto comment = DCast<CommentedNode>(node);
-		result.append(comment);
-	}
 
-	return result;
+	return commentedNodes_;
 }
 
 }

--- a/CodeReview/src/CodeReviewManager.h
+++ b/CodeReview/src/CodeReviewManager.h
@@ -51,7 +51,7 @@ class CODEREVIEW_API CodeReviewManager
 				QList<VersionControlUI::DiffFrame*> diffFrames);
 
 		void saveReview(QString newVersion);
-		QList<CommentedNode*> loadReview(QString newVersion);
+		CommentedNodeList* loadReview(QString newVersion);
 
 
 	private:

--- a/CodeReview/src/CodeReviewManager.h
+++ b/CodeReview/src/CodeReviewManager.h
@@ -42,17 +42,21 @@ using OrderingFunction =
 class CODEREVIEW_API CodeReviewManager
 {
 	public:
-		CommentedNode* commentedNode(QString nodeId);
+		CommentedNode* commentedNode(QString nodeId, QPoint offset);
 		static CodeReviewManager& instance();
 
 		static QList<QList<VersionControlUI::DiffFrame*>> orderDiffFrames(
 				GroupingFunction groupingFunction, OrderingFunction orderingFunction,
 				QList<VersionControlUI::DiffFrame*> diffFrames);
 
+		void saveReview(QString newVersion);
+		QList<CommentedNode*> loadReview(QString newVersion);
+
 
 	private:
 		QHash<QString, CommentedNode*> commentedNodes_;
 		CodeReviewManager(QString oldVersion, QString newVersion);
+		static const QString CODE_REVIEW_COMMENTS_PREFIX;
 
 };
 

--- a/CodeReview/src/CodeReviewManager.h
+++ b/CodeReview/src/CodeReviewManager.h
@@ -28,6 +28,7 @@
 
 #include "codereview_api.h"
 #include "nodes/CommentedNode.h"
+#include "nodes/CommentedNodeList.h"
 
 #include "VersionControlUI/src/nodes/DiffFrame.h"
 
@@ -54,7 +55,7 @@ class CODEREVIEW_API CodeReviewManager
 
 
 	private:
-		QHash<QString, CommentedNode*> commentedNodes_;
+		CommentedNodeList* commentedNodes_;
 		CodeReviewManager(QString oldVersion, QString newVersion);
 		static const QString CODE_REVIEW_COMMENTS_PREFIX;
 

--- a/CodeReview/src/commands/CCodeReview.cpp
+++ b/CodeReview/src/commands/CCodeReview.cpp
@@ -164,7 +164,7 @@ Interaction::CommandResult* CCodeReview::execute(Visualization::Item* source, Vi
 	Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
 								  [comments, source, reviewViewItem, headManager, diffFramesAndSetup]()
 	{
-		for (auto comment : comments)
+		for (auto comment : *comments)
 		{
 			auto node = const_cast<Model::Node*>(diffFramesAndSetup.diffSetup_.newVersionManager_->
 															 nodeIdMap().node(comment->nodeId()->get()));

--- a/CodeReview/src/commands/CCodeReview.cpp
+++ b/CodeReview/src/commands/CCodeReview.cpp
@@ -51,6 +51,9 @@ using namespace Visualization;
 
 namespace CodeReview {
 
+const QString CCodeReview::SAVE_COMMAND = "save";
+const QString CCodeReview::REVIEW_VIEW_PREFIX = "ReviewView";
+
 CCodeReview::CCodeReview() : Command{"review"} {}
 
 bool CCodeReview::canInterpret(Visualization::Item* source, Visualization::Item*,
@@ -83,6 +86,10 @@ bool CCodeReview::canInterpret(Visualization::Item* source, Visualization::Item*
 		if (!commandTokensCopy.isEmpty())
 		{
 			auto token = commandTokensCopy.takeFirst();
+			auto scene = source->scene();
+			if (token == SAVE_COMMAND && scene->currentViewItem()->name().startsWith(REVIEW_VIEW_PREFIX))
+				return true;
+
 			if (!repository.isValidRevisionString(unambigousPrefixPerRevision_.value(token, token)))
 				return false;
 		}
@@ -107,6 +114,11 @@ Interaction::CommandResult* CCodeReview::execute(Visualization::Item* source, Vi
 	Model::TreeManager* headManager = ancestorWithNode->node()->manager();
 	QString managerName = headManager->name();
 
+	if (commandTokens.value(1) == SAVE_COMMAND)
+	{
+		CodeReviewManager::instance().saveReview(source->scene()->currentViewItem()->name().split("_").value(2));
+		return new Interaction::CommandResult{};
+	}
 	QString oldRev = commandTokens.value(1, "HEAD");
 	QString newRev = commandTokens.value(2, FilePersistence::GitRepository::WORKDIR);
 
@@ -117,20 +129,24 @@ Interaction::CommandResult* CCodeReview::execute(Visualization::Item* source, Vi
 	VersionControlUI::DiffManager diffManager{managerName, {Model::SymbolMatcher{"Class"},
 																			  Model::SymbolMatcher{"Method"}}};
 
+	auto reviewViewName = REVIEW_VIEW_PREFIX + "_" + oldRev + "_" + newRev;
+
 	auto reviewViewItem = Visualization::VisualizationManager::instance().mainScene()->
-			viewItems()->viewItem("ReviewView");
+			viewItems()->viewItem(reviewViewName);
 
 	if (reviewViewItem)
 		Visualization::VisualizationManager::instance().mainScene()->
 					viewItems()->removeViewItem(reviewViewItem);
 
 	reviewViewItem = Visualization::VisualizationManager::instance().mainScene()->
-				viewItems()->newViewItem("ReviewView");
+				viewItems()->newViewItem(reviewViewName);
 
 	reviewViewItem->setMajorAxis(Visualization::GridLayouter::NoMajor);
 	reviewViewItem->setZoomLabelsEnabled(false);
 
-	auto diffFrames = diffManager.computeDiffFramesAndOverlays(oldRev, newRev, reviewViewItem);
+	auto diffFramesAndSetup = diffManager.computeDiffFramesAndOverlays(oldRev, newRev, reviewViewItem);
+
+	auto diffFrames = diffFramesAndSetup.diffFrames_;
 
 	auto orderedDiffFrames = CodeReviewManager::orderDiffFrames(UseAnalysisGroupings::useAnalysisGrouping,
 																							  Orderings::alphabeticalOrdering, diffFrames);
@@ -141,6 +157,24 @@ Interaction::CommandResult* CCodeReview::execute(Visualization::Item* source, Vi
 			MajorMinorIndex index = {i, j};
 			reviewViewItem->insertNode(orderedDiffFrames[i][j], index);
 		}
+
+	auto comments = CodeReviewManager::instance().loadReview(newRev);
+
+	// recreate comment overlays
+	Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
+								  [comments, source, reviewViewItem, headManager, diffFramesAndSetup]()
+	{
+		for (auto comment : comments)
+		{
+			auto node = const_cast<Model::Node*>(diffFramesAndSetup.diffSetup_.newVersionManager_->
+															 nodeIdMap().node(comment->nodeId()->get()));
+			for (auto item : reviewViewItem->findAllVisualizationsOf(node))
+			{
+				auto overlay = new CodeReviewCommentOverlay{item, comment};
+				item->addOverlay(overlay, "CodeReviewComment");
+			}
+		}
+	});
 
 	// switch to the newly created view
 	Visualization::VisualizationManager::instance().mainScene()->viewItems()->switchToView(reviewViewItem);
@@ -172,8 +206,13 @@ QList<Interaction::CommandSuggestion*> CCodeReview::suggest(Visualization::Item*
 			return suggestions;
 		}
 
-		return VersionControlUI::CDiff::parseVersions(tokensSoFar, name(), ancestorWithNode->node()->manager()->name(),
-									unambigousPrefixPerRevision_);
+		suggestions = VersionControlUI::CDiff::parseVersions(tokensSoFar, name(), ancestorWithNode->node()->manager()->name(),
+																			  unambigousPrefixPerRevision_);
+
+		if (SAVE_COMMAND.startsWith(tokensSoFar.first()))
+			suggestions.prepend(new Interaction::CommandSuggestion{name() + " " + SAVE_COMMAND, "safe current review comments"});
+
+		return suggestions;
 	}
 	else return {};
 }

--- a/CodeReview/src/commands/CCodeReview.h
+++ b/CodeReview/src/commands/CCodeReview.h
@@ -46,6 +46,8 @@ class CODEREVIEW_API CCodeReview : public Interaction::Command
 
 	private:
 		QHash<QString, QString> unambigousPrefixPerRevision_;
+		static const QString SAVE_COMMAND;
+		static const QString REVIEW_VIEW_PREFIX;
 };
 
 }

--- a/CodeReview/src/commands/CCodeReviewComment.cpp
+++ b/CodeReview/src/commands/CCodeReviewComment.cpp
@@ -70,7 +70,6 @@ Interaction::CommandResult* CCodeReviewComment::execute(Visualization::Item* sou
 																	ancestorWithNodeItem->mapFromScene(source->scenePos()).toPoint());
 			commentedNode->reviewComments()->append(new ReviewComment{});
 
-			// only create highlight if not already existent
 			auto overlay = new CodeReviewCommentOverlay{ancestorWithNodeItem, commentedNode};
 			ancestorWithNodeItem->addOverlay(overlay, "CodeReviewComment");
 			break;

--- a/CodeReview/src/commands/CCodeReviewComment.cpp
+++ b/CodeReview/src/commands/CCodeReviewComment.cpp
@@ -66,15 +66,13 @@ Interaction::CommandResult* CCodeReviewComment::execute(Visualization::Item* sou
 
 		if (!id.isNull())
 		{
-			auto commentedNode = CodeReviewManager::instance().commentedNode(id.toString());
+			auto commentedNode = CodeReviewManager::instance().commentedNode(id.toString(),
+																	ancestorWithNodeItem->mapFromScene(source->scenePos()).toPoint());
 			commentedNode->reviewComments()->append(new ReviewComment{});
 
 			// only create highlight if not already existent
-			if (!source->overlay<CodeReviewCommentOverlay>("CodeReviewComment"))
-			{
-				auto overlay = new CodeReviewCommentOverlay{source, commentedNode};
-				source->addOverlay(overlay, "CodeReviewComment");
-			}
+			auto overlay = new CodeReviewCommentOverlay{ancestorWithNodeItem, commentedNode};
+			ancestorWithNodeItem->addOverlay(overlay, "CodeReviewComment");
 			break;
 		}
 	}

--- a/CodeReview/src/commands/CCodeReviewComment.cpp
+++ b/CodeReview/src/commands/CCodeReviewComment.cpp
@@ -68,7 +68,9 @@ Interaction::CommandResult* CCodeReviewComment::execute(Visualization::Item* sou
 		{
 			auto commentedNode = CodeReviewManager::instance().commentedNode(id.toString(),
 																	ancestorWithNodeItem->mapFromScene(source->scenePos()).toPoint());
+			commentedNode->beginModification();
 			commentedNode->reviewComments()->append(new ReviewComment{});
+			commentedNode->endModification();
 
 			auto overlay = new CodeReviewCommentOverlay{ancestorWithNodeItem, commentedNode};
 			ancestorWithNodeItem->addOverlay(overlay, "CodeReviewComment");

--- a/CodeReview/src/nodes/CommentedNode.cpp
+++ b/CodeReview/src/nodes/CommentedNode.cpp
@@ -46,12 +46,8 @@ DEFINE_ATTRIBUTE(CommentedNode, offsetY, Integer, false, false, true)
 CommentedNode::CommentedNode(QString associatedNodeId, QPoint offset) : Super{nullptr, CommentedNode::getMetaData()}
 {
 	setNodeId(new Model::Text{associatedNodeId});
-	auto offsetX = new Model::Integer{};
-	offsetX->set(offset.x());
-	setOffsetX(offsetX);
-	auto offsetY = new Model::Integer{};
-	offsetY->set(offset.y());
-	setOffsetY(offsetY);
+	offsetX()->set(offset.x());
+	offsetY()->set(offset.y());
 }
 
 }

--- a/CodeReview/src/nodes/CommentedNode.cpp
+++ b/CodeReview/src/nodes/CommentedNode.cpp
@@ -40,10 +40,18 @@ DEFINE_COMPOSITE_TYPE_REGISTRATION_METHODS(CommentedNode)
 
 DEFINE_ATTRIBUTE(CommentedNode, nodeId, Text, false, false, true)
 DEFINE_ATTRIBUTE(CommentedNode, reviewComments, TypedListOfReviewComment, false, false, true)
+DEFINE_ATTRIBUTE(CommentedNode, offsetX, Integer, false, false, true)
+DEFINE_ATTRIBUTE(CommentedNode, offsetY, Integer, false, false, true)
 
-CommentedNode::CommentedNode(QString associatedNodeId) : Super{nullptr, CommentedNode::getMetaData()}
+CommentedNode::CommentedNode(QString associatedNodeId, QPoint offset) : Super{nullptr, CommentedNode::getMetaData()}
 {
 	setNodeId(new Model::Text{associatedNodeId});
+	auto offsetX = new Model::Integer{};
+	offsetX->set(offset.x());
+	setOffsetX(offsetX);
+	auto offsetY = new Model::Integer{};
+	offsetY->set(offset.y());
+	setOffsetY(offsetY);
 }
 
 }

--- a/CodeReview/src/nodes/CommentedNode.h
+++ b/CodeReview/src/nodes/CommentedNode.h
@@ -46,9 +46,11 @@ class CODEREVIEW_API CommentedNode : public Super<Model::CompositeNode>
 
 	ATTRIBUTE(Model::Text, nodeId, setNodeId)
 	ATTRIBUTE(Model::TypedList<CodeReview::ReviewComment>, reviewComments, setReviewComments)
+	ATTRIBUTE(Model::Integer, offsetX, setOffsetX)
+	ATTRIBUTE(Model::Integer, offsetY, setOffsetY)
 
 	public:
-		CommentedNode(QString associatedNodeId);
+		CommentedNode(QString associatedNodeId, QPoint offset);
 
 };
 

--- a/CodeReview/src/nodes/CommentedNodeList.cpp
+++ b/CodeReview/src/nodes/CommentedNodeList.cpp
@@ -1,0 +1,47 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2014 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "CommentedNodeList.h"
+
+#include "ModelBase/src/nodes/TypedList.hpp"
+#include "OOModel/src/typesystem/OOResolutionRequest.h"
+template class Model::TypedList<CodeReview::CommentedNodeList>;
+
+namespace CodeReview {
+
+DEFINE_NODE_EMPTY_CONSTRUCTORS(CommentedNodeList)
+DEFINE_NODE_TYPE_REGISTRATION_METHODS(CommentedNodeList)
+
+CommentedNode* CommentedNodeList::find(QString nodeId)
+{
+	for (auto commentedNode : *this)
+		if (commentedNode->nodeId()->get() == nodeId)
+			return commentedNode;
+
+	return nullptr;
+}
+
+}

--- a/CodeReview/src/nodes/CommentedNodeList.cpp
+++ b/CodeReview/src/nodes/CommentedNodeList.cpp
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
 **
-** Copyright (c) 2011, 2014 ETH Zurich
+** Copyright (c) 2016 ETH Zurich
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the

--- a/CodeReview/src/nodes/CommentedNodeList.h
+++ b/CodeReview/src/nodes/CommentedNodeList.h
@@ -1,0 +1,47 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2011, 2014 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+**    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+**      disclaimer.
+**    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+**      following disclaimer in the documentation and/or other materials provided with the distribution.
+**    * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+**      derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "CommentedNode.h"
+#include "ModelBase/src/nodes/TypedList.h"
+
+namespace CodeReview {
+	class CommentedNodeList;
+}
+extern template class CODEREVIEW_API Model::TypedList<CodeReview::CommentedNodeList>;
+
+namespace CodeReview {
+
+class CODEREVIEW_API CommentedNodeList : public Super<Model::TypedList<CommentedNode>>
+{
+	NODE_DECLARE_STANDARD_METHODS(CommentedNodeList)
+
+	public:
+		CommentedNode* find(QString nodeId);
+};
+
+}

--- a/CodeReview/src/nodes/CommentedNodeList.h
+++ b/CodeReview/src/nodes/CommentedNodeList.h
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
 **
-** Copyright (c) 2011, 2014 ETH Zurich
+** Copyright (c) 2016 ETH Zurich
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the

--- a/CodeReview/src/nodes/ReviewComment.cpp
+++ b/CodeReview/src/nodes/ReviewComment.cpp
@@ -62,11 +62,9 @@ ReviewComment::ReviewComment(Model::Node* parent) :
 							  QDateTime::currentMSecsSinceEpoch(), parent}
 {}
 
-ReviewComment::ReviewComment(Model::Node *, Model::PersistentStore &, bool)
-	:Super{}
-{
-	Q_ASSERT(false);
-}
+ReviewComment::ReviewComment(Model::Node* node, Model::PersistentStore& store, bool partial)
+	:Super{node, store, partial, ReviewComment::getMetaData()}
+{}
 
 ReviewComment* ReviewComment::clone() const { return new ReviewComment{*this}; }
 

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -47,7 +47,7 @@ CodeReviewCommentOverlay::CodeReviewCommentOverlay(Visualization::Item* associat
 {
 	setAcceptedMouseButtons(Qt::AllButtons);
 	setItemCategory(Visualization::Scene::MenuItemCategory);
-	offsetItemLocal_ = QPoint{0, associatedItem->heightInLocal()};
+	offsetItemLocal_ = QPoint{commentedNode->offsetX()->get(), commentedNode->offsetY()->get()};
 }
 
 void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableHeight)
@@ -84,6 +84,10 @@ void CodeReviewCommentOverlay::initializeForms()
 void CodeReviewCommentOverlay::updateOffsetItemLocal(QPointF scenePos)
 {
 	offsetItemLocal_ = CodeReviewCommentOverlay::associatedItem()->mapFromScene(scenePos);
+	commentedNode_->beginModification("edit node");
+	commentedNode_->offsetX()->set(offsetItemLocal_.x());
+	commentedNode_->offsetY()->set(offsetItemLocal_.y());
+	commentedNode_->endModification();
 }
 
 }

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -71,15 +71,6 @@ struct ChangeWithNodes {
 	FilePersistence::ChangeType changeType_{FilePersistence::ChangeType::Unclassified};
 };
 
-struct DiffSetup {
-	Model::TreeManager* newVersionManager_{};
-	Model::TreeManager* oldVersionManager_{};
-	FilePersistence::GitRepository* repository_{};
-
-	QString oldVersion_;
-	QString newVersion_;
-};
-
 DiffManager::DiffManager(QString project, QList<Model::SymbolMatcher> contextUnitMatcherPriorityList,
 								 Model::NodeIdType targetNodeID, NameChangeVisualizations nameChangeVisualization)
 	: project_{project}, contextUnitMatcherPriorityList_{contextUnitMatcherPriorityList}, targetNodeId_{targetNodeID},
@@ -398,7 +389,9 @@ void DiffManager::showDiff(QString oldVersion, QString newVersion)
 	diffViewItem->setZoomLabelsEnabled(false);
 
 	int row = 0;
-	for (auto diffFrame : computeDiffFramesAndOverlays(oldVersion, newVersion, diffViewItem))
+	auto diffFramesAndSetup = computeDiffFramesAndOverlays(oldVersion, newVersion, diffViewItem);
+	auto diffFrames = diffFramesAndSetup.diffFrames_;
+	for (auto diffFrame : diffFrames)
 		diffViewItem->insertNode(diffFrame, {row++, 0});
 
 	// switch to the newly created view
@@ -428,7 +421,7 @@ void DiffManager::createOverlaysForChanges(QList<ChangeWithNodes> changesWithNod
 	});
 }
 
-QList<DiffFrame*> DiffManager::computeDiffFramesAndOverlays(QString oldVersion, QString newVersion,
+DiffFramesAndSetup DiffManager::computeDiffFramesAndOverlays(QString oldVersion, QString newVersion,
 																										Visualization::ViewItem* viewItem)
 {
 	DiffSetup diffSetup;
@@ -449,7 +442,7 @@ QList<DiffFrame*> DiffManager::computeDiffFramesAndOverlays(QString oldVersion, 
 
 	createOverlaysForChanges(changesWithNodes, viewItem, diffSetup, viewItem);
 
-	return diffFrames;
+	return {diffFrames, diffSetup};
 }
 
 QString DiffManager::createHTMLCommitInfo(const FilePersistence::GitRepository* repository, QString revision)

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -51,8 +51,22 @@ namespace VersionControlUI {
 
 struct VersionNodes;
 struct ChangeWithNodes;
-struct DiffSetup;
 class DiffFrame;
+
+struct DiffSetup {
+	Model::TreeManager* newVersionManager_{};
+	Model::TreeManager* oldVersionManager_{};
+	FilePersistence::GitRepository* repository_{};
+
+	QString oldVersion_;
+	QString newVersion_;
+};
+
+struct DiffFramesAndSetup
+{
+	QList<DiffFrame*> diffFrames_;
+	DiffSetup diffSetup_;
+};
 
 class VERSIONCONTROLUI_API DiffManager
 {
@@ -79,7 +93,7 @@ class VERSIONCONTROLUI_API DiffManager
 
 		static QString createHTMLCommitInfo(const FilePersistence::GitRepository* repository, QString revision);
 
-		QList<DiffFrame*> computeDiffFramesAndOverlays(QString oldVersion,
+		DiffFramesAndSetup computeDiffFramesAndOverlays(QString oldVersion,
 																					QString newVersion, Visualization::ViewItem* viewItem);
 
 	private:


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71168963%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71169726%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71171264%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71171653%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71172093%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23issuecomment-233368533%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71284656%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71284664%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71284669%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71291051%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71302164%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71302215%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71302286%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23issuecomment-233580014%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71305685%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23issuecomment-233588785%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23issuecomment-233368533%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20done%20with%20the%20review.%22%2C%20%22created_at%22%3A%20%222016-07-18T15%3A44%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looks%20nice%20and%20clean.%20I%27m%20just%20wondering%20about%20the%20%60loadReview%60%20method.%22%2C%20%22created_at%22%3A%20%222016-07-19T09%3A32%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nice.%20Thanks.%22%2C%20%22created_at%22%3A%20%222016-07-19T10%3A11%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208d3f938749e5a0ab673c8b46ba4e69f087121229%20CodeReview/src/commands/CCodeReview.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71169726%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22we%20already%20use%20the%20%60save%60%20command%20for%20ordinary%20save.%20Let%27s%20pick%20a%20different%20name.%20%60save-review%60%22%2C%20%22created_at%22%3A%20%222016-07-18T15%3A31%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20actually%20part%20of%20the%20review%20command.%20So%20to%20execute%20it%20you%20have%20to%20write%20%60review%20save%60.%5Cr%5CnIs%20that%20OK%3F%22%2C%20%22created_at%22%3A%20%222016-07-19T07%3A29%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sure%2C%20I%20didn%27t%20realize%20that.%22%2C%20%22created_at%22%3A%20%222016-07-19T08%3A22%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CCodeReview.cpp%3AL51-60%22%7D%2C%20%22Pull%208d3f938749e5a0ab673c8b46ba4e69f087121229%20CodeReview/src/commands/CCodeReviewComment.cpp%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71171264%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22is%20the%20comment%20above%20still%20valid%3F%22%2C%20%22created_at%22%3A%20%222016-07-18T15%3A39%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%2C%20I%20have%20to%20remove%20it%22%2C%20%22created_at%22%3A%20%222016-07-19T07%3A29%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CCodeReviewComment.cpp%3AL66-79%22%7D%2C%20%22Pull%20b5fdba91aa92e9b369319db29fb0e6d94a2a7f94%20CodeReview/src/nodes/CommentedNodeList.h%203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71302286%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%222016%22%2C%20%22created_at%22%3A%20%222016-07-19T09%3A31%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/nodes/CommentedNodeList.h%3AL1-48%22%7D%2C%20%22Pull%20b5fdba91aa92e9b369319db29fb0e6d94a2a7f94%20CodeReview/src/nodes/CommentedNodeList.cpp%203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71302215%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22only%202016%22%2C%20%22created_at%22%3A%20%222016-07-19T09%3A31%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/nodes/CommentedNodeList.cpp%3AL1-48%22%7D%2C%20%22Pull%208d3f938749e5a0ab673c8b46ba4e69f087121229%20CodeReview/src/CodeReviewManager.cpp%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71168963%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22hmm%2C%20you%20can%27t%20simply%20set%20the%20parent%20to%20nullptr.%20If%20this%20works%20right%20now%2C%20chances%20are%20it%20does%20because%20the%20parent%20was%20already%20nullptr.%20The%20correct%20way%20to%20do%20this%20is%20to%20remove%20the%20element%20from%20the%20previous%20list%20%28which%20you%20assume%20is%20the%20parent%29.%22%2C%20%22created_at%22%3A%20%222016-07-18T15%3A28%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%2C%20I%27ll%20remove%20it%20from%20the%20other%20list%20during%20load.%22%2C%20%22created_at%22%3A%20%222016-07-19T07%3A29%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/CodeReviewManager.cpp%3AL69-111%22%7D%2C%20%22Pull%20b5fdba91aa92e9b369319db29fb0e6d94a2a7f94%20CodeReview/src/CodeReviewManager.cpp%2054%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71302164%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60loadReview%28%29%60%20return%20a%20%60QList%60.%20Is%20this%20necessary%3F%20Can%27t%20we%20simply%20return%20the%20%60CommentedNodeList%60%3F%22%2C%20%22created_at%22%3A%20%222016-07-19T09%3A30%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20you%20are%20right%2C%20I%27ll%20change%20it.%22%2C%20%22created_at%22%3A%20%222016-07-19T09%3A49%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/CodeReviewManager.cpp%3AL89-105%22%7D%2C%20%22Pull%208d3f938749e5a0ab673c8b46ba4e69f087121229%20CodeReview/src/nodes/CommentedNode.cpp%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71171653%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20attriburt%20is%20required%2C%20therefore%20it%20was%20already%20created%20when%20you%20created%20the%20object.%20Please%20don%27t%20create%20it%20here%2C%20directly%20set%20it%20on%20the%20existing%20object%20%60offsetX%28%29-%3Eset%28...%29%60%22%2C%20%22created_at%22%3A%20%222016-07-18T15%3A41%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/nodes/CommentedNode.cpp%3AL40-58%22%7D%2C%20%22Pull%208d3f938749e5a0ab673c8b46ba4e69f087121229%20VersionControlUI/src/DiffManager.h%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/427%23discussion_r71172093%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Who%27s%20responsible%20for%20deleting%20these%20frames%3F%20Where%20does%20that%20happen%3F%20Is%20this%20something%20we%20postponed%20for%20later%3F%22%2C%20%22created_at%22%3A%20%222016-07-18T15%3A44%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.h%3AL51-74%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 8d3f938749e5a0ab673c8b46ba4e69f087121229 CodeReview/src/CodeReviewManager.cpp 45'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/427#discussion_r71168963'>File: CodeReview/src/CodeReviewManager.cpp:L69-111</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> hmm, you can't simply set the parent to nullptr. If this works right now, chances are it does because the parent was already nullptr. The correct way to do this is to remove the element from the previous list (which you assume is the parent).
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> OK, I'll remove it from the other list during load.
- [ ] <a href='#crh-comment-Pull 8d3f938749e5a0ab673c8b46ba4e69f087121229 CodeReview/src/commands/CCodeReview.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/427#discussion_r71169726'>File: CodeReview/src/commands/CCodeReview.cpp:L51-60</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> we already use the `save` command for ordinary save. Let's pick a different name. `save-review`
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> It is actually part of the review command. So to execute it you have to write `review save`.
  Is that OK?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Sure, I didn't realize that.
- [ ] <a href='#crh-comment-Pull 8d3f938749e5a0ab673c8b46ba4e69f087121229 CodeReview/src/commands/CCodeReviewComment.cpp 15'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/427#discussion_r71171264'>File: CodeReview/src/commands/CCodeReviewComment.cpp:L66-79</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> is the comment above still valid?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> No, I have to remove it
- [ ] <a href='#crh-comment-Pull 8d3f938749e5a0ab673c8b46ba4e69f087121229 CodeReview/src/nodes/CommentedNode.cpp 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/427#discussion_r71171653'>File: CodeReview/src/nodes/CommentedNode.cpp:L40-58</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This attriburt is required, therefore it was already created when you created the object. Please don't create it here, directly set it on the existing object `offsetX()->set(...)`
- [ ] <a href='#crh-comment-Pull 8d3f938749e5a0ab673c8b46ba4e69f087121229 VersionControlUI/src/DiffManager.h 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/427#discussion_r71172093'>File: VersionControlUI/src/DiffManager.h:L51-74</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Who's responsible for deleting these frames? Where does that happen? Is this something we postponed for later?
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/427#issuecomment-233368533'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I'm done with the review.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Looks nice and clean. I'm just wondering about the `loadReview` method.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Nice. Thanks.
- [ ] <a href='#crh-comment-Pull b5fdba91aa92e9b369319db29fb0e6d94a2a7f94 CodeReview/src/CodeReviewManager.cpp 54'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/427#discussion_r71302164'>File: CodeReview/src/CodeReviewManager.cpp:L89-105</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `loadReview()` return a `QList`. Is this necessary? Can't we simply return the `CommentedNodeList`?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Yes you are right, I'll change it.
- [ ] <a href='#crh-comment-Pull b5fdba91aa92e9b369319db29fb0e6d94a2a7f94 CodeReview/src/nodes/CommentedNodeList.cpp 3'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/427#discussion_r71302215'>File: CodeReview/src/nodes/CommentedNodeList.cpp:L1-48</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> only 2016
- [ ] <a href='#crh-comment-Pull b5fdba91aa92e9b369319db29fb0e6d94a2a7f94 CodeReview/src/nodes/CommentedNodeList.h 3'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/427#discussion_r71302286'>File: CodeReview/src/nodes/CommentedNodeList.h:L1-48</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> 2016

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/427?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/427?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/427'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
