### PR TITLE
Gm focus

### DIFF
--- a/CodeReview/CMakeLists.txt
+++ b/CodeReview/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(CodeReview SHARED
 	src/CodeReviewManager.h
 	src/commands/CCodeReviewComment.h
 	src/commands/CCodeReview.h
+	src/commands/CFocus.h
 	src/overlays/CodeReviewCommentOverlay.h
 	src/overlays/CodeReviewCommentOverlayStyle.h
 	src/handlers/HReviewableItem.h
@@ -29,6 +30,7 @@ add_library(CodeReview SHARED
 	src/CodeReviewManager.cpp
 	src/commands/CCodeReviewComment.cpp
 	src/commands/CCodeReview.cpp
+	src/commands/CFocus.cpp
 	src/overlays/CodeReviewCommentOverlay.cpp
 	src/overlays/CodeReviewCommentOverlayStyle.cpp
 	src/handlers/HReviewableItem.cpp

--- a/CodeReview/src/CodeReviewManager.cpp
+++ b/CodeReview/src/CodeReviewManager.cpp
@@ -97,6 +97,8 @@ CommentedNodeList* CodeReviewManager::loadReview(QString newVersion, VersionCont
 	commentedNodes_ = DCast<CommentedNodeList>(manager->root());
 	Q_ASSERT(commentedNodes_);
 
+	parseCommentedNodes();
+
 	// recreate comment overlays
 	Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
 								  [this, viewItem, diffSetup]()
@@ -134,5 +136,34 @@ void CodeReviewManager::registerCommentedNodeWithOverlay(Model::Node* commentedN
 {
 	commentedNodeToOverlay_.insert(commentedNode, overlay);
 }
+
+void CodeReviewManager::parseCommentedNodes()
+{
+	for (CommentedNode* commentedNode : *commentedNodes_)
+	{
+		FocusInformation focusInformation;
+		if (commentedNode->parseReviewComments(focusInformation))
+		{
+			focusInformation.node_ = commentedNode;
+			addFocusInformation(focusInformation);
+		}
+	}
+}
+
+void CodeReviewManager::addFocusInformation(FocusInformation focusInformation)
+{
+	focusList_.insert(focusInformation.step_, focusInformation);
+}
+
+bool CodeReviewManager::focusInformationForStep(int step, FocusInformation& focusInformation)
+{
+	auto iter = focusList_.find(step);
+	if (iter == focusList_.end()) return false;
+
+	focusInformation = *iter;
+
+	return true;
+}
+
 
 }

--- a/CodeReview/src/CodeReviewManager.cpp
+++ b/CodeReview/src/CodeReviewManager.cpp
@@ -25,10 +25,14 @@
  **********************************************************************************************************************/
 
 #include "CodeReviewManager.h"
+#include "overlays/CodeReviewCommentOverlay.h"
 
 #include "ModelBase/src/model/TreeManager.h"
 
 #include "FilePersistence/src/simple/SimpleTextFileStore.h"
+
+#include "VisualizationBase/src/VisualizationManager.h"
+#include "VisualizationBase/src/items/ViewItem.h"
 
 namespace CodeReview {
 
@@ -81,7 +85,8 @@ void CodeReviewManager::saveReview(QString newVersion)
 
 }
 
-CommentedNodeList* CodeReviewManager::loadReview(QString newVersion)
+CommentedNodeList* CodeReviewManager::loadReview(QString newVersion, VersionControlUI::DiffSetup& diffSetup,
+																 Visualization::ViewItem* viewItem)
 {
 	// no comments to load
 	if (!QDir{CODE_REVIEW_COMMENTS_PREFIX+newVersion}.exists()) return {};
@@ -92,7 +97,42 @@ CommentedNodeList* CodeReviewManager::loadReview(QString newVersion)
 	commentedNodes_ = DCast<CommentedNodeList>(manager->root());
 	Q_ASSERT(commentedNodes_);
 
+	// recreate comment overlays
+	Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
+								  [this, viewItem, diffSetup]()
+	{
+		for (auto comment : *commentedNodes_)
+		{
+			Model::Node* node = nullptr;
+			auto managerName = comment->managerName()->get();
+			if (managerName == diffSetup.newVersionManager_->managerName())
+				node = const_cast<Model::Node*>(diffSetup.newVersionManager_->
+															 nodeIdMap().node(comment->nodeId()->get()));
+			else if (managerName == diffSetup.oldVersionManager_->managerName())
+				node = const_cast<Model::Node*>(diffSetup.oldVersionManager_->
+															 nodeIdMap().node(comment->nodeId()->get()));
+			if (!node) continue;
+
+			for (auto item : viewItem->findAllVisualizationsOf(node))
+			{
+				auto overlay = new CodeReviewCommentOverlay{item, comment};
+				viewItem->addOverlay(overlay, "CodeReviewComment");
+				registerCommentedNodeWithOverlay(comment, overlay);
+			}
+		}
+	});
+
 	return commentedNodes_;
+}
+
+Visualization::Item* CodeReviewManager::overlayForCommentedNode(Model::Node* commentedNode)
+{
+	return commentedNodeToOverlay_.value(commentedNode);
+}
+
+void CodeReviewManager::registerCommentedNodeWithOverlay(Model::Node* commentedNode, Visualization::Item* overlay)
+{
+	commentedNodeToOverlay_.insert(commentedNode, overlay);
 }
 
 }

--- a/CodeReview/src/CodeReviewManager.cpp
+++ b/CodeReview/src/CodeReviewManager.cpp
@@ -47,12 +47,12 @@ CodeReviewManager& CodeReviewManager::instance()
 	return manager;
 }
 
