### PR TITLE
Gm focus

### DIFF
--- a/CodeReview/src/groupings/UseAnalysisGroupings.cpp
+++ b/CodeReview/src/groupings/UseAnalysisGroupings.cpp
@@ -137,10 +137,10 @@ bool UseAnalysisGroupings::dependsOn(DiffFrameInfo infoA,
 		for (auto referal : infoA.refersTo_)
 		{
 			for (auto changesOld : frameB->oldChangedNodes())
-				if (changesOld->isSameOrAncestorOf(referal))
+				if (changesOld->isSameOrAncestorOf(referal) || referal->isSameOrAncestorOf(changesOld))
 					return true;
 			for (auto changesNew : frameB->newChangedNodes())
-				if (changesNew->isSameOrAncestorOf(referal))
+				if (changesNew->isSameOrAncestorOf(referal) || referal->isSameOrAncestorOf(changesNew))
 					return true;
 		}
 		return false;

--- a/CodeReview/src/items/VNodeReviews.cpp
+++ b/CodeReview/src/items/VNodeReviews.cpp
@@ -58,7 +58,7 @@ void VNodeReviews::initializeForms()
 			return v->node()->focusInformationNode();}, &StyleType::focusInformation);
 
 	auto headerElement = (new Visualization::GridLayoutFormElement{})
-				->setMargins(5, 5, 5, 5)
+				->setMargins(5, 0, 5, 5)
 				->setHorizontalSpacing(10)
 				->setColumnStretchFactor(0, 1)
 				->setColumnStretchFactor(1, 1)

