### PR TITLE
Gm focus

### DIFF
--- a/CodeReview/key-bindings/CodeReview.json
+++ b/CodeReview/key-bindings/CodeReview.json
@@ -1,0 +1,3 @@
+{
+	"GenericHandler.FocusStep"	: {"keys":["Ctrl+F12"], "state":"1"}
+}

--- a/CodeReview/src/CodeReviewPlugin.cpp
+++ b/CodeReview/src/CodeReviewPlugin.cpp
@@ -38,6 +38,7 @@
 #include "OOVisualization/src/declarations/VClass.h"
 
 #include "InteractionBase/src/handlers/HSceneHandlerItem.h"
+#include "InteractionBase/src/input_actions/ActionRegistry.h"
 
 #include "SelfTest/src/TestManager.h"
 
@@ -51,6 +52,8 @@ Logger::Log& CodeReviewPlugin::log()
 
 bool CodeReviewPlugin::initialize(Core::EnvisionManager&)
 {
+	Interaction::ActionRegistry::instance()->registerInputHandler("GenericHandler.FocusStep", CFocus::focusStep);
+
 	VersionControlUI::VDiffFrame::setDefaultClassHandler(HReviewableItem::instance());
 	CodeReviewCommentOverlay::setDefaultClassHandler(HCodeReviewOverlay::instance());
 

--- a/CodeReview/src/commands/CCodeReview.cpp
+++ b/CodeReview/src/commands/CCodeReview.cpp
@@ -167,6 +167,9 @@ Interaction::CommandResult* CCodeReview::execute(Visualization::Item* source, Vi
 	// switch to the newly created view
 	Visualization::VisualizationManager::instance().mainScene()->viewItems()->switchToView(reviewViewItem);
 
+	Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
+								  []() { Visualization::MainView::centerAndZoomView();});
+
 	return new Interaction::CommandResult{};
 }
 

--- a/CodeReview/src/commands/CCodeReview.cpp
+++ b/CodeReview/src/commands/CCodeReview.cpp
@@ -168,7 +168,7 @@ Interaction::CommandResult* CCodeReview::execute(Visualization::Item* source, Vi
 	Visualization::VisualizationManager::instance().mainScene()->viewItems()->switchToView(reviewViewItem);
 
 	Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
-								  []() { Visualization::MainView::centerAndZoomView();});
+								  []() { Visualization::MainView::centerAndZoomViewToFitEntireScene();});
 
 	return new Interaction::CommandResult{};
 }