-CommentedNode* CodeReviewManager::commentedNode(QString nodeId, QPoint offset)
+CommentedNode* CodeReviewManager::commentedNode(QString nodeId, QString nodeManagerName, QPoint offset)
 {
 	auto commentedNode = commentedNodes_->find(nodeId);
 	if (commentedNode) return commentedNode;
 
-	commentedNode = new CommentedNode{nodeId, offset};
+	commentedNode = new CommentedNode{nodeId, nodeManagerName, offset};
 	commentedNodes_->beginModification();
 	commentedNodes_->append(commentedNode);
 	commentedNodes_->endModification();

--- a/CodeReview/src/CodeReviewManager.h
+++ b/CodeReview/src/CodeReviewManager.h
@@ -56,6 +56,12 @@ class CODEREVIEW_API CodeReviewManager
 		void saveReview(QString newVersion);
 		CommentedNodeList* loadReview(QString newVersion, VersionControlUI::DiffSetup& diffSetup,
 																		 Visualization::ViewItem* viewItem);
+
+		void parseCommentedNodes();
+
+		void addFocusInformation(FocusInformation focusInformation);
+		bool focusInformationForStep(int step, FocusInformation& focusInformation);
+
 		void registerCommentedNodeWithOverlay(Model::Node* commentedNode, Visualization::Item* overlay);
 		Visualization::Item* overlayForCommentedNode(Model::Node* commentedNode);
 
@@ -63,6 +69,7 @@ class CODEREVIEW_API CodeReviewManager
 	private:
 		CommentedNodeList* commentedNodes_;
 		CodeReviewManager(QString oldVersion, QString newVersion);
+		QHash<int, FocusInformation> focusList_;
 		QHash<Model::Node*, Visualization::Item*> commentedNodeToOverlay_;
 
 		static const QString CODE_REVIEW_COMMENTS_PREFIX;

--- a/CodeReview/src/CodeReviewManager.h
+++ b/CodeReview/src/CodeReviewManager.h
@@ -31,6 +31,9 @@
 #include "nodes/CommentedNodeList.h"
 
 #include "VersionControlUI/src/nodes/DiffFrame.h"
+#include "VersionControlUI/src/DiffManager.h"
+
+#include "VisualizationBase/src/items/Item.h"
 
 namespace CodeReview {
 
@@ -51,12 +54,17 @@ class CODEREVIEW_API CodeReviewManager
 				QList<VersionControlUI::DiffFrame*> diffFrames);
 
 		void saveReview(QString newVersion);
-		CommentedNodeList* loadReview(QString newVersion);
+		CommentedNodeList* loadReview(QString newVersion, VersionControlUI::DiffSetup& diffSetup,
+																		 Visualization::ViewItem* viewItem);
+		void registerCommentedNodeWithOverlay(Model::Node* commentedNode, Visualization::Item* overlay);
+		Visualization::Item* overlayForCommentedNode(Model::Node* commentedNode);
 
 
 	private:
 		CommentedNodeList* commentedNodes_;
 		CodeReviewManager(QString oldVersion, QString newVersion);
+		QHash<Model::Node*, Visualization::Item*> commentedNodeToOverlay_;
+
 		static const QString CODE_REVIEW_COMMENTS_PREFIX;
 
 };