--- a/CodeReview/src/items/VReviewComment.cpp
+++ b/CodeReview/src/items/VReviewComment.cpp
@@ -92,7 +92,7 @@ void VReviewComment::updateDateText()
 		date_->setText("Some seconds ago");
 	else if (secsToCurrentDate >= 60 && secsToCurrentDate < 120)
 	{
-				date_->setText("1 minute ago");
+		date_->setText("1 minute ago");
 	}
 	else if (secsToCurrentDate < 3600)
 	{

--- a/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
+++ b/CodeReview/src/overlays/CodeReviewCommentOverlay.cpp
@@ -60,7 +60,10 @@ void CodeReviewCommentOverlay::updateGeometry(int availableWidth, int availableH
 
 void CodeReviewCommentOverlay::initializeForms()
 {
-	addForm(item(&I::nodeReviewsItem_, [](I* v) {return v->nodeReviews_;}));
+	auto container = (new Visualization::GridLayoutFormElement{})
+			->setTopMargin(10)
+			->put(0, 0, item(&I::nodeReviewsItem_, [](I* v) {return v->nodeReviews_;}));
+	addForm(container);
 }
 
 void CodeReviewCommentOverlay::updateOffsetItemLocal(QPointF scenePos)

--- a/FilePersistence/src/version_control/merge/pipeline_components/ListMergeComponent.h
+++ b/FilePersistence/src/version_control/merge/pipeline_components/ListMergeComponent.h
@@ -37,7 +37,7 @@
 namespace FilePersistence {
 class GenericNode;
 class ChangeGraph;
-class Chunk;
+struct Chunk;
 
 class FILEPERSISTENCE_API ListMergeComponent : public MergePipelineComponent
 {

--- a/VersionControlUI/key-bindings/VersionControlUI.json
+++ b/VersionControlUI/key-bindings/VersionControlUI.json
@@ -1,0 +1,3 @@
+{
+	"GenericHandler.NameChangeFilter"	: {"keys":["Ctrl+F10"], "state":"1"}
+}

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -61,7 +61,7 @@ const QString DiffManager::NAME_CHANGE_OVERLAY_NAME = "nameChange_overlay";
 const QString DiffManager::NAME_CHANGE_ARROW_OVERLAY_NAME = "nameChange_arrow_overlay";
 QHash<Model::NodeIdType, bool> DiffManager::nameChangesIdsIsNameText_;
 QList<ChangeWithNodes> DiffManager::nameChanges_;
-DiffManager::NameChangeVisualizationFlags DiffManager::nameChangeVisualizationFlags_{Summary};
+DiffManager::NameChangeVisualizationFlags DiffManager::nameChangeVisualizationFlags_{Summary | NameText | References};
 QList<int> DiffManager::nameChangeOnZoomHandlerIds_;
 QHash<Visualization::ViewItem*, int> DiffManager::onZoomHandlerIdPerViewItem_;
 QSet<Visualization::Item*> DiffManager::nameChangesScaledByAncestor_;

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -61,7 +61,7 @@ const QString DiffManager::NAME_CHANGE_OVERLAY_NAME = "nameChange_overlay";
 const QString DiffManager::NAME_CHANGE_ARROW_OVERLAY_NAME = "nameChange_arrow_overlay";
 QHash<Model::NodeIdType, bool> DiffManager::nameChangesIdsIsNameText_;
 QList<ChangeWithNodes> DiffManager::nameChanges_;
-DiffManager::NameChangeVisualizations DiffManager::nameChangeVisualization_{Summary};
+DiffManager::NameChangeVisualizationFlags DiffManager::nameChangeVisualizationFlags_{Summary};
 QList<int> DiffManager::nameChangeOnZoomHandlerIds_;
 QHash<Visualization::ViewItem*, int> DiffManager::onZoomHandlerIdPerViewItem_;
 QSet<Visualization::Item*> DiffManager::nameChangesScaledByAncestor_;
@@ -122,7 +122,7 @@ void DiffManager::clear()
 
 QString DiffManager::computeNameChangeInformation(const DiffSetup& diffSetup)
 {
-	if (nameChangeInformation_.isEmpty() || !nameChangeVisualization_.testFlag(Summary))
+	if (nameChangeInformation_.isEmpty() || !nameChangeVisualizationFlags_.testFlag(Summary))
 		return "";
 
 	QString nameChangeInformation = "";
@@ -244,11 +244,11 @@ bool DiffManager::shouldShowChange(Model::NodeIdType id)
 		return true;
 
 	// node for id is NameText, if NameText flag is not set don't show it
-	if (iter.value() && !nameChangeVisualization_.testFlag(NameText))
+	if (iter.value() && !nameChangeVisualizationFlags_.testFlag(NameText))
 		return false;
 
 	// node for id is Reference, if References flag is not set don't show it
-	if (!iter.value() && !nameChangeVisualization_.testFlag(References))
+	if (!iter.value() && !nameChangeVisualizationFlags_.testFlag(References))
 		return false;
 
 	return true;
@@ -322,22 +322,22 @@ bool DiffManager::toggleNameChangeHighlights(Visualization::Item* target,
 
 	QList<ChangeWithNodes> nameChangesToShow;
 
-	if (nameChangeVisualization_.testFlag(NameText) && nameChangeVisualization_.testFlag(References))
+	if (nameChangeVisualizationFlags_.testFlag(NameText) && nameChangeVisualizationFlags_.testFlag(References))
 	{
-		nameChangeVisualization_ &= ~NameText;
-		nameChangeVisualization_ &= ~References;
+		nameChangeVisualizationFlags_ &= ~NameText;
+		nameChangeVisualizationFlags_ &= ~References;
 	}
-	else if (!nameChangeVisualization_.testFlag(NameText) && !nameChangeVisualization_.testFlag(References))
+	else if (!nameChangeVisualizationFlags_.testFlag(NameText) && !nameChangeVisualizationFlags_.testFlag(References))
 	{
-		nameChangeVisualization_ |= NameText;
+		nameChangeVisualizationFlags_ |= NameText;
 	}
-	else if (nameChangeVisualization_.testFlag(NameText) && !nameChangeVisualization_.testFlag(References))
+	else if (nameChangeVisualizationFlags_.testFlag(NameText) && !nameChangeVisualizationFlags_.testFlag(References))
 	{
-		nameChangeVisualization_ |= References;
+		nameChangeVisualizationFlags_ |= References;
 	}
-	else if (!nameChangeVisualization_.testFlag(NameText) && nameChangeVisualization_.testFlag(References))
+	else if (!nameChangeVisualizationFlags_.testFlag(NameText) && nameChangeVisualizationFlags_.testFlag(References))
 	{
-		nameChangeVisualization_ |= NameText;
+		nameChangeVisualizationFlags_ |= NameText;
 	}
 
 	for (auto change : nameChanges_)
@@ -561,7 +561,7 @@ void DiffManager::showNodeHistory(Model::NodeIdType targetNodeID, QList<QString>
 		auto diffFrames = createDiffFrames(diffSetup, changedNodesToVisualize, changesWithNodes);
 
 		// if summary activated and no changes to show, insert dummy DiffFrame
-		if (nameChangeVisualization_.testFlag(Summary) && !nameChangesIdsIsNameText_.isEmpty()
+		if (nameChangeVisualizationFlags_.testFlag(Summary) && !nameChangesIdsIsNameText_.isEmpty()
 			 && diffFrames.isEmpty())
 			diffFrames.append(new DiffFrame{});
 
@@ -569,7 +569,7 @@ void DiffManager::showNodeHistory(Model::NodeIdType targetNodeID, QList<QString>
 		for (auto diffFrame : diffFrames)
 			historyViewItem->insertNode(diffFrame, {row++, col});
 
-		if (nameChangeVisualization_.testFlag(Summary) && !nameChangesIdsIsNameText_.isEmpty())
+		if (nameChangeVisualizationFlags_.testFlag(Summary) && !nameChangesIdsIsNameText_.isEmpty())
 			message += "<br/><br/>" + computeNameChangeInformation(diffSetup);
 
 		if (!diffFrames.isEmpty())

--- a/VersionControlUI/src/DiffManager.cpp
+++ b/VersionControlUI/src/DiffManager.cpp
@@ -67,11 +67,9 @@ QHash<Visualization::ViewItem*, int> DiffManager::onZoomHandlerIdPerViewItem_;
 QSet<Visualization::Item*> DiffManager::nameChangesScaledByAncestor_;
 
 DiffManager::DiffManager(QString project, QList<Model::SymbolMatcher> contextUnitMatcherPriorityList,
-								 Model::NodeIdType targetNodeID, NameChangeVisualizations nameChangeVisualization)
+								 Model::NodeIdType targetNodeID)
 	: project_{project}, contextUnitMatcherPriorityList_{contextUnitMatcherPriorityList}, targetNodeId_{targetNodeID}
-
 {
-	nameChangeVisualization_ = nameChangeVisualization;
 }
 
 DiffSetup DiffManager::initializeDiffPrerequisites(QString oldVersion, QString newVersion)

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -34,6 +34,7 @@
 #include "FilePersistence/src/version_control/ChangeDescription.h"
 #include "FilePersistence/src/version_control/Diff.h"
 
+#include "InteractionBase/src/input_actions/ActionRegistry.h"
 
 namespace FilePersistence
 {
@@ -49,9 +50,18 @@ namespace Visualization
 
 namespace VersionControlUI {
 
-struct VersionNodes;
-struct ChangeWithNodes;
 class DiffFrame;
+
+struct VersionNodes {
+	Model::Node* oldNode_{};
+	Model::Node* newNode_{};
+};
+
+struct ChangeWithNodes {
+	Model::NodeIdType id_;
+	VersionNodes versionNodes_;
+	FilePersistence::ChangeType changeType_{FilePersistence::ChangeType::Unclassified};
+};
 
 struct DiffSetup {
 	Model::TreeManager* newVersionManager_{};
@@ -82,7 +92,7 @@ class VERSIONCONTROLUI_API DiffManager
 		DiffManager(QString project,
 						QList<Model::SymbolMatcher> contextUnitMatcherPriorityList,
 						Model::NodeIdType targetNodeID={},
-						NameChangeVisualizations nameChangeVisualization = Summary);
+						NameChangeVisualizations nameChangeVisualization =  {Summary | NameText | References});
 
 		void showDiff(QString oldVersion, QString newVersion);
 
@@ -96,6 +106,10 @@ class VERSIONCONTROLUI_API DiffManager
 
 		DiffFramesAndSetup computeDiffFramesAndOverlays(QString oldVersion,
 																					QString newVersion, Visualization::ViewItem* viewItem);
+
+		static bool toggleNameChangeHighlights(Visualization::Item* target,
+																QKeySequence keySequence,
+																Interaction::ActionRegistry::InputState inputState);
 
 	private:
 
@@ -127,9 +141,12 @@ class VERSIONCONTROLUI_API DiffManager
 		bool findChangedNode(Model::TreeManager* treeManager, Model::NodeIdType id, Model::NodeIdType& resultId);
 
 		/**
-		 * Creates the different overlays according to the change type of the node.
+		 * Creates the different overlays according to the change type of the node. Uses \a nameChangesIds to identify
+		 * changes related to name changes and use special overlay names for them.
 		 */
-		static void createOverlaysForChanges(Visualization::ViewItem* diffViewItem, QList<ChangeWithNodes> changesWithNodes);
+		static void createOverlaysForChanges(Visualization::ViewItem* diffViewItem,
+														 QList<ChangeWithNodes> changesWithNodes,
+														 QList<Model::NodeIdType> nameChangesIds);
 
 		/**
 		 * Returns a list of DiffFrame created from the ids from \a diffFrameNodeIds.
@@ -147,6 +164,12 @@ class VERSIONCONTROLUI_API DiffManager
 		 * Returns all items which have an ancestor present in \a items.
 		 */
 		static QSet<Visualization::Item*> findAllItemsWithAncestorsIn(QSet<Visualization::Item*> items);
+
+		/**
+		 * Returns all items which have an ancestor present in \a possibleAncestors.
+		 */
+		static QSet<Visualization::Item*> findAllItemsWithAncestorsIn(QSet<Visualization::Item*> items,
+																											QSet<Visualization::Item*> possibleAncestors);
 
 		/**
 		 * Removes all nodes which have an ancestor present in \a container
@@ -181,7 +204,7 @@ class VERSIONCONTROLUI_API DiffManager
 		 * Check if change associated with id should be visualized (e.g. if the change is part of a name change, does it
 		 * satisfy the visualization constraint).
 		 */
-		bool shouldShowChange(Model::NodeIdType id);
+		static bool shouldShowChange(Model::NodeIdType id);
 
 		QString project_;
 		QList<Model::SymbolMatcher> contextUnitMatcherPriorityList_;
@@ -189,14 +212,21 @@ class VERSIONCONTROLUI_API DiffManager
 		// if set specifies which node we are interested in, used for history
 		Model::NodeIdType targetNodeId_;
 
-		QHash<QString, QPair<QString, Model::NodeIdType>> nameChanges_;
-		QHash<Model::NodeIdType, bool> nameChangesIdsIsNameText_;
-		NameChangeVisualizations nameChangeVisualization_{Summary};
+		QHash<QString, QPair<QString, Model::NodeIdType>> nameChangeInformation_;
+		static QHash<Model::NodeIdType, bool> nameChangesIdsIsNameText_;
+		static QList<ChangeWithNodes> nameChanges_;
+		static NameChangeVisualizations nameChangeVisualization_;
+		static QList<int> nameChangeOnZoomHandlerIds_;
+		static QSet<Visualization::Item*> nameChangesScaledByAncestor_;
 
-		static void scaleItems(QSet<Visualization::Item*> itemsToScale, Visualization::ViewItem* currentViewItem);
+		static void scaleItems(QSet<Visualization::Item*> itemsToScale, Visualization::ViewItem* currentViewItem,
+									  bool nameChangeRelated = false);
 
 		static const QString OVERVIEW_HIGHLIGHT_OVERLAY_NAME;
 		static const QString OVERVIEW_ICON_OVERLAY_NAME;
+
+		static const QString NAME_CHANGE_OVERLAY_NAME;
+		static const QString NAME_CHANGE_ARROW_OVERLAY_NAME;
 
 		static QHash<Visualization::ViewItem*, int> onZoomHandlerIdPerViewItem_;
 		void createOverlaysForChanges(QList<ChangeWithNodes> changesWithNodes,

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -211,11 +211,36 @@ class VERSIONCONTROLUI_API DiffManager
 		// if set specifies which node we are interested in, used for history
 		Model::NodeIdType targetNodeId_;
 
+		/**
+		 * Maps old name to a pair consisting of the new name and the id of the renamed component.
+		 */
 		QHash<QString, QPair<QString, Model::NodeIdType>> nameChangeInformation_;
+
+		/**
+		 * Contains the id of all NameTexts and References related to name changes. The bool value is used to
+		 * decide whether the id is of type NameText (true) or Reference (false).
+		 */
 		static QHash<Model::NodeIdType, bool> nameChangesIdsIsNameText_;
+
+		/**
+		 * List of all ChangeWithNodes related to name changes.
+		 */
 		static QList<ChangeWithNodes> nameChanges_;
+
+		/**
+		 * Flags used to control the amount of information that should be displayed for name changes.
+		 */
 		static NameChangeVisualizationFlags nameChangeVisualizationFlags_;
+
+		/**
+		 * List of the ids of all OnZoomHandlers associated with name changes.
+		 */
 		static QList<int> nameChangeOnZoomHandlerIds_;
+
+		/**
+		 * All items related to name changes, which do not need special scaling, since one of their ancestors is
+		 * responsible for the scaling.
+		 */
 		static QSet<Visualization::Item*> nameChangesScaledByAncestor_;
 
 		static void scaleItems(QSet<Visualization::Item*> itemsToScale, Visualization::ViewItem* currentViewItem,

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -87,7 +87,7 @@ class VERSIONCONTROLUI_API DiffManager
 				NameText = 0x2,
 				References = 0x4
 		};
-		using NameChangeVisualizations = QFlags<NameChangeVisualization>;
+		using NameChangeVisualizationFlags = QFlags<NameChangeVisualization>;
 
 		DiffManager(QString project,
 						QList<Model::SymbolMatcher> contextUnitMatcherPriorityList,
@@ -214,7 +214,7 @@ class VERSIONCONTROLUI_API DiffManager
 		QHash<QString, QPair<QString, Model::NodeIdType>> nameChangeInformation_;
 		static QHash<Model::NodeIdType, bool> nameChangesIdsIsNameText_;
 		static QList<ChangeWithNodes> nameChanges_;
-		static NameChangeVisualizations nameChangeVisualization_;
+		static NameChangeVisualizationFlags nameChangeVisualizationFlags_;
 		static QList<int> nameChangeOnZoomHandlerIds_;
 		static QSet<Visualization::Item*> nameChangesScaledByAncestor_;
 
@@ -233,6 +233,6 @@ class VERSIONCONTROLUI_API DiffManager
 												Visualization::Item* anchorItem);
 };
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(DiffManager::NameChangeVisualizations)
+Q_DECLARE_OPERATORS_FOR_FLAGS(DiffManager::NameChangeVisualizationFlags)
 
 }

--- a/VersionControlUI/src/DiffManager.h
+++ b/VersionControlUI/src/DiffManager.h
@@ -91,8 +91,7 @@ class VERSIONCONTROLUI_API DiffManager
 
 		DiffManager(QString project,
 						QList<Model::SymbolMatcher> contextUnitMatcherPriorityList,
-						Model::NodeIdType targetNodeID={},
-						NameChangeVisualizations nameChangeVisualization =  {Summary | NameText | References});
+						Model::NodeIdType targetNodeID={});
 
 		void showDiff(QString oldVersion, QString newVersion);
 

--- a/VersionControlUI/src/VersionControlUIPlugin.cpp
+++ b/VersionControlUI/src/VersionControlUIPlugin.cpp
@@ -24,18 +24,20 @@
  **
  **********************************************************************************************************************/
 
-#include "VersionControlUIPlugin.h"
-#include "SelfTest/src/TestManager.h"
-#include "Logger/src/Log.h"
-
-#include "InteractionBase/src/handlers/HSceneHandlerItem.h"
-
+#include "DiffManager.h"
 #include "items/ObjectPathCrumb.h"
 #include "handlers/HObjectPathCrumb.h"
-
 #include "commands/CClear.h"
 #include "commands/CDiff.h"
 #include "commands/CHistory.h"
+#include "VersionControlUIPlugin.h"
+
+#include "Logger/src/Log.h"
+
+#include "SelfTest/src/TestManager.h"
+
+#include "InteractionBase/src/handlers/HSceneHandlerItem.h"
+#include "InteractionBase/src/input_actions/ActionRegistry.h"
 
 namespace VersionControlUI {
 
@@ -48,6 +50,9 @@ Logger::Log& VersionControlUIPlugin::log()
 bool VersionControlUIPlugin::initialize(Core::EnvisionManager&)
 {
 	VersionControlUI::ObjectPathCrumb::setDefaultClassHandler(HObjectPathCrumb::instance());
+
+	Interaction::ActionRegistry::instance()->registerInputHandler("GenericHandler.NameChangeFilter",
+																					  DiffManager::toggleNameChangeHighlights);
 
 	Interaction::HSceneHandlerItem::instance()->addCommand(new CClear{});
 	Interaction::HSceneHandlerItem::instance()->addCommand(new CDiff{});

--- a/VersionControlUI/src/VersionControlUIPlugin.cpp
+++ b/VersionControlUI/src/VersionControlUIPlugin.cpp
@@ -23,6 +23,7 @@
  ** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **
  **********************************************************************************************************************/
+#include "VersionControlUIPlugin.h"
 
 #include "DiffManager.h"
 #include "items/ObjectPathCrumb.h"
@@ -30,7 +31,6 @@
 #include "commands/CClear.h"
 #include "commands/CDiff.h"
 #include "commands/CHistory.h"
-#include "VersionControlUIPlugin.h"
 
 #include "Logger/src/Log.h"
 


### PR DESCRIPTION
- Fix condition for dependsOn function
- Fix indentation
- Add border in ReviewComment visualization to allow for easier moving of comments
- Improve name change handling
- Add command to toggle between different levels of detail for name change highlights
- Rename nameChanges_ to nameChangeInformation_
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23discussion_r75594938%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23discussion_r75594999%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23discussion_r75595006%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23discussion_r75595053%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23discussion_r75595157%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23discussion_r75595186%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23issuecomment-241257244%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23issuecomment-241259148%22%2C%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23issuecomment-241261170%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23issuecomment-241257244%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22OK%2C%20I%27m%20done%20with%20the%20review.%22%2C%20%22created_at%22%3A%20%222016-08-21T13%3A27%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%22%2C%20%22created_at%22%3A%20%222016-08-21T13%3A57%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%22%2C%20%22created_at%22%3A%20%222016-08-21T14%3A35%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%209360be61cad6e93e24fe5a817d3ec64c50e9b02c%20VersionControlUI/src/DiffManager.h%2095%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23discussion_r75594999%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Uf%2C%20there%27s%20a%20ton%20of%20these%20statics%20related%20to%20name%20changes.%20Could%20you%20at%20least%20put%20some%20comments%2C%20to%20explain%20in%20a%20sentence%20or%20two%20what%20each%20one%20is%20for%3F%20Is%20it%20possible%20to%20perhaps%20combine%20some%20of%20these%20%28maybe%20by%20making%20an%20additional%20class/struct%29%3F%20Would%20such%20a%20combination%20be%20a%20better%20design%3F%22%2C%20%22created_at%22%3A%20%222016-08-21T13%3A13%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.h%3AL204-234%22%7D%2C%20%22Pull%209360be61cad6e93e24fe5a817d3ec64c50e9b02c%20VersionControlUI/src/DiffManager.h%2099%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23discussion_r75595006%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20is%20this%20needed%3F%5Cr%5Cn%5Cr%5CnThere%27s%20really%20a%20lot%20of%20these%20things.%22%2C%20%22created_at%22%3A%20%222016-08-21T13%3A14%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20did%20it%20because%20the%20command%20%60toggleNameChangeHighlights%60%20is%20static.%20They%20contain%20the%20information%20of%20the%20last%20diff%20and%20I%20use%20this%20to%20toggle%20the%20highlights.%22%2C%20%22created_at%22%3A%20%222016-08-21T13%3A24%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/17177211%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mgalbier%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.h%3AL204-234%22%7D%2C%20%22Pull%209360be61cad6e93e24fe5a817d3ec64c50e9b02c%20VersionControlUI/src/DiffManager.cpp%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23discussion_r75595053%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22please%2C%20use%20the%20same%20multiplicity%20for%20both%20the%20type%20name%20and%20the%20variable%20names.%20It%27s%20kind%20of%20strange%20for%20something%20of%20type%20%60Visualizations%60%20to%20be%20called%20%60visualization%60.%5Cr%5Cn%5Cr%5CnAlso%20this%20should%20be%20initialized%20above%2C%20like%20the%20rest%20of%20the%20fields%2C%20after%20the%20%60%3A%60.%5Cr%5Cn%5Cr%5CnAlso%2C%20I%20think%20the%20name%20should%20be%20a%20little%20more%20explanatory%2C%20include%20%60flags%60%20at%20the%20end.%22%2C%20%22created_at%22%3A%20%222016-08-21T13%3A17%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL57-79%22%7D%2C%20%22Pull%209360be61cad6e93e24fe5a817d3ec64c50e9b02c%20VersionControlUI/src/VersionControlUIPlugin.cpp%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23discussion_r75594938%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20put%20this%20on%20top%20of%20the%20file.%22%2C%20%22created_at%22%3A%20%222016-08-21T13%3A09%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/VersionControlUIPlugin.cpp%3AL24-44%22%7D%2C%20%22Pull%209360be61cad6e93e24fe5a817d3ec64c50e9b02c%20VersionControlUI/src/DiffManager.cpp%20361%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov/Envision/pull/439%23discussion_r75595186%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Wow%2C%20this%20name%20change%20stuff%20resulted%20in%20a%20ton%20more%20changes%20than%20I%20expected.%5Cr%5Cn%5Cr%5CnI%27m%20thinking%2C%20it%20might%20make%20sense%20to%20move%20all%20name%20change%20related%20things%20to%20a%20separate%20class.%20Let%27s%20talk%20about%20this%20in%20our%20next%20meeting.%20Think%20about%20it%20in%20the%20mean%20time.%22%2C%20%22created_at%22%3A%20%222016-08-21T13%3A27%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1152976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dimitar-asenov%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20VersionControlUI/src/DiffManager.cpp%3AL856-886%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 9360be61cad6e93e24fe5a817d3ec64c50e9b02c VersionControlUI/src/VersionControlUIPlugin.cpp 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/439#discussion_r75594938'>File: VersionControlUI/src/VersionControlUIPlugin.cpp:L24-44</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Please put this on top of the file.
- [ ] <a href='#crh-comment-Pull 9360be61cad6e93e24fe5a817d3ec64c50e9b02c VersionControlUI/src/DiffManager.h 95'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/439#discussion_r75594999'>File: VersionControlUI/src/DiffManager.h:L204-234</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Uf, there's a ton of these statics related to name changes. Could you at least put some comments, to explain in a sentence or two what each one is for? Is it possible to perhaps combine some of these (maybe by making an additional class/struct)? Would such a combination be a better design?
- [ ] <a href='#crh-comment-Pull 9360be61cad6e93e24fe5a817d3ec64c50e9b02c VersionControlUI/src/DiffManager.h 99'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/439#discussion_r75595006'>File: VersionControlUI/src/DiffManager.h:L204-234</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Why is this needed?
  There's really a lot of these things.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> I did it because the command `toggleNameChangeHighlights` is static. They contain the information of the last diff and I use this to toggle the highlights.
- [ ] <a href='#crh-comment-Pull 9360be61cad6e93e24fe5a817d3ec64c50e9b02c VersionControlUI/src/DiffManager.cpp 33'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/439#discussion_r75595053'>File: VersionControlUI/src/DiffManager.cpp:L57-79</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> please, use the same multiplicity for both the type name and the variable names. It's kind of strange for something of type `Visualizations` to be called `visualization`.
  Also this should be initialized above, like the rest of the fields, after the `:`.
  Also, I think the name should be a little more explanatory, include `flags` at the end.
- [ ] <a href='#crh-comment-Pull 9360be61cad6e93e24fe5a817d3ec64c50e9b02c VersionControlUI/src/DiffManager.cpp 361'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/439#discussion_r75595186'>File: VersionControlUI/src/DiffManager.cpp:L856-886</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Wow, this name change stuff resulted in a ton more changes than I expected.
  I'm thinking, it might make sense to move all name change related things to a separate class. Let's talk about this in our next meeting. Think about it in the mean time.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/dimitar-asenov/Envision/pull/439#issuecomment-241257244'>General Comment</a></b>
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> OK, I'm done with the review.
- <a href='https://github.com/mgalbier'><img border=0 src='https://avatars.githubusercontent.com/u/17177211?v=3' height=16 width=16'></a> Thanks
- <a href='https://github.com/dimitar-asenov'><img border=0 src='https://avatars.githubusercontent.com/u/1152976?v=3' height=16 width=16'></a> Thanks.

<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/439?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/dimitar-asenov/Envision/pull/439?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/dimitar-asenov/Envision/pull/439'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
