### PR TITLE
Add function to remove holes from list

### DIFF
--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp
@@ -250,7 +250,7 @@ void ListMergeComponentV2::removeHoles(const QList<Model::NodeIdType> lists, Gen
 			if (fractionalIndexIt == labelsToBeUpdated.constEnd())
 				fractionalIndex = qMakePair(idList.size()-1, offset++);
 			else
-				fractionalIndex = labelsToBeUpdated.constFind(change->newLabel()).value();
+				fractionalIndex = fractionalIndexIt.value();
 
 			auto newLabel = QString::number(fractionalIndex.first) + "." + QString::number(fractionalIndex.second);
 			map.insert(change->nodeId(), {newLabel, change->branches()});

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
@@ -95,9 +95,10 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 										QList<IdPosition>& list, std::shared_ptr<GenericTree> treeBase,  MergeChange::Branches branch);
 
 		/**
-		 * Removes Holes from the list and returns map of labels corresponding to each node in the list
+		 * Removes Holes from the list, makes it continuous and adjusts the CG according to it
+		 * It gives fractional indices for the elements that were supposed to move in or inserted in the holes
 		 */
-		void removeHoles(QList<Model::NodeIdType> lists, std::shared_ptr<GenericTree> tree, ChangeGraph& cg);
+		void removeHoles(QList<Model::NodeIdType> lists, GenericTree* tree, ChangeGraph& cg);
 
 };
 

--- a/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
+++ b/FilePersistence/src/version_control/merge/ListMergeComponentV2.h
@@ -93,6 +93,12 @@ class FILEPERSISTENCE_API ListMergeComponentV2 : public MergePipelineComponent
 		 */
 		void computeOffsetsInBranch(const QList<Model::NodeIdType> base, const QList<Model::NodeIdType> version,
 										QList<IdPosition>& list, std::shared_ptr<GenericTree> treeBase,  MergeChange::Branches branch);
+
+		/**
+		 * Removes Holes from the list and returns map of labels corresponding to each node in the list
+		 */
+		void removeHoles(QList<Model::NodeIdType> lists, std::shared_ptr<GenericTree> tree, ChangeGraph& cg);
+
 };
 
 }


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71863633%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71863662%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71863727%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71864057%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71864201%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71864246%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71864388%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71874285%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23issuecomment-234538895%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23issuecomment-234538895%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-07-22T13%3A07%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2066d212b3b4b20f53cafa3c5f7d90993733e19d27%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71864246%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22instead%20of%20a%20%60shared_ptr%60%20just%20take%20a%20raw%20pointer%20directly.%22%2C%20%22created_at%22%3A%20%222016-07-22T11%3A23%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL206-261%22%7D%2C%20%22Pull%2066d212b3b4b20f53cafa3c5f7d90993733e19d27%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2054%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71864057%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22please%20only%20call%20%60find%60%20once%20and%20assing%20the%20result%20to%20an%20%60auto%60%20value.%20Then%20you%20can%20compare%20this%20to%20%60end%60%20and%20use%20it%20in%20the%20other%20part%20of%20the%20if.%22%2C%20%22created_at%22%3A%20%222016-07-22T11%3A21%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL206-261%22%7D%2C%20%22Pull%2066d212b3b4b20f53cafa3c5f7d90993733e19d27%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2055%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71864201%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20we%20make%20offset%20equal%201%2C%20before%20the%20start%20of%20the%20loop%3F%22%2C%20%22created_at%22%3A%20%222016-07-22T11%3A23%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Offset%20was%20already%20set%20as%20one%20before%20the%20loop%2C%20when%20it%20breaks%20from%20while%20loop%22%2C%20%22created_at%22%3A%20%222016-07-22T11%3A25%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11445667%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Vaishal-shah%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL206-261%22%7D%2C%20%22Pull%2066d212b3b4b20f53cafa3c5f7d90993733e19d27%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71863633%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20function%20doesn%27t%20return%20anything.%20Is%20the%20comment%20correct%3F%22%2C%20%22created_at%22%3A%20%222016-07-22T11%3A16%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Why%20does%20this%20function%20take%20both%20a%20tree%20and%20a%20cg%20as%20input.%20Isn%27t%20the%20CG%20enough%3F%22%2C%20%22created_at%22%3A%20%222016-07-22T11%3A17%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20nevermind%20my%20last%20comment%2C%20I%20got%20confused.%22%2C%20%22created_at%22%3A%20%222016-07-22T11%3A17%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.h%3AL93-105%22%7D%2C%20%22Pull%2088153a2e8af2ed12ac01cfa51cb42dd14c37e520%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%2060%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/436%23discussion_r71874285%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Here%20you%20can%20just%20use%20%60fractionalIndexIt.value%28%29%60.%20This%20is%20why%20I%20mentioned%20before%20that%20you%20should%20assing%20that%20result%20to%20a%20variable%2C%20so%20that%20you%20can%20reuse%20it%20here.%22%2C%20%22created_at%22%3A%20%222016-07-22T13%3A00%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp%3AL206-264%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 66d212b3b4b20f53cafa3c5f7d90993733e19d27 FilePersistence/src/version_control/merge/ListMergeComponentV2.h 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/436#discussion_r71863633'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.h:L93-105</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This function doesn't return anything. Is the comment correct?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why does this function take both a tree and a cg as input. Isn't the CG enough?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Ah nevermind my last comment, I got confused.
- [x] <a href='#crh-comment-Pull 66d212b3b4b20f53cafa3c5f7d90993733e19d27 FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 54'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/436#discussion_r71864057'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L206-261</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> please only call `find` once and assing the result to an `auto` value. Then you can compare this to `end` and use it in the other part of the if.
- [x] <a href='#crh-comment-Pull 66d212b3b4b20f53cafa3c5f7d90993733e19d27 FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 55'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/436#discussion_r71864201'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L206-261</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Shouldn't we make offset equal 1, before the start of the loop?
- <a href='https://github.com/Vaishal-shah'><img border=0 src='https://avatars.githubusercontent.com/u/11445667?v=3' height=16 width=16'></a> Offset was already set as one before the loop, when it breaks from while loop
- [x] <a href='#crh-comment-Pull 66d212b3b4b20f53cafa3c5f7d90993733e19d27 FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/436#discussion_r71864246'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L206-261</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> instead of a `shared_ptr` just take a raw pointer directly.
- [ ] <a href='#crh-comment-Pull 88153a2e8af2ed12ac01cfa51cb42dd14c37e520 FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp 60'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/436#discussion_r71874285'>File: FilePersistence/src/version_control/merge/ListMergeComponentV2.cpp:L206-264</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Here you can just use `fractionalIndexIt.value()`. This is why I mentioned before that you should assing that result to a variable, so that you can reuse it here.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/436#issuecomment-234538895'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks :)

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/436?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/436?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/436'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