--- a/CodeReview/src/CodeReviewManager.h
+++ b/CodeReview/src/CodeReviewManager.h
@@ -43,7 +43,7 @@ using OrderingFunction =
 class CODEREVIEW_API CodeReviewManager
 {
 	public:
-		CommentedNode* commentedNode(QString nodeId, QPoint offset);
+		CommentedNode* commentedNode(QString nodeId, QString nodeManagerName, QPoint offset);
 		static CodeReviewManager& instance();
 
 		static QList<QList<VersionControlUI::DiffFrame*>> orderDiffFrames(

--- a/CodeReview/src/CodeReviewPlugin.cpp
+++ b/CodeReview/src/CodeReviewPlugin.cpp
@@ -29,6 +29,7 @@
 #include "handlers/HCodeReviewOverlay.h"
 #include "overlays/CodeReviewCommentOverlay.h"
 #include "commands/CCodeReview.h"
+#include "commands/CFocus.h"
 
 #include "Logger/src/Log.h"
 
@@ -54,6 +55,7 @@ bool CodeReviewPlugin::initialize(Core::EnvisionManager&)
 	CodeReviewCommentOverlay::setDefaultClassHandler(HCodeReviewOverlay::instance());
 
 	Interaction::HSceneHandlerItem::instance()->addCommand(new CCodeReview{});
+	Interaction::HSceneHandlerItem::instance()->addCommand(new CFocus{});
 
 	return true;
 }

--- a/CodeReview/src/commands/CCodeReview.cpp
+++ b/CodeReview/src/commands/CCodeReview.cpp
@@ -221,7 +221,7 @@ QList<Interaction::CommandSuggestion*> CCodeReview::suggest(Visualization::Item*
 																			  unambigousPrefixPerRevision_);
 
 		if (SAVE_COMMAND.startsWith(tokensSoFar.first()))
-			suggestions.prepend(new Interaction::CommandSuggestion{name() + " " + SAVE_COMMAND, "safe current review comments"});
+			suggestions.prepend(new Interaction::CommandSuggestion{name() + " " + SAVE_COMMAND, "save current review comments"});
 
 		return suggestions;
 	}

--- a/CodeReview/src/commands/CCodeReview.cpp
+++ b/CodeReview/src/commands/CCodeReview.cpp
@@ -158,34 +158,7 @@ Interaction::CommandResult* CCodeReview::execute(Visualization::Item* source, Vi
 			reviewViewItem->insertNode(orderedDiffFrames[i][j], index);
 		}
 
-	auto comments = CodeReviewManager::instance().loadReview(newRev);
-
-	if (comments)
-	{
-		// recreate comment overlays
-		Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
-									  [comments, source, reviewViewItem, headManager, diffFramesAndSetup]()
-		{
-			for (auto comment : *comments)
-			{
-				Model::Node* node = nullptr;
-				auto managerName = comment->managerName()->get();
-				if (managerName == diffFramesAndSetup.diffSetup_.newVersionManager_->managerName())
-					node = const_cast<Model::Node*>(diffFramesAndSetup.diffSetup_.newVersionManager_->
-																 nodeIdMap().node(comment->nodeId()->get()));
-				else if (managerName == diffFramesAndSetup.diffSetup_.oldVersionManager_->managerName())
-					node = const_cast<Model::Node*>(diffFramesAndSetup.diffSetup_.oldVersionManager_->
-																 nodeIdMap().node(comment->nodeId()->get()));
-				if (!node) continue;
-
-				for (auto item : reviewViewItem->findAllVisualizationsOf(node))
-				{
-					auto overlay = new CodeReviewCommentOverlay{item, comment};
-					reviewViewItem->addOverlay(overlay, "CodeReviewComment");
-				}
-			}
-		});
-	}
+	CodeReviewManager::instance().loadReview(newRev, diffFramesAndSetup.diffSetup_, reviewViewItem);
 
 	// switch to the newly created view
 	Visualization::VisualizationManager::instance().mainScene()->viewItems()->switchToView(reviewViewItem);