--- a/CodeReview/src/commands/CFocus.cpp
+++ b/CodeReview/src/commands/CFocus.cpp
@@ -121,9 +121,9 @@ CFocus::FocusInformation CFocus::extractFocusInformation(QString line)
 	{
 		auto token = commandTokens.takeFirst();
 
-		if (token.startsWith("h"))
+		if (QString{"highlight"}.startsWith(token))
 			focusInformation.type_ |= FocusInformation::FocusType::Highlight;
-		else if (token.startsWith("c"))
+		else if (QString{"center"}.startsWith(token))
 			focusInformation.type_ |= FocusInformation::FocusType::Center;
 		else
 		{

--- a/CodeReview/src/commands/CFocus.cpp
+++ b/CodeReview/src/commands/CFocus.cpp
@@ -60,16 +60,16 @@ bool CFocus::canInterpret(Visualization::Item*, Visualization::Item*,
 	return false;
 }
 
-Interaction::CommandResult* CFocus::execute(Visualization::Item*, Visualization::Item*,
+Interaction::CommandResult* CFocus::execute(Visualization::Item* source, Visualization::Item*,
 				const QStringList&, const std::unique_ptr<Visualization::Cursor>&)
 {
-	focusStep({}, {}, {});
+	focusStep(source, {}, {});
 	return new Interaction::CommandResult{};
 }
 
-bool CFocus::focusStep(Visualization::Item *, QKeySequence, Interaction::ActionRegistry::InputState)
+bool CFocus::focusStep(Visualization::Item* target, QKeySequence, Interaction::ActionRegistry::InputState)
 {
-	Visualization::VisualizationManager::instance().mainScene()->removeOverlayGroup("focusOverlay");
+	target->scene()->removeOverlayGroup("focusOverlay");
 
 	auto focusInformations = focusList_.values(currentStep_);
 

--- a/CodeReview/src/commands/CFocus.cpp
+++ b/CodeReview/src/commands/CFocus.cpp
@@ -46,6 +46,8 @@ using namespace Visualization;
 
 namespace CodeReview {
 
+int CFocus::currentStep_{0};
+
 CFocus::CFocus() : Command{"focus"} {}
 
 QHash<int, CFocus::FocusInformation> CFocus::focusList_;
@@ -61,41 +63,44 @@ bool CFocus::canInterpret(Visualization::Item*, Visualization::Item*,
 Interaction::CommandResult* CFocus::execute(Visualization::Item*, Visualization::Item*,
 				const QStringList&, const std::unique_ptr<Visualization::Cursor>&)
 {
+	focusStep({}, {}, {});
+	return new Interaction::CommandResult{};
+}
 
+bool CFocus::focusStep(Visualization::Item *, QKeySequence, Interaction::ActionRegistry::InputState)
+{
 	Visualization::VisualizationManager::instance().mainScene()->removeOverlayGroup("focusOverlay");
 
-	auto focusInformation = focusList_.value(currentStep_);
+	auto focusInformations = focusList_.values(currentStep_);
 
-	if (focusInformation.type_ == FocusInformation::None){
+	if (focusInformations.isEmpty()){
 		currentStep_ = 0;
-		focusInformation = focusList_.value(currentStep_);
+		focusInformations = focusList_.values(currentStep_);
 	}
 
-	if (focusInformation.type_ == FocusInformation::None)
-		return new Interaction::CommandResult{};
+	if (focusInformations.isEmpty())
+		return false;
 
-	auto focusItem = CodeReviewManager::instance().overlayForNodeReviews(focusInformation.node_);
+	for (auto focusInformation : focusInformations)
+	{
 
-	switch (focusInformation.type_) {
-		case FocusInformation::Center:
-			Visualization::VisualizationManager::instance().mainView()->
-					centerOn(focusItem);
-			break;
-		case FocusInformation::Highlight:
+		auto focusItem = CodeReviewManager::instance().overlayForNodeReviews(focusInformation.node_);
+
+		if (focusInformation.type_.testFlag(FocusInformation::Center))
+		{
+			Visualization::VisualizationManager::instance().mainView()->centerOn(focusItem);
+		}
+
+		if (focusInformation.type_.testFlag(FocusInformation::Highlight))
 		{
 			auto overlay = new Visualization::HighlightOverlay{focusItem,
 					Visualization::HighlightOverlay::itemStyles().get("focus")};
 			focusItem->addOverlay(overlay, "focusOverlay");
-			break;
 		}
-		default:
-			Q_ASSERT(false);
-			break;
 	}
 
 	currentStep_++;
-
-	return new Interaction::CommandResult{};
+	return true;
 }
 
 QList<Interaction::CommandSuggestion*> CFocus::suggest(Visualization::Item*, Visualization::Item*,
@@ -108,59 +113,45 @@ QList<Interaction::CommandSuggestion*> CFocus::suggest(Visualization::Item*, Vis
 
 CFocus::FocusInformation CFocus::extractFocusInformation(QString line)
 {
-	if (line.startsWith("[focus"))
+	QStringList commandTokens = line.split(" ");
+
+	FocusInformation focusInformation;
+
+	while (!commandTokens.isEmpty())
 	{
-		auto endOfCommand = line.indexOf("]");
-		// subtract one because of starting [
-		auto commandSize = endOfCommand - 1;
-		auto commandText = line.mid(1, commandSize);
-		QStringList commandTokens = commandText.split("|");
+		auto token = commandTokens.takeFirst();
 
-		// remove first token which is "focus"
-		commandTokens.pop_front();
-
-		FocusInformation focusInformation;
-
-		if (!commandTokens.isEmpty())
+		if (token.startsWith("h"))
+			focusInformation.type_ |= FocusInformation::FocusType::Highlight;
+		else if (token.startsWith("c"))
+			focusInformation.type_ |= FocusInformation::FocusType::Center;
+		else
 		{
-			auto token = commandTokens.takeFirst();
-			if (token.startsWith("hi"))
-				focusInformation.type_ = FocusInformation::FocusType::Highlight;
-			else if (token.startsWith("ce"))
-				focusInformation.type_ = FocusInformation::FocusType::Center;
+			bool isNumber;
+			auto step = token.toInt(&isNumber);
+
+			if (isNumber)
+			{
+				focusInformation.step_ = step;
+				break;
+			}
 		}
 
-		if (!commandTokens.isEmpty())
-		{
-			auto stepToken = commandTokens.takeFirst();
-			focusInformation.step_ = stepToken.toInt();
-		}
-		return focusInformation;
 	}
 
-	return {};
+	return focusInformation;
 }
 
 void CFocus::loadFocusInformation()
 {
 	for (NodeReviews* nodeReviews : *CodeReviewManager::instance().nodeReviewsList())
 	{
-		if (nodeReviews->reviewComments()->isEmpty())
-			continue;
+		auto focusInformation = extractFocusInformation(nodeReviews->focusInformation());
 
-		auto firstComment = nodeReviews->reviewComments()->first()->commentNode();
-
-		if (firstComment->lines()->isEmpty())
-			continue;
-
-		auto firstLine = firstComment->lines()->first()->get();
-
-		auto focusInformation = extractFocusInformation(firstLine);
-
-		if (focusInformation.type_ != FocusInformation::None)
+		if (!focusInformation.type_.testFlag(FocusInformation::None))
 		{
 			focusInformation.node_ = nodeReviews;
-			focusList_.insert(focusInformation.step_, focusInformation);
+			focusList_.insertMulti(focusInformation.step_, focusInformation);
 		}
 	}
 }

--- a/CodeReview/src/commands/CFocus.cpp
+++ b/CodeReview/src/commands/CFocus.cpp
@@ -148,7 +148,7 @@ void CFocus::loadFocusInformation()
 	{
 		auto focusInformation = extractFocusInformation(nodeReviews->focusInformation());
 
-		if (!focusInformation.type_.testFlag(FocusInformation::None))
+		if (focusInformation.isValid())
 		{
 			focusInformation.node_ = nodeReviews;
 			focusList_.insertMulti(focusInformation.step_, focusInformation);

--- a/CodeReview/src/commands/CFocus.h
+++ b/CodeReview/src/commands/CFocus.h
@@ -47,9 +47,11 @@ class CODEREVIEW_API CFocus : public Interaction::Command
 
 			using FocusTypes = QFlags<FocusType>;
 
-			int step_{};
+			int step_{-1};
 			FocusTypes type_{};
 			Model::Node* node_{};
+
+			bool isValid() { return (step_ != -1 && !type_.testFlag(None)); }
 		};
 
 		CFocus();

--- a/CodeReview/src/commands/CFocus.h
+++ b/CodeReview/src/commands/CFocus.h
@@ -29,6 +29,7 @@
 #include "../codereview_api.h"
 
 #include "InteractionBase/src/commands/CommandWithFlags.h"
+#include "InteractionBase/src/input_actions/ActionRegistry.h"
 
 namespace CodeReview {
 
@@ -38,10 +39,16 @@ class CODEREVIEW_API CFocus : public Interaction::Command
 
 		struct FocusInformation
 		{
-			enum FocusType {None, Center, Highlight};
+			enum FocusType {
+				None = 0x0,
+				Center = 0x1,
+				Highlight= 0x2
+			};
+
+			using FocusTypes = QFlags<FocusType>;
 
 			int step_{};
-			FocusType type_{};
+			FocusTypes type_{};
 			Model::Node* node_{};
 		};
 
@@ -59,14 +66,18 @@ class CODEREVIEW_API CFocus : public Interaction::Command
 
 		static void clearFocusInformation();
 
+		static bool focusStep(Visualization::Item *, QKeySequence, Interaction::ActionRegistry::InputState);
 
 	private:
-		int currentStep_{0};
+		static int currentStep_;
 		static QHash<int, FocusInformation> focusList_;
 		static FocusInformation extractFocusInformation(QString line);
 
 };
 
+Q_DECLARE_OPERATORS_FOR_FLAGS(CFocus::FocusInformation::FocusTypes)
+
 inline void CFocus::clearFocusInformation() { focusList_.clear(); }
+
 
 }

--- a/CodeReview/src/items/VNodeReviews.cpp
+++ b/CodeReview/src/items/VNodeReviews.cpp
@@ -54,13 +54,37 @@ Visualization::Item::UpdateType VNodeReviews::needsUpdate()
 
 void VNodeReviews::initializeForms()
 {
+	auto focusInformation = item<Visualization::VText>(&I::focusInformation_, [](I* v) {
+			return v->node()->focusInformationNode();}, &StyleType::focusInformation);
+
+	auto headerElement = (new Visualization::GridLayoutFormElement{})
+				->setMargins(5, 5, 5, 5)
+				->setHorizontalSpacing(10)
+				->setColumnStretchFactor(0, 1)
+				->setColumnStretchFactor(1, 1)
+				->setColumnHorizontalAlignment(1, Visualization::LayoutStyle::Alignment::Right)
+				->setVerticalAlignment(Visualization::LayoutStyle::Alignment::Center)
+				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
+				->put(0, 0, item<Visualization::Static>(&I::icon_, &StyleType::icon))
+				->put(1, 0, focusInformation);
+
 	auto comments = item<Visualization::VList>(&I::comments_, [](I* v) {
 			return v->node()->reviewComments();}, &StyleType::comments);
-	auto grid = (new Visualization::GridLayoutFormElement{})
+
+	auto innerGrid = (new Visualization::GridLayoutFormElement{})
 			->setHorizontalAlignment(Visualization::LayoutStyle::Alignment::Center)
 			->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
 			->setColumnStretchFactor(0, 1)
 			->put(0, 0, comments);
+
+	auto grid = (new Visualization::GridLayoutFormElement{})
+							->setColumnStretchFactor(0, 1)
+							->setMargins(5, 5, 5, 5)
+							->setVerticalAlignment(Visualization::LayoutStyle::Alignment::Center)
+							->setNoBoundaryCursors([](Item*){return true;})
+							->setNoInnerCursors([](Item*){return true;})
+							->put(0, 0, headerElement)
+							->put(0, 1, innerGrid);
 
 	addForm(grid);
 }

--- a/CodeReview/src/items/VNodeReviews.h
+++ b/CodeReview/src/items/VNodeReviews.h
@@ -28,17 +28,15 @@
 
 #include "../codereview_api.h"
 
-#include "VisualizationBase/src/items/ItemWithNode.h"
-#include "VisualizationBase/src/items/VList.h"
-
-#include "VisualizationBase/src/declarative/DeclarativeItem.h"
-#include "VisualizationBase/src/declarative/DeclarativeItemBaseStyle.h"
 #include "VNodeReviewsStyle.h"
-
 #include "../nodes/NodeReviews.h"
 
 #include "VisualizationBase/src/items/Item.h"
-
+#include "VisualizationBase/src/items/ItemWithNode.h"
+#include "VisualizationBase/src/items/VList.h"
+#include "VisualizationBase/src/items/VText.h"
+#include "VisualizationBase/src/declarative/DeclarativeItem.h"
+#include "VisualizationBase/src/declarative/DeclarativeItemBaseStyle.h"
 
 namespace CodeReview
 {
@@ -57,6 +55,9 @@ class CODEREVIEW_API VNodeReviews : public Super<Visualization::ItemWithNode<VNo
 
 	private:
 		Visualization::VList* comments_{};
+		Visualization::Static* title_{};
+		Visualization::Static* icon_{};
+		Visualization::VText* focusInformation_{};
 };
 
 }

--- a/CodeReview/src/items/VNodeReviewsStyle.h
+++ b/CodeReview/src/items/VNodeReviewsStyle.h
@@ -41,11 +41,9 @@ class CODEREVIEW_API VNodeReviewsStyle : public Super<Visualization::Declarative
 	public:
 		virtual ~VNodeReviewsStyle() override;
 		Property<Visualization::VListStyle> comments{this, "comments"};
-		Property<Visualization::TextStyle> commentInput{this, "commentInput"};
 		Property<Visualization::TextStyle> focusInformation{this, "focusInformation"};
 		Property<Visualization::StaticStyle> icon{this, "icon"};
 		Property<Visualization::StaticStyle> title{this, "title"};
-
 };
 
 }

--- a/CodeReview/src/items/VNodeReviewsStyle.h
+++ b/CodeReview/src/items/VNodeReviewsStyle.h
@@ -30,6 +30,8 @@
 
 #include "VisualizationBase/src/declarative/DeclarativeItemBaseStyle.h"
 #include "VisualizationBase/src/items/VListStyle.h"
+#include "VisualizationBase/src/items/TextStyle.h"
+#include "VisualizationBase/src/items/Static.h"
 
 namespace CodeReview
 {
@@ -39,6 +41,10 @@ class CODEREVIEW_API VNodeReviewsStyle : public Super<Visualization::Declarative
 	public:
 		virtual ~VNodeReviewsStyle() override;
 		Property<Visualization::VListStyle> comments{this, "comments"};
+		Property<Visualization::TextStyle> commentInput{this, "commentInput"};
+		Property<Visualization::TextStyle> focusInformation{this, "focusInformation"};
+		Property<Visualization::StaticStyle> icon{this, "icon"};
+		Property<Visualization::StaticStyle> title{this, "title"};
 
 };
 

--- a/CodeReview/src/nodes/NodeReviews.cpp
+++ b/CodeReview/src/nodes/NodeReviews.cpp
@@ -37,6 +37,7 @@ DEFINE_COMPOSITE_TYPE_REGISTRATION_METHODS(NodeReviews)
 
 DEFINE_ATTRIBUTE(NodeReviews, nodeId, Text, false, false, true)
 DEFINE_ATTRIBUTE(NodeReviews, revisionName, Text, false, false, true)
+DEFINE_ATTRIBUTE(NodeReviews, focusInformation, Text, false, false, true)
 DEFINE_ATTRIBUTE(NodeReviews, reviewComments, TypedListOfReviewComment, false, false, true)
 DEFINE_ATTRIBUTE(NodeReviews, offsetX, Integer, false, false, true)
 DEFINE_ATTRIBUTE(NodeReviews, offsetY, Integer, false, false, true)

--- a/CodeReview/src/nodes/NodeReviews.h
+++ b/CodeReview/src/nodes/NodeReviews.h
@@ -49,6 +49,7 @@ class CODEREVIEW_API NodeReviews : public Super<Model::CompositeNode>
 
 	ATTRIBUTE_VALUE(Model::Text, nodeId, setNodeId, QString)
 	ATTRIBUTE_VALUE(Model::Text, revisionName, setRevisionName, QString)
+	ATTRIBUTE_VALUE(Model::Text, focusInformation, setFocusInformation, QString)
 	ATTRIBUTE(Model::TypedList<CodeReview::ReviewComment>, reviewComments, setReviewComments)
 	ATTRIBUTE_VALUE(Model::Integer, offsetX, setOffsetX, int)
 	ATTRIBUTE_VALUE(Model::Integer, offsetY, setOffsetY, int)

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -60,25 +60,7 @@ void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableH
 
 void CodeReviewCommentOverlay::initializeForms()
 {
-	auto headerElement = (new Visualization::GridLayoutFormElement{})
-				->setHorizontalSpacing(10)
-				->setColumnStretchFactor(0, 1)
-				->setColumnStretchFactor(3, 1)
-				->setVerticalAlignment(Visualization::LayoutStyle::Alignment::Center)
-				->setNoBoundaryCursors([](Item*){return true;})->setNoInnerCursors([](Item*){return true;})
-				->put(1, 0, item<Visualization::Static>(&I::icon_, &StyleType::icon));
-
-	auto grid = (new Visualization::GridLayoutFormElement{})
-							->setColumnStretchFactor(0, 1)
-							->setMargins(5, 5, 5, 5)
-							->setVerticalAlignment(Visualization::LayoutStyle::Alignment::Center)
-							->setNoBoundaryCursors([](Item*){return true;})
-							->setNoInnerCursors([](Item*){return true;})
-							->put(0, 0, headerElement)
-							->put(0, 1, item(&I::nodeReviewsItem_, [](I* v) {return v->nodeReviews_;}));
-
-	addForm(grid);
-
+	addForm(item(&I::nodeReviewsItem_, [](I* v) {return v->nodeReviews_;}));
 }
 
 void CodeReviewCommentOverlay::updateOffsetItemLocal(QPointF scenePos)

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.h
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.h
@@ -28,7 +28,6 @@
 
 #include "../codereview_api.h"
 
-#include "VisualizationBase/src/items/Text.h"
 #include "VisualizationBase/src/overlays/Overlay.h"
 #include "VisualizationBase/src/declarative/DeclarativeItem.h"
 
@@ -58,9 +57,6 @@ class CODEREVIEW_API CodeReviewCommentOverlay :
 	private:
 		NodeReviews* nodeReviews_{};
 		Visualization::Item* nodeReviewsItem_{};
-
-		Visualization::Static* title_{};
-		Visualization::Static* icon_{};
 
 		QPointF offsetItemLocal_;
 

--- a/CodeReview/src/overlays/CodeReviewCommentOverlayStyle.h
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlayStyle.h
@@ -29,8 +29,6 @@
 #include "../codereview_api.h"
 
 #include "VisualizationBase/src/declarative/DeclarativeItemBaseStyle.h"
-#include "VisualizationBase/src/items/TextStyle.h"
-#include "VisualizationBase/src/items/Static.h"
 
 namespace CodeReview
 {
@@ -39,10 +37,6 @@ class CODEREVIEW_API CodeReviewCommentOverlayStyle : public Super<Visualization:
 {
 	public:
 		virtual ~CodeReviewCommentOverlayStyle() override;
-
-		Property<Visualization::TextStyle> commentInput{this, "commentInput"};
-		Property<Visualization::StaticStyle> icon{this, "icon"};
-		Property<Visualization::StaticStyle> title{this, "title"};
 
 };
 }

--- a/CodeReview/styles/item/CodeReviewCommentOverlay/default
+++ b/CodeReview/styles/item/CodeReviewCommentOverlay/default
@@ -8,13 +8,4 @@
 			<color>#ffffff</color>
 		</backgroundBrush>
 	</shape>
-	<commentInput prototypes="item/Text/default" />
-	<title prototypes="item/Symbol/keyword">
-		<symbol>Review Comment</symbol>
-	</title>
-	<icon prototypes="icon/SVGIcon/default">
-		<filename>styles/icon/speech_bubble.svg</filename>
-		<width>24</width>
-		<height>24</height>
-	</icon>
 </style>

--- a/CodeReview/styles/item/VNodeReviews/default
+++ b/CodeReview/styles/item/VNodeReviews/default
@@ -16,7 +16,6 @@
 		</shape>
 		<useBackgroundColors>false</useBackgroundColors>
 	</comments>
-	<commentInput prototypes="item/Text/default" />
 	<focusInformation prototypes="item/Text/codeReviewHeaderText" />
 	<title prototypes="item/Symbol/keyword">
 		<symbol>Review Comment</symbol>

--- a/CodeReview/styles/item/VNodeReviews/default
+++ b/CodeReview/styles/item/VNodeReviews/default
@@ -16,4 +16,14 @@
 		</shape>
 		<useBackgroundColors>false</useBackgroundColors>
 	</comments>
+	<commentInput prototypes="item/Text/default" />
+	<focusInformation prototypes="item/Text/codeReviewHeaderText" />
+	<title prototypes="item/Symbol/keyword">
+		<symbol>Review Comment</symbol>
+	</title>
+	<icon prototypes="icon/SVGIcon/default">
+		<filename>styles/icon/speech_bubble.svg</filename>
+		<width>24</width>
+		<height>24</height>
+	</icon>
 </style>

--- a/InteractionBase/src/commands/CSceneHandlerLoad.cpp
+++ b/InteractionBase/src/commands/CSceneHandlerLoad.cpp
@@ -55,7 +55,7 @@ CommandResult* CSceneHandlerLoad::executeNamed(Visualization::Item*, Visualizati
 
 		if (attributes.contains("quick")) mainScene->setApproximateUpdate(true);
 
-		Visualization::MainView::centerAndZoomView();
+		Visualization::MainView::centerAndZoomViewToFitEntireScene();
 
 	}
 

--- a/InteractionBase/src/commands/CSceneHandlerLoad.cpp
+++ b/InteractionBase/src/commands/CSceneHandlerLoad.cpp
@@ -55,26 +55,8 @@ CommandResult* CSceneHandlerLoad::executeNamed(Visualization::Item*, Visualizati
 
 		if (attributes.contains("quick")) mainScene->setApproximateUpdate(true);
 
-		// Center view and zoom so that the entire project is within the window
-		mainScene->updateNow();
-		for (auto v : mainScene->views())
-			if (auto mainView = dynamic_cast<Visualization::MainView*>(v))
-			{
-				auto size = mainView->viewport()->size();
+		Visualization::MainView::centerAndZoomView();
 
-				double sceneHeight = mainScene->sceneRect().height();
-				double scale = 1;
-				int scaleLevel = 2;
-				while (sceneHeight*scale >= size.height())
-				{
-					scaleLevel++;
-					scale *= 0.5;
-				}
-
-				mainView->zoom(scaleLevel);
-				mainView->centerOn(mainScene->sceneRect().center());
-				break;
-			}
 	}
 
 	return new CommandResult{};

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -400,6 +400,9 @@ void DiffManager::showDiff(QString oldVersion, QString newVersion)
 
 	// switch to the newly created view
 	Visualization::VisualizationManager::instance().mainScene()->viewItems()->switchToView(diffViewItem);
+
+	Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
+								  []() { Visualization::MainView::centerAndZoomView();});
 }
 
 void DiffManager::createOverlaysForChanges(QList<ChangeWithNodes> changesWithNodes, Visualization::ViewItem* viewItem,
@@ -553,6 +556,9 @@ void DiffManager::showNodeHistory(Model::NodeIdType targetNodeID, QList<QString>
 
 	// switch to the newly created view
 	Visualization::VisualizationManager::instance().mainScene()->viewItems()->switchToView(historyViewItem);
+
+	Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
+								  []() { Visualization::MainView::centerAndZoomView();});
 }
 
 // TODO maybe better implementation for this
@@ -767,14 +773,6 @@ void DiffManager::createOverlaysForChanges(Visualization::ViewItem* diffViewItem
 	}
 
 	scaleItems(allItemsToScale, diffViewItem);
-
-	// set zoom level further out and center the scene
-	Visualization::VisualizationManager::instance().mainView()->zoom(7);
-	auto centerTop = Visualization::VisualizationManager::instance().mainScene()->
-			currentViewItem()->boundingRect().center();
-	centerTop.setY(Visualization::VisualizationManager::instance().mainScene()->
-						currentViewItem()->boundingRect().top());
-	Visualization::VisualizationManager::instance().mainView()->centerOn(centerTop);
 }
 
 Visualization::Item* DiffManager::addOverlaysAndReturnItem(Model::Node* node, Visualization::ViewItem* viewItem,

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -402,7 +402,7 @@ void DiffManager::showDiff(QString oldVersion, QString newVersion)
 	Visualization::VisualizationManager::instance().mainScene()->viewItems()->switchToView(diffViewItem);
 
 	Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
-								  []() { Visualization::MainView::centerAndZoomView();});
+								  []() { Visualization::MainView::centerAndZoomViewToFitEntireScene();});
 }
 
 void DiffManager::createOverlaysForChanges(QList<ChangeWithNodes> changesWithNodes, Visualization::ViewItem* viewItem,
@@ -558,7 +558,7 @@ void DiffManager::showNodeHistory(Model::NodeIdType targetNodeID, QList<QString>
 	Visualization::VisualizationManager::instance().mainScene()->viewItems()->switchToView(historyViewItem);
 
 	Visualization::VisualizationManager::instance().mainScene()->addPostEventAction(
-								  []() { Visualization::MainView::centerAndZoomView();});
+								  []() { Visualization::MainView::centerAndZoomViewToFitEntireScene();});
 }
 
 // TODO maybe better implementation for this

--- a/VisualizationBase/src/views/MainView.cpp
+++ b/VisualizationBase/src/views/MainView.cpp
@@ -65,6 +65,31 @@ void MainView::setMiniMapSize(int width, int height)
 	}
 }
 