--- a/CodeReview/src/commands/CCodeReviewComment.cpp
+++ b/CodeReview/src/commands/CCodeReviewComment.cpp
@@ -67,13 +67,17 @@ Interaction::CommandResult* CCodeReviewComment::execute(Visualization::Item* sou
 		if (!id.isNull())
 		{
 			auto commentedNode = CodeReviewManager::instance().commentedNode(id.toString(),
+																	ancestorWithNodeItem->node()->manager()->managerName(),
 																	ancestorWithNodeItem->mapFromScene(source->scenePos()).toPoint());
 			commentedNode->beginModification();
 			commentedNode->reviewComments()->append(new ReviewComment{});
 			commentedNode->endModification();
 
-			auto overlay = new CodeReviewCommentOverlay{ancestorWithNodeItem, commentedNode};
-			ancestorWithNodeItem->addOverlay(overlay, "CodeReviewComment");
+			if (!ancestorWithNodeItem->overlay<CodeReviewCommentOverlay>("CodeReviewComment"))
+			{
+				auto overlay = new CodeReviewCommentOverlay{ancestorWithNodeItem, commentedNode};
+				ancestorWithNodeItem->addOverlay(overlay, "CodeReviewComment");
+			}
 			break;
 		}
 	}

--- a/CodeReview/src/commands/CFocus.cpp
+++ b/CodeReview/src/commands/CFocus.cpp
@@ -67,8 +67,11 @@ Interaction::CommandResult* CFocus::execute(Visualization::Item*, Visualization:
 
 	if (!focusInformationFound){
 		currentStep_ = 0;
-		CodeReviewManager::instance().focusInformationForStep(currentStep_, focusInformation);
+		focusInformationFound = CodeReviewManager::instance().focusInformationForStep(currentStep_, focusInformation);
 	}
+
+	if (!focusInformationFound)
+		return new Interaction::CommandResult{};
 
 	auto focusItem = CodeReviewManager::instance().overlayForCommentedNode(focusInformation.node_);
 

--- a/CodeReview/src/commands/CFocus.cpp
+++ b/CodeReview/src/commands/CFocus.cpp
@@ -1,0 +1,99 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2016 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+** * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+** disclaimer.
+** * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+** following disclaimer in the documentation and/or other materials provided with the distribution.
+** * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+** derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#include "CFocus.h"
+
+#include "../nodes/CommentedNode.h"
+#include "../nodes/ReviewComment.h"
+
+#include "ModelBase/src/model/TreeManager.h"
+#include "ModelBase/src/model/AllTreeManagers.h"
+
+#include "VisualizationBase/src/items/Item.h"
+#include "VisualizationBase/src/items/ViewItem.h"
+#include "VisualizationBase/src/views/MainView.h"
+#include "VisualizationBase/src/VisualizationManager.h"
+#include "VisualizationBase/src/overlays/HighlightOverlay.h"
+
+#include "../CodeReviewManager.h"
+
+#include "../overlays/CodeReviewCommentOverlay.h"
+
+using namespace Visualization;
+
+namespace CodeReview {
+
+CFocus::CFocus() : Command{"focus"} {}
+
+bool CFocus::canInterpret(Visualization::Item*, Visualization::Item*,
+		const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& )
+{
+	if (commandTokens.size() > 0)
+		return name() == commandTokens.first();
+	return false;
+}
+
+Interaction::CommandResult* CFocus::execute(Visualization::Item*, Visualization::Item*,
+				const QStringList&, const std::unique_ptr<Visualization::Cursor>&)
+{
+
+	Visualization::VisualizationManager::instance().mainScene()->removeOverlayGroup("focusOverlay");
+
+	FocusInformation focusInformation;
+	auto focusInformationFound = CodeReviewManager::instance().focusInformationForStep(currentStep_, focusInformation);
+
+	if (!focusInformationFound){
+		currentStep_ = 0;
+		CodeReviewManager::instance().focusInformationForStep(currentStep_, focusInformation);
+	}
+
+	auto focusItem = CodeReviewManager::instance().overlayForCommentedNode(focusInformation.node_);
+
+	switch (focusInformation.type_) {
+		case FocusInformation::Center:
+			Visualization::VisualizationManager::instance().mainView()->
+					centerOn(focusItem);
+			break;
+		case FocusInformation::Highlight:
+			auto overlay = new Visualization::HighlightOverlay{focusItem};
+			focusItem->addOverlay(overlay, "focusOverlay");
+			break;
+	}
+
+	currentStep_++;
+
+	return new Interaction::CommandResult{};
+}
+
+QList<Interaction::CommandSuggestion*> CFocus::suggest(Visualization::Item*, Visualization::Item*,
+		const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>&)
+{
+	if (name().startsWith(textSoFar))
+		return {new Interaction::CommandSuggestion{name()}};
+	return {};
+}
+
+}

--- a/CodeReview/src/commands/CFocus.h
+++ b/CodeReview/src/commands/CFocus.h
@@ -1,0 +1,51 @@
+/***********************************************************************************************************************
+**
+** Copyright (c) 2016 ETH Zurich
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+** following conditions are met:
+**
+** * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+** disclaimer.
+** * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+** following disclaimer in the documentation and/or other materials provided with the distribution.
+** * Neither the name of the ETH Zurich nor the names of its contributors may be used to endorse or promote products
+** derived from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+***********************************************************************************************************************/
+
+#pragma once
+
+#include "../codereview_api.h"
+
+#include "InteractionBase/src/commands/CommandWithFlags.h"
+
+namespace CodeReview {
+
+class CODEREVIEW_API CFocus : public Interaction::Command
+{
+	public:
+		CFocus();
+		virtual bool canInterpret(Visualization::Item* source, Visualization::Item* target,
+				const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& cursor) override;
+		virtual Interaction::CommandResult* execute(Visualization::Item* source, Visualization::Item* target,
+				const QStringList& commandTokens, const std::unique_ptr<Visualization::Cursor>& cursor) override;
+
+		virtual QList<Interaction::CommandSuggestion*> suggest(Visualization::Item* source, Visualization::Item* target,
+				const QString& textSoFar, const std::unique_ptr<Visualization::Cursor>& cursor) override;
+
+	private:
+		int currentStep_{0};
+};
+
+}

--- a/CodeReview/src/nodes/CommentedNode.cpp
+++ b/CodeReview/src/nodes/CommentedNode.cpp
@@ -26,9 +26,6 @@
 #include "CommentedNode.h"
 
 #include "ModelBase/src/nodes/composite/CompositeNode.h"
-
-#include "ReviewComment.h"
-
 #include "ModelBase/src/nodes/TypedList.hpp"
 
 template class Model::TypedList<CodeReview::CommentedNode>;
@@ -39,13 +36,16 @@ DEFINE_COMPOSITE_EMPTY_CONSTRUCTORS(CommentedNode)
 DEFINE_COMPOSITE_TYPE_REGISTRATION_METHODS(CommentedNode)
 
 DEFINE_ATTRIBUTE(CommentedNode, nodeId, Text, false, false, true)
+DEFINE_ATTRIBUTE(CommentedNode, managerName, Text, false, false, true)
 DEFINE_ATTRIBUTE(CommentedNode, reviewComments, TypedListOfReviewComment, false, false, true)
 DEFINE_ATTRIBUTE(CommentedNode, offsetX, Integer, false, false, true)
 DEFINE_ATTRIBUTE(CommentedNode, offsetY, Integer, false, false, true)
 
-CommentedNode::CommentedNode(QString associatedNodeId, QPoint offset) : Super{nullptr, CommentedNode::getMetaData()}
+CommentedNode::CommentedNode(QString associatedNodeId, QString nodeManagerName, QPoint offset)
+	: Super{nullptr, CommentedNode::getMetaData()}
 {
-	setNodeId(new Model::Text{associatedNodeId});
+	nodeId()->set(associatedNodeId);
+	managerName()->set(nodeManagerName);
 	offsetX()->set(offset.x());
 	offsetY()->set(offset.y());
 }

--- a/CodeReview/src/nodes/CommentedNode.cpp
+++ b/CodeReview/src/nodes/CommentedNode.cpp
@@ -50,4 +50,12 @@ CommentedNode::CommentedNode(QString associatedNodeId, QString nodeManagerName, 
 	offsetY()->set(offset.y());
 }
 
+bool CommentedNode::parseReviewComments(FocusInformation& focusInformation)
+{
+	if (auto firstReviewComment = reviewComments()->first())
+		return firstReviewComment->parseComment(focusInformation);
+
+	return false;
+}
+
 }

--- a/CodeReview/src/nodes/CommentedNode.h
+++ b/CodeReview/src/nodes/CommentedNode.h
@@ -27,9 +27,12 @@
 
 #include "../codereview_api.h"
 
-#include "ModelBase/src/nodes/nodeMacros.h"
-
 #include "ReviewComment.h"
+
+#include "ModelBase/src/nodes/nodeMacros.h"
+#include "ModelBase/src/nodes/Integer.h"
+#include "ModelBase/src/nodes/Text.h"
+#include "ModelBase/src/nodes/TypedList.h"
 
 namespace CodeReview
 {
@@ -45,12 +48,13 @@ class CODEREVIEW_API CommentedNode : public Super<Model::CompositeNode>
 	COMPOSITENODE_DECLARE_STANDARD_METHODS(CommentedNode)
 
 	ATTRIBUTE(Model::Text, nodeId, setNodeId)
+	ATTRIBUTE(Model::Text, managerName, setManagerName)
 	ATTRIBUTE(Model::TypedList<CodeReview::ReviewComment>, reviewComments, setReviewComments)
 	ATTRIBUTE(Model::Integer, offsetX, setOffsetX)
 	ATTRIBUTE(Model::Integer, offsetY, setOffsetY)
 
 	public:
-		CommentedNode(QString associatedNodeId, QPoint offset);
+		CommentedNode(QString associatedNodeId, QString nodeManagerName, QPoint offset);
 
 };
 