+void MainView::centerAndZoomView()
+{
+	auto mainScene = VisualizationManager::instance().mainScene();
+	// Center view and zoom so that the entire project is within the window
+	mainScene->updateNow();
+	for (auto v : mainScene->views())
+		if (auto mainView = dynamic_cast<Visualization::MainView*>(v))
+		{
+			auto size = mainView->viewport()->size();
+
+			double sceneHeight = mainScene->sceneRect().height();
+			double scale = 1;
+			int scaleLevel = 2;
+			while (sceneHeight*scale >= size.height())
+			{
+				scaleLevel++;
+				scale *= 0.5;
+			}
+
+			mainView->zoom(scaleLevel);
+			mainView->centerOn(mainScene->sceneRect().center());
+			break;
+		}
+}
+
 bool MainView::event( QEvent *event )
 {
 	bool result = false;

--- a/VisualizationBase/src/views/MainView.cpp
+++ b/VisualizationBase/src/views/MainView.cpp
@@ -65,7 +65,7 @@ void MainView::setMiniMapSize(int width, int height)
 	}
 }
 
-void MainView::centerAndZoomView()
+void MainView::centerAndZoomViewToFitEntireScene()
 {
 	auto mainScene = VisualizationManager::instance().mainScene();
 	// Center view and zoom so that the entire project is within the window

--- a/VisualizationBase/src/views/MainView.h
+++ b/VisualizationBase/src/views/MainView.h
@@ -49,7 +49,7 @@ class VISUALIZATIONBASE_API MainView: public View
 		static const int MINIMAP_DEFAULT_HEIGHT = 200;
 		static const int PNG_SCREENSHOT_SCALE = 8;
 
-		static void centerAndZoomView();
+		static void centerAndZoomViewToFitEntireScene();
 
 		qreal scaleFactor() const;
 

--- a/VisualizationBase/src/views/MainView.h
+++ b/VisualizationBase/src/views/MainView.h
@@ -49,6 +49,8 @@ class VISUALIZATIONBASE_API MainView: public View
 		static const int MINIMAP_DEFAULT_HEIGHT = 200;
 		static const int PNG_SCREENSHOT_SCALE = 8;
 
+		static void centerAndZoomView();
+
 		qreal scaleFactor() const;
 
 	protected:


### PR DESCRIPTION
- Improve focus handling:
  - Have new attribute in NodeReviews to store focusInformation
  - Move visualization of header to VNodeReviews
  - Added keyboard shortcut ctrl+F12 to perform focus step
  - Changed syntax for focusInformation
  - Allow multiple FocusInformation entries for the same step
  - Allow FocusTypes to be combined
- Move functionality to center and zoom view from CSceneHandlerLoad to MainView
- Use functionality after loading Diff, History and Review
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72472939%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72473106%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72473365%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72473529%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72473808%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72474024%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72474036%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72474398%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72474539%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72474657%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72475197%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23issuecomment-235644634%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72580836%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72580845%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72581204%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72581322%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72581569%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23issuecomment-235835926%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23issuecomment-235644634%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Alright%2C%20I%27m%20done%20with%20the%20review.%20Mostly%20smaller%20tweaks%20are%20needed.%22%2C%20%22created_at%22%3A%20%222016-07-27T16%3A39%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%22%2C%20%22created_at%22%3A%20%222016-07-28T08%3A45%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20e67b8a190f987714f943fbaec748dca426921359%20VisualizationBase/src/views/MainView.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72475197%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20rename%20this%20to%20%60centerAndZoomViewToFitEntireScene%60%22%2C%20%22created_at%22%3A%20%222016-07-27T16%3A38%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VisualizationBase/src/views/MainView.h%3AL49-57%22%7D%2C%20%22Pull%20f9cd2f26079e5fb6a60f75a60348266301469a79%20CodeReview/src/commands/CFocus.cpp%20146%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72474539%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20best%20option%20is%20to%20add%20%60isValid%60%20method%20to%20%60FocusInformation%60%20and%20define%20there%20what%20that%20means%2C%20not%20here.%22%2C%20%22created_at%22%3A%20%222016-07-27T16%3A34%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CFocus.cpp%3AL113-158%22%7D%2C%20%22Pull%20f9cd2f26079e5fb6a60f75a60348266301469a79%20CodeReview/src/commands/CFocus.cpp%20125%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72474398%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Perhaps%20before%20returning%20this%2C%20you%20should%20make%20sure%20that%20it%20is%20valid%3F%20This%20is%20just%20to%20future%20proof%20the%20system.%20If%20you%20make%20the%20FocusInfo%20have%20%60None%60%20as%20type%20by%20default%2C%20and%20%60-1%60%20as%20the%20step.%20Then%20a%20valid%20focus%20info%20is%20one%20which%20has%20both%20of%20these%20different.%22%2C%20%22created_at%22%3A%20%222016-07-27T16%3A33%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CFocus.cpp%3AL113-158%22%7D%2C%20%22Pull%20f9cd2f26079e5fb6a60f75a60348266301469a79%20CodeReview/src/items/VNodeReviewsStyle.h%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72472939%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20property%20seems%20to%20be%20unused%20%28also%20before%20the%20current%20change%29.%20Delete%20it.%22%2C%20%22created_at%22%3A%20%222016-07-27T16%3A24%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/items/VNodeReviewsStyle.h%3AL41-51%22%7D%2C%20%22Pull%20f9cd2f26079e5fb6a60f75a60348266301469a79%20CodeReview/src/commands/CFocus.h%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72474657%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20step%20above%2C%20should%20probably%20be%20%60-1%60%20by%20default%2C%20also%20indicating%20an%20invalid%20info.%22%2C%20%22created_at%22%3A%20%222016-07-27T16%3A35%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CFocus.h%3AL39-55%22%7D%2C%20%22Pull%20f9cd2f26079e5fb6a60f75a60348266301469a79%20CodeReview/src/commands/CFocus.cpp%2095%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72474024%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20the%20better%20condition%3A%20%60if%20%28QString%7B%5C%22highlight%5C%22%7D.startsWith%28token%29%29%60%22%2C%20%22created_at%22%3A%20%222016-07-27T16%3A31%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CFocus.cpp%3AL113-158%22%7D%2C%20%22Pull%20f9cd2f26079e5fb6a60f75a60348266301469a79%20CodeReview/src/commands/CFocus.cpp%2053%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72473808%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20somewhere%2C%20we%20should%20remove%20the%20highlights%20of%20the%20previous%20step.%20Please%20add%20that%20code%20and%20test%20it.%22%2C%20%22created_at%22%3A%20%222016-07-27T16%3A30%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22At%20the%20beginning%20of%20the%20method%20I%20call%20%60removeOverlayGroup%28%5C%22focusOverlay%5C%22%29%60.%20This%20seems%20to%20work.%22%2C%20%22created_at%22%3A%20%222016-07-28T08%3A14%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20indeed.%20I%20missed%20that%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-07-28T08%3A17%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CFocus.cpp%3AL63-107%22%7D%2C%20%22Pull%20f9cd2f26079e5fb6a60f75a60348266301469a79%20CodeReview/src/commands/CFocus.cpp%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72473365%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Instead%20of%20using%20the%20%60mainScene%60%20use%20the%20scene%20of%20the%20%60target%60%20argument%2C%20which%20you%27re%20currently%20not%20using.%22%2C%20%22created_at%22%3A%20%222016-07-27T16%3A27%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20should%20also%20make%20it%20unnecessary%20to%20%60%23include%20%5C%22VisualizationBase/src/VisualizationManager.h%5C%22%60%22%2C%20%22created_at%22%3A%20%222016-07-27T16%3A28%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20also%20use%20%60Visualization%3A%3AVisualizationManager%3A%3Ainstance%28%29.mainView%28%29-%3EcenterOn%28focusItem%29%3B%60.%20Is%20there%20also%20a%20way%20to%20do%20this%20using%20target%3F%22%2C%20%22created_at%22%3A%20%222016-07-28T08%3A14%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20for%20that%20you%20should%20better%20keep%20using%20your%20current%20approach%20%28and%20keep%20the%20include%29%2C%20but%20still%20use%20the%20target%27s%20scene%20for%20the%20line%20below.%22%2C%20%22created_at%22%3A%20%222016-07-28T08%3A18%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20will%20do.%22%2C%20%22created_at%22%3A%20%222016-07-28T08%3A19%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CFocus.cpp%3AL63-107%22%7D%2C%20%22Pull%20f9cd2f26079e5fb6a60f75a60348266301469a79%20CodeReview/src/commands/CFocus.cpp%2097%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72474036%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Like%20above.%22%2C%20%22created_at%22%3A%20%222016-07-27T16%3A31%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/src/commands/CFocus.cpp%3AL113-158%22%7D%2C%20%22Pull%20f9cd2f26079e5fb6a60f75a60348266301469a79%20CodeReview/styles/item/VNodeReviews/default%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/438%23discussion_r72473106%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22remove%22%2C%20%22created_at%22%3A%20%222016-07-27T16%3A25%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20CodeReview/styles/item/VNodeReviews/default%3AL16-30%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull f9cd2f26079e5fb6a60f75a60348266301469a79 CodeReview/src/items/VNodeReviewsStyle.h 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/438#discussion_r72472939'>File: CodeReview/src/items/VNodeReviewsStyle.h:L41-51</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> This property seems to be unused (also before the current change). Delete it.
- [ ] <a href='#crh-comment-Pull f9cd2f26079e5fb6a60f75a60348266301469a79 CodeReview/styles/item/VNodeReviews/default 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/438#discussion_r72473106'>File: CodeReview/styles/item/VNodeReviews/default:L16-30</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> remove
- [ ] <a href='#crh-comment-Pull f9cd2f26079e5fb6a60f75a60348266301469a79 CodeReview/src/commands/CFocus.cpp 18'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/438#discussion_r72473365'>File: CodeReview/src/commands/CFocus.cpp:L63-107</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Instead of using the `mainScene` use the scene of the `target` argument, which you're currently not using.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> That should also make it unnecessary to `#include "VisualizationBase/src/VisualizationManager.h"`
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> I also use `Visualization::VisualizationManager::instance().mainView()->centerOn(focusItem);`. Is there also a way to do this using target?
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, for that you should better keep using your current approach (and keep the include), but still use the target's scene for the line below.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Ok, will do.
- [ ] <a href='#crh-comment-Pull f9cd2f26079e5fb6a60f75a60348266301469a79 CodeReview/src/commands/CFocus.cpp 53'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/438#discussion_r72473808'>File: CodeReview/src/commands/CFocus.cpp:L63-107</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Hmm, somewhere, we should remove the highlights of the previous step. Please add that code and test it.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> At the beginning of the method I call `removeOverlayGroup("focusOverlay")`. This seems to work.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Yes indeed. I missed that :)
- [ ] <a href='#crh-comment-Pull f9cd2f26079e5fb6a60f75a60348266301469a79 CodeReview/src/commands/CFocus.cpp 95'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/438#discussion_r72474024'>File: CodeReview/src/commands/CFocus.cpp:L113-158</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Use the better condition: `if (QString{"highlight"}.startsWith(token))`
- [ ] <a href='#crh-comment-Pull f9cd2f26079e5fb6a60f75a60348266301469a79 CodeReview/src/commands/CFocus.cpp 97'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/438#discussion_r72474036'>File: CodeReview/src/commands/CFocus.cpp:L113-158</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Like above.
- [ ] <a href='#crh-comment-Pull f9cd2f26079e5fb6a60f75a60348266301469a79 CodeReview/src/commands/CFocus.cpp 125'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/438#discussion_r72474398'>File: CodeReview/src/commands/CFocus.cpp:L113-158</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Perhaps before returning this, you should make sure that it is valid? This is just to future proof the system. If you make the FocusInfo have `None` as type by default, and `-1` as the step. Then a valid focus info is one which has both of these different.
- [ ] <a href='#crh-comment-Pull f9cd2f26079e5fb6a60f75a60348266301469a79 CodeReview/src/commands/CFocus.cpp 146'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/438#discussion_r72474539'>File: CodeReview/src/commands/CFocus.cpp:L113-158</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> The best option is to add `isValid` method to `FocusInformation` and define there what that means, not here.
- [ ] <a href='#crh-comment-Pull f9cd2f26079e5fb6a60f75a60348266301469a79 CodeReview/src/commands/CFocus.h 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/438#discussion_r72474657'>File: CodeReview/src/commands/CFocus.h:L39-55</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> The step above, should probably be `-1` by default, also indicating an invalid info.
- [ ] <a href='#crh-comment-Pull e67b8a190f987714f943fbaec748dca426921359 VisualizationBase/src/views/MainView.h 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/438#discussion_r72475197'>File: VisualizationBase/src/views/MainView.h:L49-57</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please rename this to `centerAndZoomViewToFitEntireScene`
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/438#issuecomment-235644634'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Alright, I'm done with the review. Mostly smaller tweaks are needed.
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/438?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/438?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/438'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