--- a/CodeReview/src/nodes/CommentedNode.h
+++ b/CodeReview/src/nodes/CommentedNode.h
@@ -56,6 +56,8 @@ class CODEREVIEW_API CommentedNode : public Super<Model::CompositeNode>
 	public:
 		CommentedNode(QString associatedNodeId, QString nodeManagerName, QPoint offset);
 
+		bool parseReviewComments(FocusInformation& focusInformation);
+
 };
 
 }

--- a/CodeReview/src/nodes/ReviewComment.h
+++ b/CodeReview/src/nodes/ReviewComment.h
@@ -27,22 +27,31 @@
 
 #include "../codereview_api.h"
 
-#include "ModelBase/src/nodes/nodeMacros.h"
-
 #include "VersionControlUI/src/nodes/DiffFrame.h"
 
-#include "Comments/src/nodes/CommentNode.h"
-
+#include "ModelBase/src/nodes/nodeMacros.h"
 #include "ModelBase/src/nodes/Text.h"
+
+#include "Comments/src/nodes/CommentNode.h"
 
 namespace CodeReview
 {
 class ReviewComment;
+
 }
 
 extern template class CODEREVIEW_API Model::TypedList<CodeReview::ReviewComment>;
 
 namespace CodeReview {
+
+struct FocusInformation
+{
+	enum FocusType {Center, Highlight};
+
+	int step_{};
+	FocusType type_{};
+	Model::Node* node_{};
+};
 
 class CODEREVIEW_API ReviewComment : public Super<Model::CompositeNode>
 {
@@ -53,12 +62,15 @@ class CODEREVIEW_API ReviewComment : public Super<Model::CompositeNode>
 	PRIVATE_ATTRIBUTE_VALUE(Model::Text, dateString, setDateString, QString)
 
 	public:
+
 		ReviewComment(Comments::CommentNode* commentNode, qint64 date, Model::Node* parent=nullptr);
 		qint64 date();
 		void setDate(qint64 date);
 
 		// TODO move to more fitting place
 		static QString systemUsername();
+
+		bool parseComment(FocusInformation& focusInformation);
 };
 
 inline qint64 ReviewComment::date() { return dateString().toLongLong(); }

--- a/ModelBase/src/model/TreeManager.h
+++ b/ModelBase/src/model/TreeManager.h
@@ -207,6 +207,16 @@ class MODELBASE_API TreeManager: public QObject
 		void setName(const QString& name);
 
 		/**
+		 * Returns the name of the manager.
+		 */
+		QString managerName();
+
+		/**
+		 * Sets the name of the manager.
+		 */
+		void setManagerName(const QString& managerName);
+
+		/**
 		 * Sets the root node of this manager to \a node.
 		 *
 		 * The TreeManager should not have a root node set. This method must be called outside of a modification block.
@@ -378,6 +388,12 @@ class MODELBASE_API TreeManager: public QObject
 		QString name_;
 
 		/**
+		 * Can be used to name the manager itself. This name will be used in the diff to differentiate between old and new
+		 * version manager;
+		 */
+		QString managerName_;
+
+		/**
 		 * The root node for this manager's tree
 		 */
 		Node* root_{};
@@ -489,6 +505,9 @@ inline NodeReadWriteLock* TreeManager::rootLock() { return &rootLock_; }
 inline Node* TreeManager::root(){ return root_; }
 inline QString TreeManager::name() { return name_; }
 inline void TreeManager::setName(const QString& name) { name_ = name; }
+
+inline QString TreeManager::managerName() { return managerName_; }
+inline void TreeManager::setManagerName(const QString& managerName) { managerName_ = managerName; }
 
 inline PersistentStore* TreeManager::store() { return store_; }
 

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -94,9 +94,11 @@ DiffSetup DiffManager::initializeDiffPrerequisites(QString oldVersion, QString n
 
 	// load newer version
 	diffSetup.newVersionManager_ = createTreeManagerFromVersion(diffSetup.repository_, diffSetup.newVersion_);
+	diffSetup.newVersionManager_->setManagerName(project_+"#newVersion");
 
 	// load older version
 	diffSetup.oldVersionManager_ = createTreeManagerFromVersion(diffSetup.repository_, diffSetup.oldVersion_);
+	diffSetup.oldVersionManager_->setManagerName(project_+"#oldVersion");
 
 	Model::Reference::resolvePending();
 


### PR DESCRIPTION
- Add new field managerName_ to TreeManager
- Set manager name for old-/newVersionManager in DiffManager
- Add new attribute managerName to CommentedNode 
- Improve commentedNode loading
- Correct setting of nodeId attribute
- Correct description string for CCodeReview  
- Move creation of overlays after loading of comments to CodeReviewManager
- Initial version of focus feature
- Only execute focus if focusInformation was found
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71662884%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71663068%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71663188%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71664334%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71664384%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71665101%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71665197%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71666295%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71669060%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2095afc27a6750d4817fcbb272cfcd880e534f361f%20VersionControlUI/src/DiffManager.cpp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71663068%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22So%20the%20manager%20name%20includes%20both%20the%20project%20and%20the%20version%20name%3F%20Why%20is%20that%20necessary%3F%20The%20project%20name%20is%20already%20in%20%60manager-%3Ename%28%29%60%3F%22%2C%20%22created_at%22%3A%20%222016-07-21T08%3A08%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Another%20thing%20is%20that%20this%20commit%20should%20have%20ideally%20included%20the%20code%20where%20you%20use%20the%20%60managerName%60%2C%20cause%20right%20now%20you%27re%20just%20setting%20a%20field%20and%20it%20doesn%27t%20become%20clear%20why%20this%20is%20necessary.%20I%27m%20guess%20further%20commits%20will%20make%20this%20clear.%22%2C%20%22created_at%22%3A%20%222016-07-21T08%3A09%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL94-105%22%7D%2C%20%22Pull%20b55bd7f6c968c8bbda0ed433cedd95faf4ab9490%20ModelBase/src/model/TreeManager.h%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71662884%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20like%20the%20name%20of%20this%20field.%20Now%20manager%20has%20the%20%60TreeManager%3A%3Aname%60%20and%20%60TreeManager%3A%3AmanagerName%60%20fields.%20These%20are%20totally%20identical%2C%20unless%20one%20reads%20the%20comments.%20We%20should%20call%20it%20something%20else.%20How%20about%20%60revisionName%60%20or%20is%20there%20an%20even%20more%20precise%20name%3F%22%2C%20%22created_at%22%3A%20%222016-07-21T08%3A06%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20could%20also%20call%20it%20%60revisionName%60%20and%20only%20distinguish%20between%20new%20and%20old.%20That%20would%20also%20work.%5Cr%5CnBTW%3A%20is%20%60TreeManager%3A%3Aname%60%20not%20also%20a%20bad%20name%2C%20since%20it%20is%20not%20the%20name%20of%20the%20manager%20but%20the%20name%20of%20the%20tree%20that%20is%20managed%3F%20%28At%20least%20if%20I%20understood%20correctly%29%22%2C%20%22created_at%22%3A%20%222016-07-21T08%3A24%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22yes%2C%20%60name%60%20is%20also%20not%20ideal%2C%20but%20it%27s%20also%20not%20that%20bad%2C%20since%20a%20manager%27s%20name%20is%20supposed%20to%20be%20the%20name%20of%20the%20top-level%20root%20node.%22%2C%20%22created_at%22%3A%20%222016-07-21T08%3A33%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ModelBase/src/model/TreeManager.h%3AL506-515%22%7D%2C%20%22Pull%20d3d47864b103eb32eacaa82fb9996a43c5a694ef%20CodeReview/src/nodes/CommentedNode.h%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71664334%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Dont%27%20use%20just%20%60ATTRIBUTE%60%2C%20instead%20use%20%60ATTRIBUTE_VALUE%60%20as%20in%20for%20example%20is%20done%20in%20%60Comments%3A%3ACommentFreeNode%60.%20That%20makes%20it%20so%20that%20you%20don%27t%20have%20to%20always%20use%20%60set%60%20and%20%60get%60%20but%20can%20directly%20work%20with%20the%20value.%22%2C%20%22created_at%22%3A%20%222016-07-21T08%3A18%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20should%20also%20do%20this%20for%20the%20%60offsetX/Y%60%20below.%22%2C%20%22created_at%22%3A%20%222016-07-21T08%3A19%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%20nice%2C%20did%20not%20know%20about%20that.%20I%27ll%20change%20it.%22%2C%20%22created_at%22%3A%20%222016-07-21T08%3A25%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/nodes/CommentedNode.h%3AL48-61%22%7D%2C%20%22Pull%20856fbe19d9c04ad42875b218cbcb01513b52a14e%20CodeReview/src/nodes/CommentedNode.cpp%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/433%23discussion_r71669060%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60isEmpty%60%22%2C%20%22created_at%22%3A%20%222016-07-21T08%3A53%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/nodes/CommentedNode.cpp%3AL50-62%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull b55bd7f6c968c8bbda0ed433cedd95faf4ab9490 ModelBase/src/model/TreeManager.h 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/433#discussion_r71662884'>File: ModelBase/src/model/TreeManager.h:L506-515</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> I don't like the name of this field. Now manager has the `TreeManager::name` and `TreeManager::managerName` fields. These are totally identical, unless one reads the comments. We should call it something else. How about `revisionName` or is there an even more precise name?
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> I could also call it `revisionName` and only distinguish between new and old. That would also work.
  BTW: is `TreeManager::name` not also a bad name, since it is not the name of the manager but the name of the tree that is managed? (At least if I understood correctly)
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> yes, `name` is also not ideal, but it's also not that bad, since a manager's name is supposed to be the name of the top-level root node.
- [ ] <a href='#crh-comment-Pull 95afc27a6750d4817fcbb272cfcd880e534f361f VersionControlUI/src/DiffManager.cpp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/433#discussion_r71663068'>File: VersionControlUI/src/DiffManager.cpp:L94-105</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> So the manager name includes both the project and the version name? Why is that necessary? The project name is already in `manager->name()`?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Another thing is that this commit should have ideally included the code where you use the `managerName`, cause right now you're just setting a field and it doesn't become clear why this is necessary. I'm guess further commits will make this clear.
- [ ] <a href='#crh-comment-Pull d3d47864b103eb32eacaa82fb9996a43c5a694ef CodeReview/src/nodes/CommentedNode.h 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/433#discussion_r71664334'>File: CodeReview/src/nodes/CommentedNode.h:L48-61</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Dont' use just `ATTRIBUTE`, instead use `ATTRIBUTE_VALUE` as in for example is done in `Comments::CommentFreeNode`. That makes it so that you don't have to always use `set` and `get` but can directly work with the value.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> You should also do this for the `offsetX/Y` below.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Oh nice, did not know about that. I'll change it.
- [ ] <a href='#crh-comment-Pull 856fbe19d9c04ad42875b218cbcb01513b52a14e CodeReview/src/nodes/CommentedNode.cpp 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/433#discussion_r71669060'>File: CodeReview/src/nodes/CommentedNode.cpp:L50-62</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> `isEmpty`

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/433?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/433?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/433'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
